### PR TITLE
Add iOS BridgeViewProvider for React Native view overrides

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
@@ -94,4 +94,13 @@ RCT_EXTERN_METHOD(enableNavigationForwarding:(BOOL)enabled
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+// MARK: - View Provider
+
+RCT_EXTERN_METHOD(registerViewProvider:(NSDictionary *)config
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(clearViewProvider:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -760,14 +760,13 @@ class AgentforceModule: RCTEventEmitter {
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) {
         guard let dict = config as? [String: Any],
-              let types = dict["componentTypes"] as? [String],
-              let componentName = dict["reactComponentName"] as? String,
-              !types.isEmpty, !componentName.isEmpty else {
-            reject("INVALID_CONFIG", "Must provide componentTypes array and reactComponentName", nil)
+              let componentMap = dict["componentMap"] as? [String: String],
+              !componentMap.isEmpty else {
+            reject("INVALID_CONFIG", "Must provide a non-empty componentMap dictionary", nil)
             return
         }
-        bridgeViewProvider.register(componentTypes: types, reactComponentName: componentName)
-        resolve(["success": true, "registeredTypes": types])
+        bridgeViewProvider.register(componentMap: componentMap)
+        resolve(["success": true, "registeredTypes": Array(componentMap.keys)])
     }
 
     /// Clear the custom view provider registration.

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -60,6 +60,14 @@ class AgentforceModule: RCTEventEmitter {
         return BridgeNavigation(module: self)
     }()
 
+    // MARK: - View Provider
+
+    /// Bridge view provider for delegating native SDK views to React Native components.
+    /// Initialized lazily so the RCT bridge is available.
+    private lazy var bridgeViewProvider: BridgeViewProvider = {
+        return BridgeViewProvider(bridge: self.bridge)
+    }()
+
     // MARK: - Module Setup
 
     override static func requiresMainQueueSetup() -> Bool {
@@ -164,10 +172,11 @@ class AgentforceModule: RCTEventEmitter {
 
         agentforceClient = AgentforceClient(
             credentialProvider: credentialProvider,
-            mode: .fullConfig(fullConfiguration)
+            mode: .fullConfig(fullConfiguration),
+            viewProvider: bridgeViewProvider.isRegistered ? bridgeViewProvider : nil
         )
     }
-    
+
     // MARK: - Employee Agent Configuration
     
     private func configureEmployeeAgent(_ configDict: [String: Any]) async throws {
@@ -236,7 +245,8 @@ class AgentforceModule: RCTEventEmitter {
         // Initialize Agentforce Client with fullConfig mode (explicit config + feature flags).
         agentforceClient = AgentforceClient(
             credentialProvider: credentialProvider,
-            mode: .fullConfig(fullConfiguration)
+            mode: .fullConfig(fullConfiguration),
+            viewProvider: bridgeViewProvider.isRegistered ? bridgeViewProvider : nil
         )
     }
     
@@ -739,8 +749,39 @@ class AgentforceModule: RCTEventEmitter {
         sendEvent(withName: "onNavigationRequest", body: payload)
     }
 
+    // MARK: - View Provider
+
+    /// Register a React Native component as a custom view provider for specified types.
+    /// Must be called before configure() so the provider is attached at SDK init time.
+    @objc
+    func registerViewProvider(
+        _ config: NSDictionary,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        guard let dict = config as? [String: Any],
+              let types = dict["componentTypes"] as? [String],
+              let componentName = dict["reactComponentName"] as? String,
+              !types.isEmpty, !componentName.isEmpty else {
+            reject("INVALID_CONFIG", "Must provide componentTypes array and reactComponentName", nil)
+            return
+        }
+        bridgeViewProvider.register(componentTypes: types, reactComponentName: componentName)
+        resolve(["success": true, "registeredTypes": types])
+    }
+
+    /// Clear the custom view provider registration.
+    @objc
+    func clearViewProvider(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        bridgeViewProvider.reset()
+        resolve(["success": true])
+    }
+
     // MARK: - Cleanup
-    
+
     private func cleanupClient() {
         currentConversation = nil
         agentforceClient = nil
@@ -771,6 +812,7 @@ class AgentforceModule: RCTEventEmitter {
             cleanupClient()
             currentMode = nil
             credentialProvider.reset()
+            bridgeViewProvider.reset()
             ServiceAgentManager.shared.resetToDefaults()
             UserDefaults.standard.removeObject(forKey: "EmployeeAgentId")
             resolve(["success": true])

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Providers/BridgeViewProvider.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Providers/BridgeViewProvider.swift
@@ -68,17 +68,15 @@ class BridgeViewProvider: AgentforceViewProviding {
 // MARK: - SwiftUI wrapper for RCTRootView
 
 /// Wraps an RCTRootView in a UIViewRepresentable for use in SwiftUI.
+/// Uses RCTRootView's intrinsic content size so SwiftUI can lay it out correctly.
 private struct ReactNativeViewWrapper: UIViewRepresentable {
     let bridge: RCTBridge?
     let moduleName: String
     let initialProperties: [String: Any]
 
-    func makeUIView(context: Context) -> UIView {
+    func makeUIView(context: Context) -> RCTRootView {
         guard let bridge = bridge else {
-            let label = UILabel()
-            label.text = "Bridge unavailable"
-            label.textAlignment = .center
-            return label
+            return RCTRootView()
         }
         let rootView = RCTRootView(
             bridge: bridge,
@@ -86,10 +84,18 @@ private struct ReactNativeViewWrapper: UIViewRepresentable {
             initialProperties: initialProperties
         )
         rootView.backgroundColor = .clear
+        rootView.sizeFlexibility = .widthAndHeight
         return rootView
     }
 
-    func updateUIView(_ uiView: UIView, context: Context) {
+    func updateUIView(_ uiView: RCTRootView, context: Context) {
         // RCTRootView handles its own updates via the bridge
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: RCTRootView, context: Context) -> CGSize? {
+        let width = proposal.width ?? UIScreen.main.bounds.width
+        let size = uiView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
+        guard size.height > 0 else { return nil }
+        return CGSize(width: width, height: size.height)
     }
 }

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Providers/BridgeViewProvider.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Providers/BridgeViewProvider.swift
@@ -16,11 +16,9 @@ import AgentforceSDK
 /// Component types are registered synchronously from JS; rendering uses RCTRootView.
 class BridgeViewProvider: AgentforceViewProviding {
 
-    /// Set of component definition strings this provider handles (e.g. "copilot/richText")
-    private var registeredTypes: Set<String> = []
-
-    /// The React Native component name to render for matching types
-    private var reactComponentName: String = ""
+    /// Maps component definition strings to React Native component names (1:1).
+    /// e.g. ["copilot/richText": "CustomRichTextView", "copilot/markdown": "CustomMarkdownView"]
+    private var componentMap: [String: String] = [:]
 
     /// Reference to the RCT bridge for creating root views
     private weak var bridge: RCTBridge?
@@ -29,38 +27,39 @@ class BridgeViewProvider: AgentforceViewProviding {
         self.bridge = bridge
     }
 
-    /// Register component types and the React component to render them.
+    /// Register a 1:1 mapping of component definition strings to React component names.
     /// Called from JS via the native module before launching conversation.
-    func register(componentTypes: [String], reactComponentName: String) {
-        self.registeredTypes = Set(componentTypes)
-        self.reactComponentName = reactComponentName
+    func register(componentMap: [String: String]) {
+        self.componentMap = componentMap
     }
 
     /// Clear all registrations
     func reset() {
-        registeredTypes.removeAll()
-        reactComponentName = ""
+        componentMap.removeAll()
     }
 
     var isRegistered: Bool {
-        !registeredTypes.isEmpty && !reactComponentName.isEmpty
+        !componentMap.isEmpty
     }
 
     // MARK: - AgentforceViewProviding
 
     func canHandle(type: String) -> Bool {
-        registeredTypes.contains(type)
+        componentMap[type] != nil
     }
 
     @MainActor
     func view(for type: String, data: [String: Any]) -> AnyView {
+        guard let moduleName = componentMap[type] else {
+            return AnyView(EmptyView())
+        }
         let props: [String: Any] = [
             "definition": type,
             "properties": data,
         ]
         return AnyView(ReactNativeViewWrapper(
             bridge: bridge,
-            moduleName: reactComponentName,
+            moduleName: moduleName,
             initialProperties: props
         ))
     }

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Providers/BridgeViewProvider.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Providers/BridgeViewProvider.swift
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
+ *
+ * Bridges the native AgentforceViewProviding protocol to React Native.
+ * When enabled, delegates rendering of specified component types to a
+ * registered React Native component via RCTRootView.
+ */
+
+import Foundation
+import UIKit
+import SwiftUI
+import React
+import AgentforceSDK
+
+/// Implements AgentforceViewProviding by delegating to a React Native component.
+/// Component types are registered synchronously from JS; rendering uses RCTRootView.
+class BridgeViewProvider: AgentforceViewProviding {
+
+    /// Set of component definition strings this provider handles (e.g. "copilot/richText")
+    private var registeredTypes: Set<String> = []
+
+    /// The React Native component name to render for matching types
+    private var reactComponentName: String = ""
+
+    /// Reference to the RCT bridge for creating root views
+    private weak var bridge: RCTBridge?
+
+    init(bridge: RCTBridge?) {
+        self.bridge = bridge
+    }
+
+    /// Register component types and the React component to render them.
+    /// Called from JS via the native module before launching conversation.
+    func register(componentTypes: [String], reactComponentName: String) {
+        self.registeredTypes = Set(componentTypes)
+        self.reactComponentName = reactComponentName
+    }
+
+    /// Clear all registrations
+    func reset() {
+        registeredTypes.removeAll()
+        reactComponentName = ""
+    }
+
+    var isRegistered: Bool {
+        !registeredTypes.isEmpty && !reactComponentName.isEmpty
+    }
+
+    // MARK: - AgentforceViewProviding
+
+    func canHandle(type: String) -> Bool {
+        registeredTypes.contains(type)
+    }
+
+    @MainActor
+    func view(for type: String, data: [String: Any]) -> AnyView {
+        let props: [String: Any] = [
+            "definition": type,
+            "properties": data,
+        ]
+        return AnyView(ReactNativeViewWrapper(
+            bridge: bridge,
+            moduleName: reactComponentName,
+            initialProperties: props
+        ))
+    }
+}
+
+// MARK: - SwiftUI wrapper for RCTRootView
+
+/// Wraps an RCTRootView in a UIViewRepresentable for use in SwiftUI.
+private struct ReactNativeViewWrapper: UIViewRepresentable {
+    let bridge: RCTBridge?
+    let moduleName: String
+    let initialProperties: [String: Any]
+
+    func makeUIView(context: Context) -> UIView {
+        guard let bridge = bridge else {
+            let label = UILabel()
+            label.text = "Bridge unavailable"
+            label.textAlignment = .center
+            return label
+        }
+        let rootView = RCTRootView(
+            bridge: bridge,
+            moduleName: moduleName,
+            initialProperties: initialProperties
+        )
+        rootView.backgroundColor = .clear
+        return rootView
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        // RCTRootView handles its own updates via the bridge
+    }
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/index.ts
@@ -17,7 +17,7 @@ export {
 } from './services/EmployeeAgentAuth';
 export type { AuthCredentials } from './services/EmployeeAgentAuth';
 
-export type { ServiceAgentConfig, EmployeeAgentConfig, AgentConfig, FeatureFlags, LegacyServiceAgentConfig, ConfigurationResult, ConfigurationInfo, LoggerDelegate, LogLevel, NavigationDelegate, NavigationRequest } from './types';
+export type { ServiceAgentConfig, EmployeeAgentConfig, AgentConfig, FeatureFlags, LegacyServiceAgentConfig, ConfigurationResult, ConfigurationInfo, LoggerDelegate, LogLevel, NavigationDelegate, NavigationRequest, ViewProviderDelegate, ViewProviderComponentData } from './types';
 export { isServiceAgentConfig, isEmployeeAgentConfig, isLegacyConfig } from './types';
 
 export {

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -341,6 +341,7 @@ class AgentforceService {
         enableMultiModalInput: false,
         enablePDFUpload: false,
         enableVoice: false,
+        enableCustomViewProvider: false,
       };
     }
     if (!AgentforceModule?.getFeatureFlags) {
@@ -349,6 +350,7 @@ class AgentforceService {
         enableMultiModalInput: false,
         enablePDFUpload: false,
         enableVoice: false,
+        enableCustomViewProvider: false,
       };
     }
     try {
@@ -358,6 +360,7 @@ class AgentforceService {
         enableMultiModalInput: flags?.enableMultiModalInput ?? false,
         enablePDFUpload: flags?.enablePDFUpload ?? false,
         enableVoice: flags?.enableVoice ?? false,
+        enableCustomViewProvider: flags?.enableCustomViewProvider ?? false,
       };
     } catch {
       return {
@@ -365,6 +368,7 @@ class AgentforceService {
         enableMultiModalInput: false,
         enablePDFUpload: false,
         enableVoice: false,
+        enableCustomViewProvider: false,
       };
     }
   }

--- a/AgentforceSDK-ReactNative-Bridge/src/types/AgentConfig.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/AgentConfig.ts
@@ -13,6 +13,7 @@ export interface FeatureFlags {
   enableMultiModalInput: boolean;
   enablePDFUpload: boolean;
   enableVoice: boolean;
+  enableCustomViewProvider: boolean;
 }
 
 /**

--- a/AgentforceSDK-ReactNative-Bridge/src/types/ViewProviderDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/ViewProviderDelegate.ts
@@ -5,14 +5,19 @@
  * When enabled, the native SDK checks the registered component types before rendering
  * its built-in views. If a match is found, a React Native root view is rendered instead.
  *
+ * Each component type maps 1:1 to a React Native component name, so different
+ * SDK view types can be rendered by different React components.
+ *
  * Known component definition strings follow the pattern "copilot/<type>" or "agentforce/<type>".
  * Examples: 'copilot/richText', 'copilot/markdown', 'copilot/recordInfo', 'copilot/list'.
  *
  * @example
  * ```typescript
  * AgentforceService.setViewProviderDelegate({
- *   componentTypes: ['copilot/richText', 'copilot/markdown'],
- *   reactComponentName: 'CustomAgentforceView',
+ *   componentMap: {
+ *     'copilot/richText': 'CustomRichTextView',
+ *     'copilot/markdown': 'CustomMarkdownView',
+ *   },
  * });
  * ```
  */
@@ -35,24 +40,26 @@ export interface ViewProviderComponentData {
  * Configuration for the View Provider delegate.
  *
  * Register this to tell the native SDK which component types your React Native
- * view can handle. When the SDK encounters a matching type, it renders your
- * registered React component instead of the built-in native view.
+ * views can handle. Each key is a component definition string, and the value
+ * is the registered React Native component name to render for that type.
+ *
+ * Register each component with `AppRegistry.registerComponent()`.
  */
 export interface ViewProviderDelegate {
   /**
-   * List of component definition strings this provider handles.
-   * The native `canHandle()` method checks against this list synchronously.
+   * Maps component definition strings to React Native component names.
+   * The native `canHandle()` method checks against the keys synchronously.
+   * The `view()` / `GetView()` method looks up the component name for the
+   * matching key and renders it via RCTRootView / ReactRootView.
    *
-   * @example ['copilot/richText', 'copilot/markdown', 'copilot/recordInfo']
+   * @example
+   * ```typescript
+   * {
+   *   'copilot/richText': 'CustomRichTextView',
+   *   'copilot/markdown': 'CustomMarkdownView',
+   *   'copilot/recordInfo': 'CustomRecordInfoView',
+   * }
+   * ```
    */
-  componentTypes: string[];
-
-  /**
-   * The registered React Native component name that will be rendered
-   * for matching types. This component receives `ViewProviderComponentData`
-   * as its props via the native root view.
-   *
-   * Register the component with `AppRegistry.registerComponent()`.
-   */
-  reactComponentName: string;
+  componentMap: Record<string, string>;
 }

--- a/AgentforceSDK-ReactNative-Bridge/src/types/ViewProviderDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/ViewProviderDelegate.ts
@@ -1,0 +1,58 @@
+/**
+ * View Provider delegate types for Agentforce SDK
+ *
+ * Allows JS to override native SDK output views with custom React Native components.
+ * When enabled, the native SDK checks the registered component types before rendering
+ * its built-in views. If a match is found, a React Native root view is rendered instead.
+ *
+ * Known component definition strings follow the pattern "copilot/<type>" or "agentforce/<type>".
+ * Examples: 'copilot/richText', 'copilot/markdown', 'copilot/recordInfo', 'copilot/list'.
+ *
+ * @example
+ * ```typescript
+ * AgentforceService.setViewProviderDelegate({
+ *   componentTypes: ['copilot/richText', 'copilot/markdown'],
+ *   reactComponentName: 'CustomAgentforceView',
+ * });
+ * ```
+ */
+
+/**
+ * Data passed from the native SDK to the React Native view for rendering.
+ */
+export interface ViewProviderComponentData {
+  /** The component definition string (e.g. 'copilot/richText') */
+  definition: string;
+  /** Component name from the SDK (may be null) */
+  name?: string;
+  /** Key-value properties for the component */
+  properties: Record<string, unknown>;
+  /** Nested sub-components, if any */
+  subComponents?: ViewProviderComponentData[];
+}
+
+/**
+ * Configuration for the View Provider delegate.
+ *
+ * Register this to tell the native SDK which component types your React Native
+ * view can handle. When the SDK encounters a matching type, it renders your
+ * registered React component instead of the built-in native view.
+ */
+export interface ViewProviderDelegate {
+  /**
+   * List of component definition strings this provider handles.
+   * The native `canHandle()` method checks against this list synchronously.
+   *
+   * @example ['copilot/richText', 'copilot/markdown', 'copilot/recordInfo']
+   */
+  componentTypes: string[];
+
+  /**
+   * The registered React Native component name that will be rendered
+   * for matching types. This component receives `ViewProviderComponentData`
+   * as its props via the native root view.
+   *
+   * Register the component with `AppRegistry.registerComponent()`.
+   */
+  reactComponentName: string;
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
@@ -23,3 +23,6 @@ export { LoggerDelegate, LogLevel } from './LoggerDelegate';
 
 // Navigation delegate types
 export { NavigationDelegate, NavigationRequest } from './NavigationDelegate';
+
+// View provider delegate types
+export { ViewProviderDelegate, ViewProviderComponentData } from './ViewProviderDelegate';


### PR DESCRIPTION
## Summary
- Creates `BridgeViewProvider.swift` implementing `AgentforceViewProviding` protocol
- `canHandle(type:)` checks against pre-registered component type strings from JS
- `view(for:data:)` returns an `RCTRootView` wrapped in SwiftUI via `UIViewRepresentable`
- Adds `registerViewProvider` / `clearViewProvider` native methods to `AgentforceModule`
- Passes the view provider to `AgentforceClient` init when registered

## Stack
PR 2/6 in the `viewprovider` stack. Depends on PR #30.

## Test plan
- [ ] iOS build compiles with new BridgeViewProvider
- [ ] registerViewProvider accepts componentTypes + reactComponentName
- [ ] clearViewProvider resets registration
- [ ] Without registration, AgentforceClient inits with nil viewProvider (no behavior change)