### PR TITLE
Add ViewProvider types and enableCustomViewProvider feature flag

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/src/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/index.ts
@@ -17,7 +17,7 @@ export {
 } from './services/EmployeeAgentAuth';
 export type { AuthCredentials } from './services/EmployeeAgentAuth';
 
-export type { ServiceAgentConfig, EmployeeAgentConfig, AgentConfig, FeatureFlags, LegacyServiceAgentConfig, ConfigurationResult, ConfigurationInfo, LoggerDelegate, LogLevel, NavigationDelegate, NavigationRequest } from './types';
+export type { ServiceAgentConfig, EmployeeAgentConfig, AgentConfig, FeatureFlags, LegacyServiceAgentConfig, ConfigurationResult, ConfigurationInfo, LoggerDelegate, LogLevel, NavigationDelegate, NavigationRequest, ViewProviderDelegate, ViewProviderComponentData } from './types';
 export { isServiceAgentConfig, isEmployeeAgentConfig, isLegacyConfig } from './types';
 
 export {

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -341,6 +341,7 @@ class AgentforceService {
         enableMultiModalInput: false,
         enablePDFUpload: false,
         enableVoice: false,
+        enableCustomViewProvider: false,
       };
     }
     if (!AgentforceModule?.getFeatureFlags) {
@@ -349,6 +350,7 @@ class AgentforceService {
         enableMultiModalInput: false,
         enablePDFUpload: false,
         enableVoice: false,
+        enableCustomViewProvider: false,
       };
     }
     try {
@@ -358,6 +360,7 @@ class AgentforceService {
         enableMultiModalInput: flags?.enableMultiModalInput ?? false,
         enablePDFUpload: flags?.enablePDFUpload ?? false,
         enableVoice: flags?.enableVoice ?? false,
+        enableCustomViewProvider: flags?.enableCustomViewProvider ?? false,
       };
     } catch {
       return {
@@ -365,6 +368,7 @@ class AgentforceService {
         enableMultiModalInput: false,
         enablePDFUpload: false,
         enableVoice: false,
+        enableCustomViewProvider: false,
       };
     }
   }

--- a/AgentforceSDK-ReactNative-Bridge/src/types/AgentConfig.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/AgentConfig.ts
@@ -13,6 +13,7 @@ export interface FeatureFlags {
   enableMultiModalInput: boolean;
   enablePDFUpload: boolean;
   enableVoice: boolean;
+  enableCustomViewProvider: boolean;
 }
 
 /**

--- a/AgentforceSDK-ReactNative-Bridge/src/types/ViewProviderDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/ViewProviderDelegate.ts
@@ -5,14 +5,19 @@
  * When enabled, the native SDK checks the registered component types before rendering
  * its built-in views. If a match is found, a React Native root view is rendered instead.
  *
+ * Each component type maps 1:1 to a React Native component name, so different
+ * SDK view types can be rendered by different React components.
+ *
  * Known component definition strings follow the pattern "copilot/<type>" or "agentforce/<type>".
  * Examples: 'copilot/richText', 'copilot/markdown', 'copilot/recordInfo', 'copilot/list'.
  *
  * @example
  * ```typescript
  * AgentforceService.setViewProviderDelegate({
- *   componentTypes: ['copilot/richText', 'copilot/markdown'],
- *   reactComponentName: 'CustomAgentforceView',
+ *   componentMap: {
+ *     'copilot/richText': 'CustomRichTextView',
+ *     'copilot/markdown': 'CustomMarkdownView',
+ *   },
  * });
  * ```
  */
@@ -35,24 +40,26 @@ export interface ViewProviderComponentData {
  * Configuration for the View Provider delegate.
  *
  * Register this to tell the native SDK which component types your React Native
- * view can handle. When the SDK encounters a matching type, it renders your
- * registered React component instead of the built-in native view.
+ * views can handle. Each key is a component definition string, and the value
+ * is the registered React Native component name to render for that type.
+ *
+ * Register each component with `AppRegistry.registerComponent()`.
  */
 export interface ViewProviderDelegate {
   /**
-   * List of component definition strings this provider handles.
-   * The native `canHandle()` method checks against this list synchronously.
+   * Maps component definition strings to React Native component names.
+   * The native `canHandle()` method checks against the keys synchronously.
+   * The `view()` / `GetView()` method looks up the component name for the
+   * matching key and renders it via RCTRootView / ReactRootView.
    *
-   * @example ['copilot/richText', 'copilot/markdown', 'copilot/recordInfo']
+   * @example
+   * ```typescript
+   * {
+   *   'copilot/richText': 'CustomRichTextView',
+   *   'copilot/markdown': 'CustomMarkdownView',
+   *   'copilot/recordInfo': 'CustomRecordInfoView',
+   * }
+   * ```
    */
-  componentTypes: string[];
-
-  /**
-   * The registered React Native component name that will be rendered
-   * for matching types. This component receives `ViewProviderComponentData`
-   * as its props via the native root view.
-   *
-   * Register the component with `AppRegistry.registerComponent()`.
-   */
-  reactComponentName: string;
+  componentMap: Record<string, string>;
 }

--- a/AgentforceSDK-ReactNative-Bridge/src/types/ViewProviderDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/ViewProviderDelegate.ts
@@ -1,0 +1,58 @@
+/**
+ * View Provider delegate types for Agentforce SDK
+ *
+ * Allows JS to override native SDK output views with custom React Native components.
+ * When enabled, the native SDK checks the registered component types before rendering
+ * its built-in views. If a match is found, a React Native root view is rendered instead.
+ *
+ * Known component definition strings follow the pattern "copilot/<type>" or "agentforce/<type>".
+ * Examples: 'copilot/richText', 'copilot/markdown', 'copilot/recordInfo', 'copilot/list'.
+ *
+ * @example
+ * ```typescript
+ * AgentforceService.setViewProviderDelegate({
+ *   componentTypes: ['copilot/richText', 'copilot/markdown'],
+ *   reactComponentName: 'CustomAgentforceView',
+ * });
+ * ```
+ */
+
+/**
+ * Data passed from the native SDK to the React Native view for rendering.
+ */
+export interface ViewProviderComponentData {
+  /** The component definition string (e.g. 'copilot/richText') */
+  definition: string;
+  /** Component name from the SDK (may be null) */
+  name?: string;
+  /** Key-value properties for the component */
+  properties: Record<string, unknown>;
+  /** Nested sub-components, if any */
+  subComponents?: ViewProviderComponentData[];
+}
+
+/**
+ * Configuration for the View Provider delegate.
+ *
+ * Register this to tell the native SDK which component types your React Native
+ * view can handle. When the SDK encounters a matching type, it renders your
+ * registered React component instead of the built-in native view.
+ */
+export interface ViewProviderDelegate {
+  /**
+   * List of component definition strings this provider handles.
+   * The native `canHandle()` method checks against this list synchronously.
+   *
+   * @example ['copilot/richText', 'copilot/markdown', 'copilot/recordInfo']
+   */
+  componentTypes: string[];
+
+  /**
+   * The registered React Native component name that will be rendered
+   * for matching types. This component receives `ViewProviderComponentData`
+   * as its props via the native root view.
+   *
+   * Register the component with `AppRegistry.registerComponent()`.
+   */
+  reactComponentName: string;
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
@@ -23,3 +23,6 @@ export { LoggerDelegate, LogLevel } from './LoggerDelegate';
 
 // Navigation delegate types
 export { NavigationDelegate, NavigationRequest } from './NavigationDelegate';
+
+// View provider delegate types
+export { ViewProviderDelegate, ViewProviderComponentData } from './ViewProviderDelegate';


### PR DESCRIPTION
## Summary
- Adds `ViewProviderDelegate` and `ViewProviderComponentData` TypeScript types for bridging native SDK view customization to React Native
- Adds `enableCustomViewProvider` to `FeatureFlags` interface
- Exports new types from the bridge package

## Stack
PR 1/6 in the `viewprovider` stack. This PR adds the type foundation for subsequent native bridge and JS service PRs.

## Test plan
- [ ] TypeScript compilation passes with new types
- [ ] No runtime changes — types only