### PR TITLE
@W-21382190 Fix sdk initialization issue

### DIFF
--- a/android/app/src/employeeAgent/java/com/salesforce/android/reactagentforce/app/SdkInitializer.java
+++ b/android/app/src/employeeAgent/java/com/salesforce/android/reactagentforce/app/SdkInitializer.java
@@ -26,6 +26,7 @@
  */
 package com.salesforce.android.reactagentforce.app;
 
+import android.app.Activity;
 import android.content.Context;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 
@@ -34,7 +35,7 @@ import com.salesforce.androidsdk.app.SalesforceSDKManager;
  * Initializes Salesforce Mobile SDK for OAuth authentication.
  */
 public class SdkInitializer {
-    public static void initialize(Context context, Class<?> mainActivityClass) {
+    public static void initialize(Context context, Class<? extends Activity> mainActivityClass) {
         SalesforceSDKManager.initNative(context, mainActivityClass);
     }
 }

--- a/android/app/src/serviceAgent/java/com/salesforce/android/reactagentforce/app/SdkInitializer.java
+++ b/android/app/src/serviceAgent/java/com/salesforce/android/reactagentforce/app/SdkInitializer.java
@@ -26,6 +26,7 @@
  */
 package com.salesforce.android.reactagentforce.app;
 
+import android.app.Activity;
 import android.content.Context;
 
 /**
@@ -33,7 +34,7 @@ import android.content.Context;
  * No Mobile SDK initialization needed for Service Agent (uses anonymous auth).
  */
 public class SdkInitializer {
-    public static void initialize(Context context, Class<?> mainActivityClass) {
+    public static void initialize(Context context, Class<? extends Activity> mainActivityClass) {
         // No-op: Service Agent does not use Mobile SDK
     }
 }


### PR DESCRIPTION
### Description
This PR fixes a mobile SDK initialization error coming from the fact that the SalesforceSDKManager.initNative() expects Class<? extends Activity.