### PR TITLE
@W-21340539: [iOS] Add logging implementation to React Native app

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
@@ -82,4 +82,10 @@ RCT_EXTERN_METHOD(provideRefreshedToken:(NSString *)token
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+// MARK: - Logging
+
+RCT_EXTERN_METHOD(enableLogForwarding:(BOOL)enabled
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
@@ -88,4 +88,10 @@ RCT_EXTERN_METHOD(enableLogForwarding:(BOOL)enabled
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+// MARK: - Navigation (stub until iOS implementation)
+
+RCT_EXTERN_METHOD(enableNavigationForwarding:(BOOL)enabled
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -38,7 +38,17 @@ class AgentforceModule: RCTEventEmitter {
 
     /// Voice delegate for handling voice interactions
     private var voiceDelegate: AgentforceVoiceDelegate?
-    
+
+    private let listenerLock = NSLock()
+    private var _hasListeners = false
+
+    // MARK: - Logging
+
+    /// Bridge logger for forwarding SDK logs to JavaScript
+    private lazy var bridgeLogger: BridgeLogger = {
+        return BridgeLogger(module: self)
+    }()
+
     // MARK: - Module Setup
 
     override static func requiresMainQueueSetup() -> Bool {
@@ -46,7 +56,15 @@ class AgentforceModule: RCTEventEmitter {
     }
 
     override func supportedEvents() -> [String]! {
-        return []
+        return ["onLogMessage"]  // Required for logging events to work
+    }
+
+    override func startObserving() {
+        listenerLock.withLock { _hasListeners = true }
+    }
+
+    override func stopObserving() {
+        listenerLock.withLock { _hasListeners = false }
     }
 
     // MARK: - Unified Configuration Method
@@ -114,17 +132,28 @@ class AgentforceModule: RCTEventEmitter {
             )
         }
         
-        // Create Service Agent Configuration for SDK
-        let sdkServiceConfig = ServiceAgentConfiguration(
-            esDeveloperName: config.esDeveloperName,
-            organizationId: config.organizationId,
+        // Using fullConfig instead of .serviceAgent() to inject bridgeLogger.
+        // TODO: Migrate to mode .serviceAgent(config) when ServiceAgentConfiguration supports a logger parameter.
+        let serviceUser = User(
+            userId: "",
+            org: Org(id: config.organizationId),
+            username: "service_user",
+            displayName: "Service User"
+        )
+
+        let fullConfiguration = AgentforceConfiguration(
+            user: serviceUser,
+            forceConfigEndpoint: config.serviceApiURL,
+            agentforceFeatureFlagSettings: AgentforceFeatureFlagSettings(),
+            salesforceNetwork: nil,
+            salesforceNavigation: nil,
+            salesforceLogger: bridgeLogger,
             serviceApiURL: config.serviceApiURL
         )
-        
-        // Initialize Agentforce Client with Service Agent mode
+
         agentforceClient = AgentforceClient(
             credentialProvider: credentialProvider,
-            mode: .serviceAgent(sdkServiceConfig)
+            mode: .fullConfig(fullConfiguration)
         )
     }
     
@@ -163,6 +192,7 @@ class AgentforceModule: RCTEventEmitter {
 
         // Create User for FullConfig mode (SDK 14.x). We use .fullConfig(AgentforceConfiguration)
         // instead of .employeeAgent so we can set feature flags explicitly (e.g. multiAgent only).
+        // TODO: Migrate to mode .employeeAgent(config) when EmployeeAgentConfiguration supports a logger parameter.
         let user = User(
             userId: userId,
             org: Org(id: organizationId),
@@ -188,7 +218,8 @@ class AgentforceModule: RCTEventEmitter {
             forceConfigEndpoint: config.instanceUrl,
             agentforceFeatureFlagSettings: featureFlagSettings,
             salesforceNetwork: nil,
-            salesforceNavigation: nil
+            salesforceNavigation: nil,
+            salesforceLogger: bridgeLogger
         )
         
         // Initialize Agentforce Client with fullConfig mode (explicit config + feature flags).
@@ -648,7 +679,28 @@ class AgentforceModule: RCTEventEmitter {
             resolve(initialized)
         }
     }
-    
+
+    // MARK: - Logging
+
+    /// Enable or disable forwarding of native SDK logs to JavaScript
+    /// Called by AgentforceService.setLoggerDelegate() and clearLoggerDelegate()
+    @objc
+    func enableLogForwarding(
+        _ enabled: Bool,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        bridgeLogger.forwardingEnabled = enabled
+        resolve(true)
+    }
+
+    /// Emits a log event to JavaScript if listeners are active
+    /// Called by BridgeLogger when forwarding is enabled
+    func emitLogEvent(_ payload: [String: Any]) {
+        guard listenerLock.withLock({ _hasListeners }) else { return }
+        sendEvent(withName: "onLogMessage", body: payload)
+    }
+
     // MARK: - Cleanup
     
     private func cleanupClient() {

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -56,7 +56,7 @@ class AgentforceModule: RCTEventEmitter {
     }
 
     override func supportedEvents() -> [String]! {
-        return ["onLogMessage"]  // Required for logging events to work
+        return ["onLogMessage", "onNavigationRequest"]
     }
 
     override func startObserving() {
@@ -699,6 +699,18 @@ class AgentforceModule: RCTEventEmitter {
     func emitLogEvent(_ payload: [String: Any]) {
         guard listenerLock.withLock({ _hasListeners }) else { return }
         sendEvent(withName: "onLogMessage", body: payload)
+    }
+
+    // MARK: - Navigation (stub until iOS implementation)
+
+    @objc
+    func enableNavigationForwarding(
+        _ enabled: Bool,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        // No-op: iOS navigation forwarding not yet implemented
+        resolve(true)
     }
 
     // MARK: - Cleanup

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeLogger.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeLogger.swift
@@ -1,0 +1,70 @@
+//
+//  BridgeLogger.swift
+//  AgentforceSDK-ReactNative-Bridge
+//
+//  Created for React Native bridge logging integration
+//
+
+import Foundation
+import SalesforceLogging
+
+/// Bridge logger that forwards Agentforce SDK logs to React Native JavaScript
+///
+/// Implements the iOS Agentforce SDK's Logger protocol and emits log events
+/// to the React Native event emitter. Forwarding can be enabled/disabled
+/// to avoid bridge overhead when no JS delegate is registered.
+class BridgeLogger: Logger {
+
+    // MARK: - Properties
+
+    /// Weak reference to the module to avoid retain cycles
+    private weak var module: AgentforceModule?
+
+    private let lock = NSLock()
+    private var _forwardingEnabled: Bool = false
+
+    /// Controls whether logs should be forwarded to JavaScript.
+    /// Thread-safe: written on the JS thread, read on SDK callback threads.
+    var forwardingEnabled: Bool {
+        get { lock.withLock { _forwardingEnabled } }
+        set { lock.withLock { _forwardingEnabled = newValue } }
+    }
+
+    // MARK: - Initialization
+
+    init(module: AgentforceModule) {
+        self.module = module
+    }
+
+    // MARK: - Logger Protocol Implementation
+
+    /// Logs a message at the specified level
+    /// Forwards to React Native if forwarding is enabled
+    func log(_ logMessage: String, level: LogLevel) {
+        guard forwardingEnabled else { return }
+
+        // Map iOS LogLevel to TypeScript string literal
+        let levelString: String
+        switch level {
+        case .error:
+            levelString = "error"
+        case .warning:
+            levelString = "warn"
+        case .info:
+            levelString = "info"
+        case .debug:
+            levelString = "debug"
+        @unknown default:
+            levelString = "info"  // Fallback for future log levels
+        }
+
+        // Build event payload matching TypeScript LoggerDelegate interface
+        let payload: [String: Any] = [
+            "level": levelString,
+            "message": logMessage
+        ]
+
+        // Emit to React Native (must be called from module with hasListeners check)
+        module?.emitLogEvent(payload)
+    }
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/types/LoggerDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/LoggerDelegate.ts
@@ -10,9 +10,9 @@
 
 /**
  * Log levels emitted by the Agentforce SDK.
- * Maps to the native Logger interface methods: e() → error, w() → warn, i() → info.
+ * Android emits: error, warn, info. iOS additionally emits: debug.
  */
-export type LogLevel = 'error' | 'warn' | 'info';
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug';
 
 /**
  * Delegate interface for receiving log messages from the Agentforce SDK.
@@ -39,7 +39,7 @@ export interface LoggerDelegate {
   /**
    * Called when the Agentforce SDK emits a log message.
    *
-   * @param level - The log level: 'error', 'warn', or 'info'
+   * @param level - The log level: 'error', 'warn', 'info', or 'debug' (iOS only)
    * @param message - The log message from the SDK
    * @param error - Optional stringified exception (only present for error/warn with exceptions)
    */

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1506,63 +1506,63 @@ SPEC CHECKSUMS:
   Messaging-InApp-Core: f456cce32c37e36ac1a029704d86ddf4f744e59b
   NetworkImage: 294cd73dda97309cf9da83626f1b2ec7b2801cca
   OrderedCollections: 68f29db2e771b704400ee1078ea34ef98a38e01f
-  RCT-Folly: 5dc73daec3476616d19e8a53f0156176f7b55461
+  RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
   RCTDeprecation: c4e6e3f6d44f76c45a964b40fa3eb2475259c027
   RCTRequired: c4886806a178cd895cd4a17dae1642b72e7e8233
   RCTTypeSafety: 4e9f36465ccbcca7b62f5cb8fc1ff2c997c3b92e
   React: 7f6ee889aa17245726efe5c0be52389e58d9d7c1
   React-callinvoker: 0155d33f43924c206dfaa040c020d0404bbb54d6
-  React-Codegen: dbde37f3f0e1b41442c05cdaac9170266eb32327
-  React-Core: 063d3e42f48c671822d16ade452b8d25793cc9fa
-  React-CoreModules: 46303f9f50e942fdd8763626464a8a24d9a36419
-  React-cxxreact: 08e7fb41e693d0d18266c394d95501c719f81a7e
+  React-Codegen: 35a204b7faa0cfbd55fb63e7790bbec237890cbb
+  React-Core: da6746240394ea2bb828e6e93baed4dea3c27689
+  React-CoreModules: 319cbc30aee816ea4716115b0f77035b95902a80
+  React-cxxreact: b8e823d419880d779be49fc049732e8facf64fc7
   React-debug: 2ebca59859f724f9bec1a27ea5e42127323dbb63
-  React-Fabric: f35364c067beb490413087d476e7c32ff7ce35d3
-  React-FabricImage: e56ff44c910a8cffd7c957101ca6ab7a12f7b5fe
+  React-Fabric: c0d78f1ad92b005389b54085a9d6b92a213ae31c
+  React-FabricImage: 95c4dabd61d26c76ef88fbb4bf4f2f581cf623f2
   React-featureflags: 22ae4b2df9d070cbca7bb84ff7b6ce1507c589e5
-  React-graphics: e17f9762507f78a65c7c2ea3ec8f15ae3f9b393e
-  React-hermes: 1313182de2921855390a3cde52e2a407a345775f
-  React-ImageManager: 08b97d6df4f71349ee32a415f971682f5e7b0939
-  React-jserrorhandler: 81e491ad79c93e1495fbac4d297de673921c486c
-  React-jsi: ffc343198a6e03042a205db9e149f321d356f033
-  React-jsiexecutor: 50079a521784bfb675522f1c93dd741200c6d8dc
-  React-jsinspector: 1eeb36a1a34369a793e7194838682dd380843b88
-  React-jsitracing: 82d47f192fdf740779c586fe06035ab366b73e6a
-  React-logger: 58cd5ca2c3ab03a06b33e6d46a210d2b17ca116d
-  React-Mapbuffer: 038c3530476b004ab938c56d1a00140afa3fdc3c
-  react-native-safe-area-context: 758e894ca5a9bd1868d2a9cfbca7326a2b6bf9dc
+  React-graphics: cc8e7420a3561cdb5f8d98dccf73e17fea765fed
+  React-hermes: 010c8dc210afa547991e13fc5acee7e63cf9f2e8
+  React-ImageManager: eef2518c287385d9dc785d560dc8ca1d8318f291
+  React-jserrorhandler: 48cf3eb5ec175cd202cd3b1462372df83313f8b9
+  React-jsi: df1b6ca5308a888cbdf44c5035ca2e46822f1902
+  React-jsiexecutor: 88e8f50d2e0cdb1531c6d956c148577698311ac8
+  React-jsinspector: d259c66bae14028a09f69fddccdefd2c45f4e73a
+  React-jsitracing: 719445d613a2e34962e9991e86f603e81465d5ed
+  React-logger: 87cddd161bd9784d60fc5528f21c57ca07d2962a
+  React-Mapbuffer: 1cc78f4d99f0b72286776ebf3406afd816838055
+  react-native-safe-area-context: 141eca0fd4e4191288dfc8b96a7c7e1c2983447a
   React-nativeconfig: fc1e87992e794e20f5e22116221577f21e05a18c
-  React-NativeModulesApple: 02a87759a8b359b91e5f5c57d05204d012bbce20
+  React-NativeModulesApple: e3718ff7726806ed0ea6ec4973a38b951b3296f8
   React-perflogger: e9ebfc705cb9f60ef5d471637350ccab7abd0444
   React-RCTActionSheet: 75cf1acf78e9c2eab4431c3bec100a6462a7f0d5
-  React-RCTAnimation: 93c464b62848bf9eddecf592819ca76111efb542
-  React-RCTAppDelegate: 2f909ac09a87c15465f8b9a5a23c522ca1c19bb3
-  React-RCTBlob: 946b43b7698e04ca313f4c872d716887f9e87fd8
-  React-RCTFabric: d6183f2a3838d6d3db780653d25e947bb34ee66a
-  React-RCTImage: f3e09ea018d9d49908ce13b4a56949bb7a27a640
-  React-RCTLinking: d808fd43aeb59a4e8851a31b82adcf86d585ac5d
-  React-RCTNetwork: c36cabc37ebd5b6944ad2ba6b41971d8fb273dae
-  React-RCTSettings: 4268e08911a0005568328fa8909f3558c8ce2a83
-  React-RCTText: 82d4e9e279c9cfaed5b95bb86a1d7212a7fd6f21
-  React-RCTVibration: 6a0fe57a35bf19d88a611d64563b34fce81af0a7
-  React-rendererdebug: 52f603fe6170cf607db1ea49c43eabb2f42a4cf7
+  React-RCTAnimation: 57a1a83a919ead49436ebe69a902d823f2059e61
+  React-RCTAppDelegate: 7732b1367774126055f64b3154cef2ba7d28eea2
+  React-RCTBlob: efb9cd99a32b22ca94989adde148a9938a8f6fcc
+  React-RCTFabric: ce1029e7f3cdbcf89ce05228a3ce87e1dedf9d6b
+  React-RCTImage: 862823815db42c847cbd875b5ccdd64d320da693
+  React-RCTLinking: 682e3018e2192f2cf87ddc601cccdac53fb8b1b7
+  React-RCTNetwork: 2945ab8c3ff4e2a6603b5d9a220c35b49f3a3ae0
+  React-RCTSettings: 807d08082b799d79a00b9fb3ac1590183afaa241
+  React-RCTText: d0e6f900dc2d9796240ff991abec9af8ef713a7b
+  React-RCTVibration: 4feafdb46bebf5380ab343d86b3ddfa4aadcb071
+  React-rendererdebug: 2584aee086dcf9e20693359df30b37a70071dc3c
   React-rncore: 0812a9d992dc5f522a3b82a44a538206356194c6
-  React-RuntimeApple: 3fc2684f07223b77ff34de60c39456e6c72db070
-  React-RuntimeCore: a6f1390c11cf7bcaeba0198549bdbda029a93a30
+  React-RuntimeApple: e9c5f5b495bb1ad65e382e3ec415dde7c7859ac2
+  React-RuntimeCore: 74b584e843610c27046a17e49ec8903a2616ad9e
   React-runtimeexecutor: 99640ce20e73e06301dd5e18cc6646fa0968347b
-  React-RuntimeHermes: e88641ccd12fc7b0e7879e6ead6b70fe28a5c409
-  React-runtimescheduler: 1dcdcd65d72bdce74a58a2da5d5b3295b27c6ca2
-  React-utils: e45cd7466d8fd9f1a88611fb8e9d38b92ef05b76
-  ReactCommon: 82c202f4ec2759b2e8461a5a524e3d0e9ec14b1e
-  ReactNativeAgentforce: 1b850b508bf262e20d164d42ceeb323043247aa9
-  RNGestureHandler: 5d95b0a3cffed8325ed0c181f4f411c1dcd49317
-  RNScreens: 9ffe14a19aa4fecfe49ead4cfea952cba63e02f5
+  React-RuntimeHermes: c4eb2640deadb89e50bb380f84295e54132689bc
+  React-runtimescheduler: 1ef8dbcea93f2017439af896bd38547a44d7ecee
+  React-utils: 51e69f7e95502e1e8b5f661209e81aac797dc6ce
+  ReactCommon: 9dadd8ca53f0a8b28f01799f1c3d44bd1bd0fa0a
+  ReactNativeAgentforce: a3746228f2499170548650bff3765cd2124bf9d1
+  RNGestureHandler: 20a4307fd21cbff339abfcfa68192f3f0a6a518b
+  RNScreens: b5ec99a7b9af5a8a6f23cc88716fe37be27aee97
   SalesforceLogging: 174438f5745353c816de5c3188ffaa21be55ff49
   SalesforceNavigation: c7dfa7a232252295585817d0ce3920c7e1dc7ad6
   SalesforceNetwork: 4a527f3c192515507c61d259f70e433a2a4f90dd
   SalesforceUser: 5b5614e282f7dc491dedcb92d3a6cf6b61f58fd9
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  swift-markdown-ui: 1ca8de6ca80a9530177f06503d2e74c8e75af995
+  swift-markdown-ui: 22463e21e80b69581ac302a8d8db757057b850d1
   SwiftCrypto: 8d2cd09cae2eafd28f37b049f8c24b3b28c4d12e
   SwiftProtobuf: e1b437c8e31a4c5577b643249a0bb62ed4f02153
   Yoga: 6986e115ef4e300f1f5b4910d5eef51c711c8747

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -55,9 +55,10 @@ interface HomeScreenProps {
 // Sample logger delegate — forwards Agentforce SDK logs to console
 const agentforceLogger: LoggerDelegate = {
   onLog(level: LogLevel, message: string, error?: string) {
-    const prefix = `[Agentforce ${level.toUpperCase()}]`;
+    const timestamp = new Date().toISOString();
+    const prefix = `[${timestamp}][Agentforce ${level.toUpperCase()}]`;
     if (error) {
-      console.log(`${prefix} ${message} | ${error}`);
+      console.log(`${prefix} ${message} | ERROR: ${error}`);
     } else {
       console.log(`${prefix} ${message}`);
     }


### PR DESCRIPTION
  ---                                                                                                                                                                                                       
  Title: [iOS] Expose Agentforce SDK Logger to React Native JS
                                                                                                                                                                                                            
  Body:                                                                                                                                                                                                     
                                                                                                                                                                                                            
  ## Summary

  - Add iOS `BridgeLogger` implementing `SalesforceLogging.Logger` to forward native SDK logs to JavaScript via `NativeEventEmitter`, mirroring the existing Android implementation
  - Add `enableNavigationForwarding` stub on iOS so the navigation JS layer (merged in #24) doesn't crash on iOS
  - Add `debug` to TypeScript `LogLevel` type to match the iOS SDK's four log levels (Android emits error/warn/info; iOS additionally emits debug)
  - Add thread safety (`NSLock`) for `hasListeners` and `forwardingEnabled` flags accessed across JS and SDK threads

  ## Details

  **Logging (W-21340539):**
  - New `BridgeLogger.swift` implements `SalesforceLogging.Logger` protocol
  - `AgentforceModule` emits `onLogMessage` events with `{ level, message }` payload
  - Service Agent config uses `.fullConfig()` instead of `.serviceAgent()` to pass the logger — `ServiceAgentConfiguration` doesn't accept a logger parameter (see TODO)
  - Employee Agent config passes `bridgeLogger` via existing `salesforceLogger` parameter

  **Navigation stub:**
  - No-op `enableNavigationForwarding` exported to unblock #24 on iOS
  - `onNavigationRequest` registered in `supportedEvents()` for the same reason