### PR TITLE
Expose Agentforce SDK Navigation to React Native JS

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -64,6 +64,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     // Bridge logger for forwarding SDK logs to JS
     private val bridgeLogger = BridgeLogger(reactContext)
 
+    // Bridge navigation for forwarding SDK navigation requests to JS
+    private val bridgeNavigation = BridgeNavigation(reactContext)
+
     // Coroutine scope for async operations
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
@@ -157,6 +160,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setFeatureFlagSettings(featureFlagSettings)
                     .setCameraUriProvider(cameraUriProvider)
                     .setLogger(bridgeLogger)
+                    .setNavigation(bridgeNavigation)
                 permissions?.let { agentforceConfigBuilder.setPermission(it) }
                 val agentforceConfig = agentforceConfigBuilder.build()
 
@@ -230,6 +234,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setFeatureFlagSettings(featureFlagSettings)
                     .setCameraUriProvider(cameraUriProvider)
                     .setLogger(bridgeLogger)
+                    .setNavigation(bridgeNavigation)
                 permissions?.let { agentforceConfigBuilder.setPermission(it) }
                 val agentforceConfig = agentforceConfigBuilder.build()
 
@@ -503,6 +508,15 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     fun enableLogForwarding(enabled: Boolean, promise: Promise) {
         bridgeLogger.forwardingEnabled = enabled
         Log.d(TAG, "Log forwarding ${if (enabled) "enabled" else "disabled"}")
+        promise.resolve(true)
+    }
+
+    // MARK: - Navigation Forwarding
+
+    @ReactMethod
+    fun enableNavigationForwarding(enabled: Boolean, promise: Promise) {
+        bridgeNavigation.forwardingEnabled = enabled
+        Log.d(TAG, "Navigation forwarding ${if (enabled) "enabled" else "disabled"}")
         promise.resolve(true)
     }
 

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNavigation.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNavigation.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Bridge navigation that forwards Agentforce SDK navigation requests to React Native JS via events.
+ */
+package com.salesforce.android.reactagentforce
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.salesforce.android.mobile.interfaces.navigation.Navigation
+import com.salesforce.android.mobile.interfaces.navigation.destination.App
+import com.salesforce.android.mobile.interfaces.navigation.destination.Destination
+import com.salesforce.android.mobile.interfaces.navigation.destination.Link
+import com.salesforce.android.mobile.interfaces.navigation.destination.ObjectHome
+import com.salesforce.android.mobile.interfaces.navigation.destination.PageReference
+import com.salesforce.android.mobile.interfaces.navigation.destination.QuickAction
+import com.salesforce.android.mobile.interfaces.navigation.destination.Record
+
+/**
+ * Implements the Agentforce SDK Navigation interface and forwards navigation requests
+ * to JavaScript via NativeEventEmitter events.
+ *
+ * Navigation forwarding is disabled by default and enabled when JS registers a NavigationDelegate.
+ */
+class BridgeNavigation(private val reactContext: ReactContext) : Navigation {
+
+    /** Controls whether navigation requests are forwarded to JS. */
+    var forwardingEnabled: Boolean = false
+
+    override fun goto(destination: Destination) {
+        if (!forwardingEnabled) return
+        emitDestination(destination, replace = false)
+    }
+
+    override fun goto(destination: Destination, replace: Boolean) {
+        if (!forwardingEnabled) return
+        emitDestination(destination, replace = replace)
+    }
+
+    override fun openApp(app: App): App.OpenResult {
+        if (!forwardingEnabled) return App.OpenResult.NOTOPEN
+
+        val params = Arguments.createMap().apply {
+            putString("type", "app")
+            putString("packageName", app.packageName)
+            app.uri?.let { putString("uri", it.toString()) }
+        }
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit("onNavigationRequest", params)
+
+        // We can't know if JS actually opened the app, so return OPEN optimistically
+        return App.OpenResult.OPEN
+    }
+
+    private fun emitDestination(destination: Destination, replace: Boolean) {
+        val params = Arguments.createMap()
+
+        when (destination) {
+            is Record -> {
+                params.putString("type", "record")
+                params.putString("recordId", destination.id)
+                destination.type?.let { params.putString("objectType", it) }
+                destination.pageReference?.let { params.putString("pageReference", it) }
+            }
+            is ObjectHome -> {
+                params.putString("type", "objectHome")
+                params.putString("objectType", destination.type)
+                destination.pageReference?.let { params.putString("pageReference", it) }
+            }
+            is Link -> {
+                params.putString("type", "link")
+                params.putString("uri", destination.uri.toString())
+                destination.pageReference?.let { params.putString("pageReference", it) }
+            }
+            is QuickAction -> {
+                params.putString("type", "quickAction")
+                params.putString("actionName", destination.actionName)
+                destination.target?.let { target ->
+                    params.putString("recordId", target.id)
+                    target.type?.let { params.putString("objectType", it) }
+                }
+            }
+            is PageReference -> {
+                params.putString("type", "pageReference")
+                destination.pageReference?.let { params.putString("pageReference", it) }
+            }
+            else -> {
+                params.putString("type", "unknown")
+                params.putString("raw", destination.toString())
+            }
+        }
+
+        if (replace) {
+            params.putBoolean("replace", true)
+        }
+
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit("onNavigationRequest", params)
+    }
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/index.ts
@@ -17,7 +17,7 @@ export {
 } from './services/EmployeeAgentAuth';
 export type { AuthCredentials } from './services/EmployeeAgentAuth';
 
-export type { ServiceAgentConfig, EmployeeAgentConfig, AgentConfig, FeatureFlags, LegacyServiceAgentConfig, ConfigurationResult, ConfigurationInfo, LoggerDelegate, LogLevel } from './types';
+export type { ServiceAgentConfig, EmployeeAgentConfig, AgentConfig, FeatureFlags, LegacyServiceAgentConfig, ConfigurationResult, ConfigurationInfo, LoggerDelegate, LogLevel, NavigationDelegate, NavigationRequest } from './types';
 export { isServiceAgentConfig, isEmployeeAgentConfig, isLegacyConfig } from './types';
 
 export {

--- a/AgentforceSDK-ReactNative-Bridge/src/types/NavigationDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/NavigationDelegate.ts
@@ -1,0 +1,38 @@
+/**
+ * Navigation delegate types for Agentforce SDK
+ *
+ * Allows JS to receive navigation requests from the native Agentforce SDK
+ * when users tap records, links, quick actions, or page references.
+ *
+ * Known `type` values: 'record', 'link', 'quickAction', 'pageReference',
+ * 'objectHome', 'app', 'unknown'.
+ *
+ * Known fields by type:
+ *   record       — recordId, objectType, pageReference?
+ *   link         — uri, pageReference?
+ *   quickAction  — actionName, recordId?, objectType?
+ *   pageReference — pageReference
+ *   objectHome   — objectType, pageReference?
+ *   app          — packageName, uri?
+ *   unknown      — raw
+ *
+ * The index signature lets consumers access any field the native bridge
+ * sends, so the JS layer is forward-compatible when the SDK adds new
+ * destination types or fields.
+ */
+
+export interface NavigationRequest {
+  /** Destination kind (e.g. 'record', 'link', 'quickAction', 'pageReference', 'objectHome', 'app') */
+  type: string;
+  /** Any additional fields serialized by the native bridge */
+  [key: string]: string | boolean | undefined;
+}
+
+export interface NavigationDelegate {
+  /**
+   * Called when the Agentforce SDK requests navigation.
+   *
+   * @param request - The navigation request with destination details
+   */
+  onNavigate(request: NavigationRequest): void;
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
@@ -20,3 +20,6 @@ export {
 
 // Logger delegate types
 export { LoggerDelegate, LogLevel } from './LoggerDelegate';
+
+// Navigation delegate types
+export { NavigationDelegate, NavigationRequest } from './NavigationDelegate';

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -64,12 +64,16 @@ const agentforceLogger: LoggerDelegate = {
   },
 };
 
-// Sample navigation delegate — handles Agentforce SDK navigation requests
+// Sample navigation delegate — handles Agentforce SDK navigation requests.
+// Modify this to add your own navigation handling logic.
+// The request.type indicates the destination kind ('record', 'link',
+// 'quickAction', 'pageReference', 'objectHome', 'app').
+// Access fields like request.recordId, request.uri, request.actionName, etc.
+// See NavigationDelegate.ts for the full list of known fields per type.
 const agentforceNavigation: NavigationDelegate = {
   onNavigate(request: NavigationRequest) {
-    // Show a toast with the raw request data for debugging
+    // For debugging — replace with your own navigation handling
     Alert.alert('Navigation Request', JSON.stringify(request, null, 2));
-
     console.log(`[Agentforce Nav] ${request.type}:`, request);
   },
 };

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -30,6 +30,7 @@ import {
   StyleSheet,
   Alert,
   Image,
+  Linking,
   Platform,
   ScrollView,
 } from 'react-native';
@@ -42,6 +43,8 @@ import {
   isEmployeeAgentConfigValid,
   LoggerDelegate,
   LogLevel,
+  NavigationDelegate,
+  NavigationRequest,
 } from 'react-native-agentforce';
 import { UI_FEATURES } from '../config/UIFeatures';
 
@@ -61,6 +64,16 @@ const agentforceLogger: LoggerDelegate = {
   },
 };
 
+// Sample navigation delegate — handles Agentforce SDK navigation requests
+const agentforceNavigation: NavigationDelegate = {
+  onNavigate(request: NavigationRequest) {
+    // Show a toast with the raw request data for debugging
+    Alert.alert('Navigation Request', JSON.stringify(request, null, 2));
+
+    console.log(`[Agentforce Nav] ${request.type}:`, request);
+  },
+};
+
 const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   const [isServiceAgentConfigured, setIsServiceAgentConfigured] =
     useState(false);
@@ -76,10 +89,13 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   useEffect(() => {
     // Register logger delegate so SDK logs are forwarded to JS
     AgentforceService.setLoggerDelegate(agentforceLogger);
+    // Register navigation delegate so SDK navigation requests are forwarded to JS
+    AgentforceService.setNavigationDelegate(agentforceNavigation);
     checkConfigurations();
 
     return () => {
       AgentforceService.clearLoggerDelegate();
+      AgentforceService.clearNavigationDelegate();
     };
   }, []);
 


### PR DESCRIPTION
## Goal

Allow React Native JS developers to define their own navigation handler that receives navigation requests from the Agentforce SDK via `AgentforceConfiguration.builder().setNavigation(navigation)`. This enables the host app to handle record opens, links, quick actions, and page references in a React Native–native way.

## Implementation

### TypeScript: `NavigationDelegate` and related types

**File:** `AgentforceSDK-ReactNative-Bridge/src/types/NavigationDelegate.ts` (new)

Simplified to two exports — no union type for destination kinds. `type` is a plain `string` so the bridge is forward-compatible when the SDK adds new destination types. An index signature lets consumers access any field the native layer sends without requiring a bridge update.

```typescript
export interface NavigationRequest {
  /** Destination kind: 'record' | 'link' | 'quickAction' | 'pageReference' | 'objectHome' | 'app' | 'unknown' */
  type: string;
  /** Any additional fields serialized by the native bridge */
  [key: string]: string | boolean | undefined;
}

export interface NavigationDelegate {
  onNavigate(request: NavigationRequest): void;
}
```
### Sample App: Navigation delegate in HomeScreen

**File:** `src/screens/HomeScreen.tsx`

```typescript
import { Linking, Alert } from 'react-native';
import {
  AgentforceService,
  NavigationDelegate,
  NavigationRequest,
} from 'react-native-agentforce';

// Sample navigation delegate — handles Agentforce SDK navigation requests.
// Modify this to add your own navigation handling logic.
// The request.type indicates the destination kind ('record', 'link',
// 'quickAction', 'pageReference', 'objectHome', 'app').
// Access fields like request.recordId, request.uri, request.actionName, etc.
// See NavigationDelegate.ts for the full list of known fields per type.
const agentforceNavigation: NavigationDelegate = {
  onNavigate(request: NavigationRequest) {
    // For debugging — replace with your own navigation handling
    Alert.alert('Navigation Request', JSON.stringify(request, null, 2));
    console.log(`[Agentforce Nav] ${request.type}:`, request);
  },
};

// In component useEffect — register alongside logger delegate
useEffect(() => {
  AgentforceService.setNavigationDelegate(agentforceNavigation);

  return () => {
    AgentforceService.clearNavigationDelegate();
  };
}, []);
```