### PR TITLE
Add example CustomAgentforceView and wire ViewProvider in HomeScreen

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -24,6 +24,7 @@ import com.salesforce.android.agentforcesdkimpl.utils.AgentforceFeatureFlagSetti
 import com.salesforce.android.reactagentforce.models.AgentMode as LocalAgentMode
 import com.salesforce.android.reactagentforce.models.EmployeeAgentModeConfig
 import com.salesforce.android.reactagentforce.models.ServiceAgentModeConfig
+import com.salesforce.android.reactagentforce.providers.BridgeViewProvider
 import com.salesforce.android.reactagentforce.providers.UnifiedCredentialProvider
 import kotlinx.coroutines.*
 
@@ -66,6 +67,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
 
     // Bridge navigation for forwarding SDK navigation requests to JS
     private val bridgeNavigation = BridgeNavigation(reactContext)
+
+    // Bridge view provider for delegating native SDK views to React Native components
+    private val bridgeViewProvider = BridgeViewProvider(reactContext)
 
     // Coroutine scope for async operations
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
@@ -162,6 +166,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setLogger(bridgeLogger)
                     .setNavigation(bridgeNavigation)
                 permissions?.let { agentforceConfigBuilder.setPermission(it) }
+                if (bridgeViewProvider.isRegistered) {
+                    agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
+                }
                 val agentforceConfig = agentforceConfigBuilder.build()
 
                 val sdkMode = AgentforceMode.ServiceAgent(
@@ -236,6 +243,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setLogger(bridgeLogger)
                     .setNavigation(bridgeNavigation)
                 permissions?.let { agentforceConfigBuilder.setPermission(it) }
+                if (bridgeViewProvider.isRegistered) {
+                    agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
+                }
                 val agentforceConfig = agentforceConfigBuilder.build()
 
                 // Use FullConfig mode for Employee Agent
@@ -520,6 +530,34 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         promise.resolve(true)
     }
 
+    // MARK: - View Provider
+
+    @ReactMethod
+    fun registerViewProvider(config: ReadableMap, promise: Promise) {
+        val types = config.getArray("componentTypes")
+        val componentName = config.getString("reactComponentName")
+
+        if (types == null || types.size() == 0 || componentName.isNullOrEmpty()) {
+            promise.reject("INVALID_CONFIG", "Must provide componentTypes array and reactComponentName")
+            return
+        }
+
+        val typeList = (0 until types.size()).mapNotNull { types.getString(it) }
+        bridgeViewProvider.register(typeList, componentName)
+        promise.resolve(Arguments.createMap().apply {
+            putBoolean("success", true)
+            putArray("registeredTypes", Arguments.fromList(typeList))
+        })
+    }
+
+    @ReactMethod
+    fun clearViewProvider(promise: Promise) {
+        bridgeViewProvider.reset()
+        promise.resolve(Arguments.createMap().apply {
+            putBoolean("success", true)
+        })
+    }
+
     // MARK: - Cleanup
 
     @ReactMethod
@@ -537,6 +575,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         viewModel?.resetConfiguration()
         currentMode = null
         credentialProvider.reset()
+        bridgeViewProvider.reset()
         employeePrefs.edit().remove(KEY_EMPLOYEE_AGENT_ID).apply()
         promise.resolve(Arguments.createMap().apply {
             putBoolean("success", true)

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -534,19 +534,29 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun registerViewProvider(config: ReadableMap, promise: Promise) {
-        val types = config.getArray("componentTypes")
-        val componentName = config.getString("reactComponentName")
+        val mapData = config.getMap("componentMap")
 
-        if (types == null || types.size() == 0 || componentName.isNullOrEmpty()) {
-            promise.reject("INVALID_CONFIG", "Must provide componentTypes array and reactComponentName")
+        if (mapData == null) {
+            promise.reject("INVALID_CONFIG", "Must provide a non-empty componentMap dictionary")
             return
         }
 
-        val typeList = (0 until types.size()).mapNotNull { types.getString(it) }
-        bridgeViewProvider.register(typeList, componentName)
+        val componentMap = mutableMapOf<String, String>()
+        val iterator = mapData.keySetIterator()
+        while (iterator.hasNextKey()) {
+            val key = iterator.nextKey()
+            mapData.getString(key)?.let { componentMap[key] = it }
+        }
+
+        if (componentMap.isEmpty()) {
+            promise.reject("INVALID_CONFIG", "Must provide a non-empty componentMap dictionary")
+            return
+        }
+
+        bridgeViewProvider.register(componentMap)
         promise.resolve(Arguments.createMap().apply {
             putBoolean("success", true)
-            putArray("registeredTypes", Arguments.fromList(typeList))
+            putInt("registeredCount", componentMap.size)
         })
     }
 

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -45,6 +45,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         private const val KEY_ENABLE_MULTI_MODAL_INPUT = "enableMultiModalInput"
         private const val KEY_ENABLE_PDF_UPLOAD = "enablePDFUpload"
         private const val KEY_ENABLE_VOICE = "enableVoice"
+        private const val KEY_ENABLE_CUSTOM_VIEW_PROVIDER = "enableCustomViewProvider"
     }
 
     private val employeePrefs: SharedPreferences
@@ -433,7 +434,8 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         val enableMultiAgent: Boolean,
         val enableMultiModalInput: Boolean,
         val enablePDFUpload: Boolean,
-        val enableVoice: Boolean
+        val enableVoice: Boolean,
+        val enableCustomViewProvider: Boolean
     )
 
     private fun getFeatureFlagsFromConfigOrPrefs(config: ReadableMap): FeatureFlags {
@@ -443,14 +445,16 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                 enableMultiAgent = featureFlagsMap.hasKey("enableMultiAgent") && featureFlagsMap.getBoolean("enableMultiAgent"),
                 enableMultiModalInput = featureFlagsMap.hasKey("enableMultiModalInput") && featureFlagsMap.getBoolean("enableMultiModalInput"),
                 enablePDFUpload = featureFlagsMap.hasKey("enablePDFUpload") && featureFlagsMap.getBoolean("enablePDFUpload"),
-                enableVoice = featureFlagsMap.hasKey("enableVoice") && featureFlagsMap.getBoolean("enableVoice")
+                enableVoice = featureFlagsMap.hasKey("enableVoice") && featureFlagsMap.getBoolean("enableVoice"),
+                enableCustomViewProvider = featureFlagsMap.hasKey("enableCustomViewProvider") && featureFlagsMap.getBoolean("enableCustomViewProvider")
             )
         } else {
             FeatureFlags(
                 enableMultiAgent = featureFlagsPrefs.getBoolean(KEY_ENABLE_MULTI_AGENT, true),
                 enableMultiModalInput = featureFlagsPrefs.getBoolean(KEY_ENABLE_MULTI_MODAL_INPUT, false),
                 enablePDFUpload = featureFlagsPrefs.getBoolean(KEY_ENABLE_PDF_UPLOAD, false),
-                enableVoice = featureFlagsPrefs.getBoolean(KEY_ENABLE_VOICE, false)
+                enableVoice = featureFlagsPrefs.getBoolean(KEY_ENABLE_VOICE, false),
+                enableCustomViewProvider = featureFlagsPrefs.getBoolean(KEY_ENABLE_CUSTOM_VIEW_PROVIDER, false)
             )
         }
     }
@@ -461,6 +465,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             .putBoolean(KEY_ENABLE_MULTI_MODAL_INPUT, flags.enableMultiModalInput)
             .putBoolean(KEY_ENABLE_PDF_UPLOAD, flags.enablePDFUpload)
             .putBoolean(KEY_ENABLE_VOICE, flags.enableVoice)
+            .putBoolean(KEY_ENABLE_CUSTOM_VIEW_PROVIDER, flags.enableCustomViewProvider)
             .apply()
     }
 
@@ -471,6 +476,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             putBoolean("enableMultiModalInput", featureFlagsPrefs.getBoolean(KEY_ENABLE_MULTI_MODAL_INPUT, false))
             putBoolean("enablePDFUpload", featureFlagsPrefs.getBoolean(KEY_ENABLE_PDF_UPLOAD, false))
             putBoolean("enableVoice", featureFlagsPrefs.getBoolean(KEY_ENABLE_VOICE, false))
+            putBoolean("enableCustomViewProvider", featureFlagsPrefs.getBoolean(KEY_ENABLE_CUSTOM_VIEW_PROVIDER, false))
         })
     }
 
@@ -481,6 +487,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             .putBoolean(KEY_ENABLE_MULTI_MODAL_INPUT, flags.hasKey("enableMultiModalInput") && flags.getBoolean("enableMultiModalInput"))
             .putBoolean(KEY_ENABLE_PDF_UPLOAD, flags.hasKey("enablePDFUpload") && flags.getBoolean("enablePDFUpload"))
             .putBoolean(KEY_ENABLE_VOICE, flags.hasKey("enableVoice") && flags.getBoolean("enableVoice"))
+            .putBoolean(KEY_ENABLE_CUSTOM_VIEW_PROVIDER, flags.hasKey("enableCustomViewProvider") && flags.getBoolean("enableCustomViewProvider"))
             .apply()
         promise.resolve(null)
     }

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Bridges the native AgentforceViewProvider interface to React Native.
+ * When enabled, delegates rendering of specified component types to a
+ * registered React Native component via ReactRootView.
+ */
+package com.salesforce.android.reactagentforce.providers
+
+import android.os.Bundle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactRootView
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableMap
+import com.salesforce.android.agentforcesdk.components.models.AgentforceComponent
+import com.salesforce.android.agentforcesdk.components.models.AgentforceViewProvider
+
+/**
+ * Implements AgentforceViewProvider by delegating to a React Native component.
+ * Component types are registered synchronously from JS; rendering uses ReactRootView.
+ */
+class BridgeViewProvider(
+    private val reactContext: ReactApplicationContext
+) : AgentforceViewProvider {
+
+    /** Set of component definition strings this provider handles */
+    private var registeredTypes: MutableSet<String> = mutableSetOf()
+
+    /** The React Native component name to render for matching types */
+    private var reactComponentName: String = ""
+
+    /** Register component types and the React component to render them. */
+    fun register(componentTypes: List<String>, reactComponentName: String) {
+        this.registeredTypes = componentTypes.toMutableSet()
+        this.reactComponentName = reactComponentName
+    }
+
+    /** Clear all registrations */
+    fun reset() {
+        registeredTypes.clear()
+        reactComponentName = ""
+    }
+
+    val isRegistered: Boolean
+        get() = registeredTypes.isNotEmpty() && reactComponentName.isNotEmpty()
+
+    // MARK: - AgentforceViewProvider
+
+    override fun canHandle(definition: String): Boolean {
+        return registeredTypes.contains(definition)
+    }
+
+    @Composable
+    override fun GetView(modifier: Modifier, view: AgentforceComponent) {
+        val props = componentToBundle(view)
+        AndroidView(
+            modifier = modifier,
+            factory = { context ->
+                ReactRootView(context).apply {
+                    val reactApp = reactContext.applicationContext as? ReactApplication
+                    val reactHost = reactApp?.reactHost
+                    // Start the React surface with the registered component name and props
+                    startReactApplication(
+                        reactHost?.currentReactContext?.catalystInstance?.let {
+                            // For modern RN, get the instance manager from the host
+                            (reactApp as? ReactApplication)?.reactNativeHost?.reactInstanceManager
+                        },
+                        reactComponentName,
+                        props
+                    )
+                }
+            }
+        )
+    }
+
+    /** Convert AgentforceComponent to a Bundle for React Native initial properties */
+    private fun componentToBundle(component: AgentforceComponent): Bundle {
+        return Bundle().apply {
+            putString("definition", component.definition)
+            component.name?.let { putString("name", it) }
+            putBundle("properties", mapToBundle(component.properties))
+            if (component.subComponents.isNotEmpty()) {
+                val subArray = component.subComponents.mapIndexed { i, sub ->
+                    componentToBundle(sub)
+                }.toTypedArray()
+                putParcelableArray("subComponents", subArray)
+            }
+        }
+    }
+
+    /** Recursively convert a Map to a Bundle */
+    private fun mapToBundle(map: Map<String, Any>): Bundle {
+        return Bundle().apply {
+            for ((key, value) in map) {
+                when (value) {
+                    is String -> putString(key, value)
+                    is Int -> putInt(key, value)
+                    is Long -> putLong(key, value)
+                    is Double -> putDouble(key, value)
+                    is Float -> putFloat(key, value)
+                    is Boolean -> putBoolean(key, value)
+                    is Map<*, *> -> {
+                        @Suppress("UNCHECKED_CAST")
+                        putBundle(key, mapToBundle(value as Map<String, Any>))
+                    }
+                    is List<*> -> {
+                        // Convert list to array of strings as a safe fallback
+                        putStringArray(key, value.map { it?.toString() ?: "" }.toTypedArray())
+                    }
+                    else -> putString(key, value.toString())
+                }
+            }
+        }
+    }
+}

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
@@ -28,35 +28,31 @@ class BridgeViewProvider(
     private val reactContext: ReactApplicationContext
 ) : AgentforceViewProvider {
 
-    /** Set of component definition strings this provider handles */
-    private var registeredTypes: MutableSet<String> = mutableSetOf()
+    /** Maps component definition strings to their React Native component names */
+    private var componentMap: MutableMap<String, String> = mutableMapOf()
 
-    /** The React Native component name to render for matching types */
-    private var reactComponentName: String = ""
-
-    /** Register component types and the React component to render them. */
-    fun register(componentTypes: List<String>, reactComponentName: String) {
-        this.registeredTypes = componentTypes.toMutableSet()
-        this.reactComponentName = reactComponentName
+    /** Register a 1:1 mapping of component types to React component names. */
+    fun register(componentMap: Map<String, String>) {
+        this.componentMap = componentMap.toMutableMap()
     }
 
     /** Clear all registrations */
     fun reset() {
-        registeredTypes.clear()
-        reactComponentName = ""
+        componentMap.clear()
     }
 
     val isRegistered: Boolean
-        get() = registeredTypes.isNotEmpty() && reactComponentName.isNotEmpty()
+        get() = componentMap.isNotEmpty()
 
     // MARK: - AgentforceViewProvider
 
     override fun canHandle(definition: String): Boolean {
-        return registeredTypes.contains(definition)
+        return componentMap.containsKey(definition)
     }
 
     @Composable
     override fun GetView(modifier: Modifier, view: AgentforceComponent) {
+        val moduleName = componentMap[view.definition] ?: return
         val props = componentToBundle(view)
         AndroidView(
             modifier = modifier,
@@ -64,13 +60,13 @@ class BridgeViewProvider(
                 ReactRootView(context).apply {
                     val reactApp = reactContext.applicationContext as? ReactApplication
                     val reactHost = reactApp?.reactHost
-                    // Start the React surface with the registered component name and props
+                    // Start the React surface with the per-type component name and props
                     startReactApplication(
                         reactHost?.currentReactContext?.catalystInstance?.let {
                             // For modern RN, get the instance manager from the host
                             (reactApp as? ReactApplication)?.reactNativeHost?.reactInstanceManager
                         },
-                        reactComponentName,
+                        moduleName,
                         props
                     )
                 }

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
@@ -94,4 +94,13 @@ RCT_EXTERN_METHOD(enableNavigationForwarding:(BOOL)enabled
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+// MARK: - View Provider
+
+RCT_EXTERN_METHOD(registerViewProvider:(NSDictionary *)config
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(clearViewProvider:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -760,14 +760,13 @@ class AgentforceModule: RCTEventEmitter {
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) {
         guard let dict = config as? [String: Any],
-              let types = dict["componentTypes"] as? [String],
-              let componentName = dict["reactComponentName"] as? String,
-              !types.isEmpty, !componentName.isEmpty else {
-            reject("INVALID_CONFIG", "Must provide componentTypes array and reactComponentName", nil)
+              let componentMap = dict["componentMap"] as? [String: String],
+              !componentMap.isEmpty else {
+            reject("INVALID_CONFIG", "Must provide a non-empty componentMap dictionary", nil)
             return
         }
-        bridgeViewProvider.register(componentTypes: types, reactComponentName: componentName)
-        resolve(["success": true, "registeredTypes": types])
+        bridgeViewProvider.register(componentMap: componentMap)
+        resolve(["success": true, "registeredTypes": Array(componentMap.keys)])
     }
 
     /// Clear the custom view provider registration.

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -556,14 +556,16 @@ class AgentforceModule: RCTEventEmitter {
         enableMultiAgent: "AgentforceFF_enableMultiAgent",
         enableMultiModalInput: "AgentforceFF_enableMultiModalInput",
         enablePDFUpload: "AgentforceFF_enablePDFUpload",
-        enableVoice: "AgentforceFF_enableVoice"
+        enableVoice: "AgentforceFF_enableVoice",
+        enableCustomViewProvider: "AgentforceFF_enableCustomViewProvider"
     )
-    
+
     private struct FeatureFlags {
         let enableMultiAgent: Bool
         let enableMultiModalInput: Bool
         let enablePDFUpload: Bool
         let enableVoice: Bool
+        let enableCustomViewProvider: Bool
     }
     
     private func getFeatureFlagsFromConfigOrUserDefaults(_ configDict: [String: Any]) -> FeatureFlags {
@@ -572,7 +574,8 @@ class AgentforceModule: RCTEventEmitter {
                 enableMultiAgent: (featureFlags["enableMultiAgent"] as? NSNumber)?.boolValue ?? true,
                 enableMultiModalInput: (featureFlags["enableMultiModalInput"] as? NSNumber)?.boolValue ?? false,
                 enablePDFUpload: (featureFlags["enablePDFUpload"] as? NSNumber)?.boolValue ?? false,
-                enableVoice: (featureFlags["enableVoice"] as? NSNumber)?.boolValue ?? false
+                enableVoice: (featureFlags["enableVoice"] as? NSNumber)?.boolValue ?? false,
+                enableCustomViewProvider: (featureFlags["enableCustomViewProvider"] as? NSNumber)?.boolValue ?? false
             )
         }
         let ud = UserDefaults.standard
@@ -580,7 +583,8 @@ class AgentforceModule: RCTEventEmitter {
             enableMultiAgent: ud.object(forKey: Self.featureFlagKeys.enableMultiAgent) == nil ? true : ud.bool(forKey: Self.featureFlagKeys.enableMultiAgent),
             enableMultiModalInput: ud.bool(forKey: Self.featureFlagKeys.enableMultiModalInput),
             enablePDFUpload: ud.bool(forKey: Self.featureFlagKeys.enablePDFUpload),
-            enableVoice: ud.object(forKey: Self.featureFlagKeys.enableVoice) == nil ? false : ud.bool(forKey: Self.featureFlagKeys.enableVoice)
+            enableVoice: ud.object(forKey: Self.featureFlagKeys.enableVoice) == nil ? false : ud.bool(forKey: Self.featureFlagKeys.enableVoice),
+            enableCustomViewProvider: ud.bool(forKey: Self.featureFlagKeys.enableCustomViewProvider)
         )
     }
     
@@ -589,6 +593,7 @@ class AgentforceModule: RCTEventEmitter {
         UserDefaults.standard.set(flags.enableMultiModalInput, forKey: Self.featureFlagKeys.enableMultiModalInput)
         UserDefaults.standard.set(flags.enablePDFUpload, forKey: Self.featureFlagKeys.enablePDFUpload)
         UserDefaults.standard.set(flags.enableVoice, forKey: Self.featureFlagKeys.enableVoice)
+        UserDefaults.standard.set(flags.enableCustomViewProvider, forKey: Self.featureFlagKeys.enableCustomViewProvider)
     }
     
     @objc
@@ -601,7 +606,8 @@ class AgentforceModule: RCTEventEmitter {
             "enableMultiAgent": ud.object(forKey: Self.featureFlagKeys.enableMultiAgent) == nil ? true : ud.bool(forKey: Self.featureFlagKeys.enableMultiAgent),
             "enableMultiModalInput": ud.object(forKey: Self.featureFlagKeys.enableMultiModalInput) == nil ? false : ud.bool(forKey: Self.featureFlagKeys.enableMultiModalInput),
             "enablePDFUpload": ud.object(forKey: Self.featureFlagKeys.enablePDFUpload) == nil ? false : ud.bool(forKey: Self.featureFlagKeys.enablePDFUpload),
-            "enableVoice": ud.object(forKey: Self.featureFlagKeys.enableVoice) == nil ? false : ud.bool(forKey: Self.featureFlagKeys.enableVoice)
+            "enableVoice": ud.object(forKey: Self.featureFlagKeys.enableVoice) == nil ? false : ud.bool(forKey: Self.featureFlagKeys.enableVoice),
+            "enableCustomViewProvider": ud.bool(forKey: Self.featureFlagKeys.enableCustomViewProvider)
         ]
         resolve(flags)
     }
@@ -620,11 +626,13 @@ class AgentforceModule: RCTEventEmitter {
         let enableMultiModalInput = (dict["enableMultiModalInput"] as? NSNumber)?.boolValue ?? false
         let enablePDFUpload = (dict["enablePDFUpload"] as? NSNumber)?.boolValue ?? false
         let enableVoice = (dict["enableVoice"] as? NSNumber)?.boolValue ?? false
+        let enableCustomViewProvider = (dict["enableCustomViewProvider"] as? NSNumber)?.boolValue ?? false
 
         UserDefaults.standard.set(enableMultiAgent, forKey: Self.featureFlagKeys.enableMultiAgent)
         UserDefaults.standard.set(enableMultiModalInput, forKey: Self.featureFlagKeys.enableMultiModalInput)
         UserDefaults.standard.set(enablePDFUpload, forKey: Self.featureFlagKeys.enablePDFUpload)
         UserDefaults.standard.set(enableVoice, forKey: Self.featureFlagKeys.enableVoice)
+        UserDefaults.standard.set(enableCustomViewProvider, forKey: Self.featureFlagKeys.enableCustomViewProvider)
 
         resolve(nil)
     }

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -60,6 +60,14 @@ class AgentforceModule: RCTEventEmitter {
         return BridgeNavigation(module: self)
     }()
 
+    // MARK: - View Provider
+
+    /// Bridge view provider for delegating native SDK views to React Native components.
+    /// Initialized lazily so the RCT bridge is available.
+    private lazy var bridgeViewProvider: BridgeViewProvider = {
+        return BridgeViewProvider(bridge: self.bridge)
+    }()
+
     // MARK: - Module Setup
 
     override static func requiresMainQueueSetup() -> Bool {
@@ -164,10 +172,11 @@ class AgentforceModule: RCTEventEmitter {
 
         agentforceClient = AgentforceClient(
             credentialProvider: credentialProvider,
-            mode: .fullConfig(fullConfiguration)
+            mode: .fullConfig(fullConfiguration),
+            viewProvider: bridgeViewProvider.isRegistered ? bridgeViewProvider : nil
         )
     }
-    
+
     // MARK: - Employee Agent Configuration
     
     private func configureEmployeeAgent(_ configDict: [String: Any]) async throws {
@@ -236,7 +245,8 @@ class AgentforceModule: RCTEventEmitter {
         // Initialize Agentforce Client with fullConfig mode (explicit config + feature flags).
         agentforceClient = AgentforceClient(
             credentialProvider: credentialProvider,
-            mode: .fullConfig(fullConfiguration)
+            mode: .fullConfig(fullConfiguration),
+            viewProvider: bridgeViewProvider.isRegistered ? bridgeViewProvider : nil
         )
     }
     
@@ -739,8 +749,39 @@ class AgentforceModule: RCTEventEmitter {
         sendEvent(withName: "onNavigationRequest", body: payload)
     }
 
+    // MARK: - View Provider
+
+    /// Register a React Native component as a custom view provider for specified types.
+    /// Must be called before configure() so the provider is attached at SDK init time.
+    @objc
+    func registerViewProvider(
+        _ config: NSDictionary,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        guard let dict = config as? [String: Any],
+              let types = dict["componentTypes"] as? [String],
+              let componentName = dict["reactComponentName"] as? String,
+              !types.isEmpty, !componentName.isEmpty else {
+            reject("INVALID_CONFIG", "Must provide componentTypes array and reactComponentName", nil)
+            return
+        }
+        bridgeViewProvider.register(componentTypes: types, reactComponentName: componentName)
+        resolve(["success": true, "registeredTypes": types])
+    }
+
+    /// Clear the custom view provider registration.
+    @objc
+    func clearViewProvider(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        bridgeViewProvider.reset()
+        resolve(["success": true])
+    }
+
     // MARK: - Cleanup
-    
+
     private func cleanupClient() {
         currentConversation = nil
         agentforceClient = nil
@@ -771,6 +812,7 @@ class AgentforceModule: RCTEventEmitter {
             cleanupClient()
             currentMode = nil
             credentialProvider.reset()
+            bridgeViewProvider.reset()
             ServiceAgentManager.shared.resetToDefaults()
             UserDefaults.standard.removeObject(forKey: "EmployeeAgentId")
             resolve(["success": true])

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Providers/BridgeViewProvider.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Providers/BridgeViewProvider.swift
@@ -68,17 +68,15 @@ class BridgeViewProvider: AgentforceViewProviding {
 // MARK: - SwiftUI wrapper for RCTRootView
 
 /// Wraps an RCTRootView in a UIViewRepresentable for use in SwiftUI.
+/// Uses RCTRootView's intrinsic content size so SwiftUI can lay it out correctly.
 private struct ReactNativeViewWrapper: UIViewRepresentable {
     let bridge: RCTBridge?
     let moduleName: String
     let initialProperties: [String: Any]
 
-    func makeUIView(context: Context) -> UIView {
+    func makeUIView(context: Context) -> RCTRootView {
         guard let bridge = bridge else {
-            let label = UILabel()
-            label.text = "Bridge unavailable"
-            label.textAlignment = .center
-            return label
+            return RCTRootView()
         }
         let rootView = RCTRootView(
             bridge: bridge,
@@ -86,10 +84,18 @@ private struct ReactNativeViewWrapper: UIViewRepresentable {
             initialProperties: initialProperties
         )
         rootView.backgroundColor = .clear
+        rootView.sizeFlexibility = .widthAndHeight
         return rootView
     }
 
-    func updateUIView(_ uiView: UIView, context: Context) {
+    func updateUIView(_ uiView: RCTRootView, context: Context) {
         // RCTRootView handles its own updates via the bridge
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: RCTRootView, context: Context) -> CGSize? {
+        let width = proposal.width ?? UIScreen.main.bounds.width
+        let size = uiView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
+        guard size.height > 0 else { return nil }
+        return CGSize(width: width, height: size.height)
     }
 }

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Providers/BridgeViewProvider.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Providers/BridgeViewProvider.swift
@@ -16,11 +16,9 @@ import AgentforceSDK
 /// Component types are registered synchronously from JS; rendering uses RCTRootView.
 class BridgeViewProvider: AgentforceViewProviding {
 
-    /// Set of component definition strings this provider handles (e.g. "copilot/richText")
-    private var registeredTypes: Set<String> = []
-
-    /// The React Native component name to render for matching types
-    private var reactComponentName: String = ""
+    /// Maps component definition strings to React Native component names (1:1).
+    /// e.g. ["copilot/richText": "CustomRichTextView", "copilot/markdown": "CustomMarkdownView"]
+    private var componentMap: [String: String] = [:]
 
     /// Reference to the RCT bridge for creating root views
     private weak var bridge: RCTBridge?
@@ -29,38 +27,39 @@ class BridgeViewProvider: AgentforceViewProviding {
         self.bridge = bridge
     }
 
-    /// Register component types and the React component to render them.
+    /// Register a 1:1 mapping of component definition strings to React component names.
     /// Called from JS via the native module before launching conversation.
-    func register(componentTypes: [String], reactComponentName: String) {
-        self.registeredTypes = Set(componentTypes)
-        self.reactComponentName = reactComponentName
+    func register(componentMap: [String: String]) {
+        self.componentMap = componentMap
     }
 
     /// Clear all registrations
     func reset() {
-        registeredTypes.removeAll()
-        reactComponentName = ""
+        componentMap.removeAll()
     }
 
     var isRegistered: Bool {
-        !registeredTypes.isEmpty && !reactComponentName.isEmpty
+        !componentMap.isEmpty
     }
 
     // MARK: - AgentforceViewProviding
 
     func canHandle(type: String) -> Bool {
-        registeredTypes.contains(type)
+        componentMap[type] != nil
     }
 
     @MainActor
     func view(for type: String, data: [String: Any]) -> AnyView {
+        guard let moduleName = componentMap[type] else {
+            return AnyView(EmptyView())
+        }
         let props: [String: Any] = [
             "definition": type,
             "properties": data,
         ]
         return AnyView(ReactNativeViewWrapper(
             bridge: bridge,
-            moduleName: reactComponentName,
+            moduleName: moduleName,
             initialProperties: props
         ))
     }

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Providers/BridgeViewProvider.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Providers/BridgeViewProvider.swift
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
+ *
+ * Bridges the native AgentforceViewProviding protocol to React Native.
+ * When enabled, delegates rendering of specified component types to a
+ * registered React Native component via RCTRootView.
+ */
+
+import Foundation
+import UIKit
+import SwiftUI
+import React
+import AgentforceSDK
+
+/// Implements AgentforceViewProviding by delegating to a React Native component.
+/// Component types are registered synchronously from JS; rendering uses RCTRootView.
+class BridgeViewProvider: AgentforceViewProviding {
+
+    /// Set of component definition strings this provider handles (e.g. "copilot/richText")
+    private var registeredTypes: Set<String> = []
+
+    /// The React Native component name to render for matching types
+    private var reactComponentName: String = ""
+
+    /// Reference to the RCT bridge for creating root views
+    private weak var bridge: RCTBridge?
+
+    init(bridge: RCTBridge?) {
+        self.bridge = bridge
+    }
+
+    /// Register component types and the React component to render them.
+    /// Called from JS via the native module before launching conversation.
+    func register(componentTypes: [String], reactComponentName: String) {
+        self.registeredTypes = Set(componentTypes)
+        self.reactComponentName = reactComponentName
+    }
+
+    /// Clear all registrations
+    func reset() {
+        registeredTypes.removeAll()
+        reactComponentName = ""
+    }
+
+    var isRegistered: Bool {
+        !registeredTypes.isEmpty && !reactComponentName.isEmpty
+    }
+
+    // MARK: - AgentforceViewProviding
+
+    func canHandle(type: String) -> Bool {
+        registeredTypes.contains(type)
+    }
+
+    @MainActor
+    func view(for type: String, data: [String: Any]) -> AnyView {
+        let props: [String: Any] = [
+            "definition": type,
+            "properties": data,
+        ]
+        return AnyView(ReactNativeViewWrapper(
+            bridge: bridge,
+            moduleName: reactComponentName,
+            initialProperties: props
+        ))
+    }
+}
+
+// MARK: - SwiftUI wrapper for RCTRootView
+
+/// Wraps an RCTRootView in a UIViewRepresentable for use in SwiftUI.
+private struct ReactNativeViewWrapper: UIViewRepresentable {
+    let bridge: RCTBridge?
+    let moduleName: String
+    let initialProperties: [String: Any]
+
+    func makeUIView(context: Context) -> UIView {
+        guard let bridge = bridge else {
+            let label = UILabel()
+            label.text = "Bridge unavailable"
+            label.textAlignment = .center
+            return label
+        }
+        let rootView = RCTRootView(
+            bridge: bridge,
+            moduleName: moduleName,
+            initialProperties: initialProperties
+        )
+        rootView.backgroundColor = .clear
+        return rootView
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        // RCTRootView handles its own updates via the bridge
+    }
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/index.ts
@@ -17,7 +17,7 @@ export {
 } from './services/EmployeeAgentAuth';
 export type { AuthCredentials } from './services/EmployeeAgentAuth';
 
-export type { ServiceAgentConfig, EmployeeAgentConfig, AgentConfig, FeatureFlags, LegacyServiceAgentConfig, ConfigurationResult, ConfigurationInfo, LoggerDelegate, LogLevel, NavigationDelegate, NavigationRequest } from './types';
+export type { ServiceAgentConfig, EmployeeAgentConfig, AgentConfig, FeatureFlags, LegacyServiceAgentConfig, ConfigurationResult, ConfigurationInfo, LoggerDelegate, LogLevel, NavigationDelegate, NavigationRequest, ViewProviderDelegate, ViewProviderComponentData } from './types';
 export { isServiceAgentConfig, isEmployeeAgentConfig, isLegacyConfig } from './types';
 
 export {

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -27,6 +27,7 @@ import {
 
 import { LoggerDelegate, LogLevel } from '../types/LoggerDelegate';
 import { NavigationDelegate, NavigationRequest } from '../types/NavigationDelegate';
+import { ViewProviderDelegate, ViewProviderComponentData } from '../types/ViewProviderDelegate';
 
 const { AgentforceModule } = NativeModules;
 
@@ -34,6 +35,7 @@ const { AgentforceModule } = NativeModules;
 export type { ServiceAgentConfig, EmployeeAgentConfig, AgentConfig, FeatureFlags };
 export type { LoggerDelegate, LogLevel };
 export type { NavigationDelegate, NavigationRequest };
+export type { ViewProviderDelegate, ViewProviderComponentData };
 
 /**
  * Native module event names
@@ -98,6 +100,11 @@ class AgentforceService {
    * Subscription for navigation request events
    */
   private navigationSubscription: EmitterSubscription | null = null;
+
+  /**
+   * View provider delegate configuration (registered component types + React component name)
+   */
+  private viewProviderDelegate: ViewProviderDelegate | null = null;
 
   /**
    * Track if service has been initialized
@@ -234,6 +241,64 @@ class AgentforceService {
         this.navigationDelegate?.onNavigate(event);
       },
     );
+  }
+
+  /**
+   * Register a view provider delegate to override native SDK output views
+   * with custom React Native components.
+   *
+   * Must be called before `configure()` so the native provider is attached
+   * at SDK initialization time.
+   *
+   * @param delegate - View provider delegate configuration
+   *
+   * @example
+   * ```typescript
+   * AgentforceService.setViewProviderDelegate({
+   *   componentTypes: ['copilot/richText', 'copilot/markdown'],
+   *   reactComponentName: 'CustomAgentforceView',
+   * });
+   * ```
+   */
+  async setViewProviderDelegate(delegate: ViewProviderDelegate): Promise<void> {
+    this.viewProviderDelegate = delegate;
+
+    if (!AgentforceModule?.registerViewProvider) {
+      console.warn('[AgentforceService] registerViewProvider not available on native module');
+      return;
+    }
+
+    try {
+      await AgentforceModule.registerViewProvider({
+        componentTypes: delegate.componentTypes,
+        reactComponentName: delegate.reactComponentName,
+      });
+      console.log(
+        `[AgentforceService] View provider registered for ${delegate.componentTypes.length} types`,
+      );
+    } catch (error) {
+      console.error('[AgentforceService] Failed to register view provider:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Clear the registered view provider delegate.
+   * After clearing, the native SDK will render its built-in views for all types.
+   */
+  async clearViewProviderDelegate(): Promise<void> {
+    this.viewProviderDelegate = null;
+
+    if (!AgentforceModule?.clearViewProvider) {
+      return;
+    }
+
+    try {
+      await AgentforceModule.clearViewProvider();
+      console.log('[AgentforceService] View provider delegate cleared');
+    } catch (error) {
+      console.warn('[AgentforceService] Failed to clear view provider:', error);
+    }
   }
 
   /**
@@ -713,6 +778,8 @@ class AgentforceService {
     this.navigationSubscription?.remove();
     this.navigationSubscription = null;
     this.navigationDelegate = null;
+
+    this.viewProviderDelegate = null;
 
     this.eventEmitter = null;
     this.initialized = false;

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -341,6 +341,7 @@ class AgentforceService {
         enableMultiModalInput: false,
         enablePDFUpload: false,
         enableVoice: false,
+        enableCustomViewProvider: false,
       };
     }
     if (!AgentforceModule?.getFeatureFlags) {
@@ -349,6 +350,7 @@ class AgentforceService {
         enableMultiModalInput: false,
         enablePDFUpload: false,
         enableVoice: false,
+        enableCustomViewProvider: false,
       };
     }
     try {
@@ -358,6 +360,7 @@ class AgentforceService {
         enableMultiModalInput: flags?.enableMultiModalInput ?? false,
         enablePDFUpload: flags?.enablePDFUpload ?? false,
         enableVoice: flags?.enableVoice ?? false,
+        enableCustomViewProvider: flags?.enableCustomViewProvider ?? false,
       };
     } catch {
       return {
@@ -365,6 +368,7 @@ class AgentforceService {
         enableMultiModalInput: false,
         enablePDFUpload: false,
         enableVoice: false,
+        enableCustomViewProvider: false,
       };
     }
   }

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -255,8 +255,10 @@ class AgentforceService {
    * @example
    * ```typescript
    * AgentforceService.setViewProviderDelegate({
-   *   componentTypes: ['copilot/richText', 'copilot/markdown'],
-   *   reactComponentName: 'CustomAgentforceView',
+   *   componentMap: {
+   *     'copilot/richText': 'CustomRichTextView',
+   *     'copilot/markdown': 'CustomMarkdownView',
+   *   },
    * });
    * ```
    */
@@ -270,11 +272,10 @@ class AgentforceService {
 
     try {
       await AgentforceModule.registerViewProvider({
-        componentTypes: delegate.componentTypes,
-        reactComponentName: delegate.reactComponentName,
+        componentMap: delegate.componentMap,
       });
       console.log(
-        `[AgentforceService] View provider registered for ${delegate.componentTypes.length} types`,
+        `[AgentforceService] View provider registered for ${Object.keys(delegate.componentMap).length} types`,
       );
     } catch (error) {
       console.error('[AgentforceService] Failed to register view provider:', error);

--- a/AgentforceSDK-ReactNative-Bridge/src/types/AgentConfig.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/AgentConfig.ts
@@ -13,6 +13,7 @@ export interface FeatureFlags {
   enableMultiModalInput: boolean;
   enablePDFUpload: boolean;
   enableVoice: boolean;
+  enableCustomViewProvider: boolean;
 }
 
 /**

--- a/AgentforceSDK-ReactNative-Bridge/src/types/ViewProviderDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/ViewProviderDelegate.ts
@@ -5,14 +5,19 @@
  * When enabled, the native SDK checks the registered component types before rendering
  * its built-in views. If a match is found, a React Native root view is rendered instead.
  *
+ * Each component type maps 1:1 to a React Native component name, so different
+ * SDK view types can be rendered by different React components.
+ *
  * Known component definition strings follow the pattern "copilot/<type>" or "agentforce/<type>".
  * Examples: 'copilot/richText', 'copilot/markdown', 'copilot/recordInfo', 'copilot/list'.
  *
  * @example
  * ```typescript
  * AgentforceService.setViewProviderDelegate({
- *   componentTypes: ['copilot/richText', 'copilot/markdown'],
- *   reactComponentName: 'CustomAgentforceView',
+ *   componentMap: {
+ *     'copilot/richText': 'CustomRichTextView',
+ *     'copilot/markdown': 'CustomMarkdownView',
+ *   },
  * });
  * ```
  */
@@ -35,24 +40,26 @@ export interface ViewProviderComponentData {
  * Configuration for the View Provider delegate.
  *
  * Register this to tell the native SDK which component types your React Native
- * view can handle. When the SDK encounters a matching type, it renders your
- * registered React component instead of the built-in native view.
+ * views can handle. Each key is a component definition string, and the value
+ * is the registered React Native component name to render for that type.
+ *
+ * Register each component with `AppRegistry.registerComponent()`.
  */
 export interface ViewProviderDelegate {
   /**
-   * List of component definition strings this provider handles.
-   * The native `canHandle()` method checks against this list synchronously.
+   * Maps component definition strings to React Native component names.
+   * The native `canHandle()` method checks against the keys synchronously.
+   * The `view()` / `GetView()` method looks up the component name for the
+   * matching key and renders it via RCTRootView / ReactRootView.
    *
-   * @example ['copilot/richText', 'copilot/markdown', 'copilot/recordInfo']
+   * @example
+   * ```typescript
+   * {
+   *   'copilot/richText': 'CustomRichTextView',
+   *   'copilot/markdown': 'CustomMarkdownView',
+   *   'copilot/recordInfo': 'CustomRecordInfoView',
+   * }
+   * ```
    */
-  componentTypes: string[];
-
-  /**
-   * The registered React Native component name that will be rendered
-   * for matching types. This component receives `ViewProviderComponentData`
-   * as its props via the native root view.
-   *
-   * Register the component with `AppRegistry.registerComponent()`.
-   */
-  reactComponentName: string;
+  componentMap: Record<string, string>;
 }

--- a/AgentforceSDK-ReactNative-Bridge/src/types/ViewProviderDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/ViewProviderDelegate.ts
@@ -1,0 +1,58 @@
+/**
+ * View Provider delegate types for Agentforce SDK
+ *
+ * Allows JS to override native SDK output views with custom React Native components.
+ * When enabled, the native SDK checks the registered component types before rendering
+ * its built-in views. If a match is found, a React Native root view is rendered instead.
+ *
+ * Known component definition strings follow the pattern "copilot/<type>" or "agentforce/<type>".
+ * Examples: 'copilot/richText', 'copilot/markdown', 'copilot/recordInfo', 'copilot/list'.
+ *
+ * @example
+ * ```typescript
+ * AgentforceService.setViewProviderDelegate({
+ *   componentTypes: ['copilot/richText', 'copilot/markdown'],
+ *   reactComponentName: 'CustomAgentforceView',
+ * });
+ * ```
+ */
+
+/**
+ * Data passed from the native SDK to the React Native view for rendering.
+ */
+export interface ViewProviderComponentData {
+  /** The component definition string (e.g. 'copilot/richText') */
+  definition: string;
+  /** Component name from the SDK (may be null) */
+  name?: string;
+  /** Key-value properties for the component */
+  properties: Record<string, unknown>;
+  /** Nested sub-components, if any */
+  subComponents?: ViewProviderComponentData[];
+}
+
+/**
+ * Configuration for the View Provider delegate.
+ *
+ * Register this to tell the native SDK which component types your React Native
+ * view can handle. When the SDK encounters a matching type, it renders your
+ * registered React component instead of the built-in native view.
+ */
+export interface ViewProviderDelegate {
+  /**
+   * List of component definition strings this provider handles.
+   * The native `canHandle()` method checks against this list synchronously.
+   *
+   * @example ['copilot/richText', 'copilot/markdown', 'copilot/recordInfo']
+   */
+  componentTypes: string[];
+
+  /**
+   * The registered React Native component name that will be rendered
+   * for matching types. This component receives `ViewProviderComponentData`
+   * as its props via the native root view.
+   *
+   * Register the component with `AppRegistry.registerComponent()`.
+   */
+  reactComponentName: string;
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
@@ -23,3 +23,6 @@ export { LoggerDelegate, LogLevel } from './LoggerDelegate';
 
 // Navigation delegate types
 export { NavigationDelegate, NavigationRequest } from './NavigationDelegate';
+
+// View provider delegate types
+export { ViewProviderDelegate, ViewProviderComponentData } from './ViewProviderDelegate';

--- a/index.js
+++ b/index.js
@@ -27,5 +27,9 @@
 import 'react-native-gesture-handler';
 import { AppRegistry } from 'react-native';
 import App from './App';
+import CustomAgentforceView from './src/components/CustomAgentforceView';
 
 AppRegistry.registerComponent('ReactAgentforce', () => App);
+
+// Register the custom view provider component so native can render it via RCTRootView/ReactRootView
+AppRegistry.registerComponent('CustomAgentforceView', () => CustomAgentforceView);

--- a/src/components/CustomAgentforceView.tsx
+++ b/src/components/CustomAgentforceView.tsx
@@ -30,27 +30,167 @@ interface CustomAgentforceViewProps {
   subComponents?: ViewProviderComponentData[];
 }
 
+/** Max nesting depth to prevent runaway recursion. */
+const MAX_DEPTH = 6;
+
+/** Check whether a value is a plain object (not an array). */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/** Format a leaf value as a string. */
+function formatLeaf(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  return String(value);
+}
+
+/** Whether a value will render as a nested block (table or array). */
+function isNestedValue(v: unknown, depth: number): boolean {
+  if (depth >= MAX_DEPTH) return false;
+  if (isPlainObject(v)) return Object.keys(v).length > 0;
+  if (Array.isArray(v)) return v.length > 0;
+  return false;
+}
+
+/**
+ * Recursively renders a value. Plain objects become nested key/value tables,
+ * arrays render each element, and primitives render as text.
+ */
+const ValueRenderer: React.FC<{ value: unknown; depth: number }> = ({
+  value,
+  depth,
+}) => {
+  const compact = depth >= 3; // tighter padding at deeper levels
+
+  if (isPlainObject(value) && depth < MAX_DEPTH) {
+    const entries = Object.entries(value);
+    if (entries.length === 0) return <Text style={styles.emptyText}>{'{ }'}</Text>;
+    return (
+      <View style={[styles.nestedTable, compact && styles.nestedTableCompact]}>
+        {entries.map(([k, v], i) => (
+          <PropertyRow key={k} label={k} value={v} depth={depth} isLast={i === entries.length - 1} />
+        ))}
+      </View>
+    );
+  }
+
+  if (Array.isArray(value) && depth < MAX_DEPTH) {
+    if (value.length === 0) return <Text style={styles.emptyText}>{'[ ]'}</Text>;
+    return (
+      <View style={[styles.nestedArray, compact && styles.nestedTableCompact]}>
+        {value.map((item, i) => {
+          const itemNested = isNestedValue(item, depth + 1);
+          return (
+            <View
+              key={i}
+              style={[
+                itemNested ? styles.arrayItemVertical : styles.arrayItem,
+                i < value.length - 1 && styles.arrayItemBorder,
+              ]}
+            >
+              <Text style={styles.arrayIndex}>{i}</Text>
+              <View style={itemNested ? undefined : styles.arrayValue}>
+                <ValueRenderer value={item} depth={depth + 1} />
+              </View>
+            </View>
+          );
+        })}
+      </View>
+    );
+  }
+
+  // Leaf value (or max depth reached — fall back to JSON)
+  const text =
+    depth >= MAX_DEPTH && typeof value === 'object'
+      ? JSON.stringify(value)
+      : formatLeaf(value);
+
+  return (
+    <Text style={styles.rowValue} selectable>
+      {text}
+    </Text>
+  );
+};
+
+/**
+ * Renders a single key/value row, stacking vertically when the value is a
+ * nested object/array so it can use the full width.
+ */
+const PropertyRow: React.FC<{
+  label: string;
+  value: unknown;
+  depth: number;
+  isLast: boolean;
+}> = ({ label, value, depth, isLast }) => {
+  const nested = isNestedValue(value, depth + 1);
+  const compact = depth >= 2;
+
+  return (
+    <View
+      style={[
+        nested ? styles.rowVertical : styles.row,
+        compact && styles.rowCompact,
+        !isLast && styles.rowBorder,
+      ]}
+    >
+      <Text
+        style={[styles.rowKey, compact && styles.rowKeyCompact]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+      <ValueRenderer value={value} depth={depth + 1} />
+    </View>
+  );
+};
+
 const CustomAgentforceView: React.FC<CustomAgentforceViewProps> = ({
   definition = 'unknown',
   properties = {},
 }) => {
-  // Extract text content from common property patterns
-  const textContent =
-    (properties.text as string) ??
-    (properties.value as string) ??
-    (properties.content as string) ??
-    (properties.label as string) ??
-    JSON.stringify(properties, null, 2);
+  const entries = Object.entries(properties);
+
+  // If the only meaningful property is a single text-like value, show it inline
+  const textKeys = ['text', 'value', 'content', 'label'];
+  const singleText =
+    entries.length === 1 &&
+    textKeys.includes(entries[0][0]) &&
+    typeof entries[0][1] === 'string'
+      ? (entries[0][1] as string)
+      : null;
 
   return (
     <View style={styles.container}>
-      <View style={styles.badge}>
-        <Text style={styles.badgeText}>Custom RN View</Text>
+      <View style={styles.header}>
+        <View style={styles.badge}>
+          <Text style={styles.badgeText}>Custom RN View</Text>
+        </View>
+        <Text style={styles.definitionText}>{definition}</Text>
       </View>
-      <Text style={styles.definitionText}>{definition}</Text>
-      <ScrollView style={styles.contentScroll} nestedScrollEnabled>
-        <Text style={styles.contentText}>{textContent}</Text>
-      </ScrollView>
+
+      {singleText ? (
+        <Text style={styles.contentText} selectable>
+          {singleText}
+        </Text>
+      ) : entries.length > 0 ? (
+        <ScrollView style={styles.contentScroll} nestedScrollEnabled>
+          <View style={styles.table}>
+            {entries.map(([key, val], idx) => (
+              <PropertyRow
+                key={key}
+                label={key}
+                value={val}
+                depth={0}
+                isLast={idx === entries.length - 1}
+              />
+            ))}
+          </View>
+        </ScrollView>
+      ) : (
+        <Text style={styles.emptyText}>No properties</Text>
+      )}
     </View>
   );
 };
@@ -64,13 +204,17 @@ const styles = StyleSheet.create({
     padding: 12,
     margin: 4,
   },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+    gap: 8,
+  },
   badge: {
     backgroundColor: '#4a90d9',
     borderRadius: 4,
     paddingHorizontal: 8,
     paddingVertical: 2,
-    alignSelf: 'flex-start',
-    marginBottom: 6,
   },
   badgeText: {
     color: '#ffffff',
@@ -80,16 +224,105 @@ const styles = StyleSheet.create({
   definitionText: {
     fontSize: 11,
     color: '#6c757d',
-    marginBottom: 4,
     fontFamily: 'monospace',
   },
   contentScroll: {
-    maxHeight: 200,
+    maxHeight: 400,
+  },
+  table: {
+    backgroundColor: '#ffffff',
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#d0d7e2',
+    overflow: 'hidden',
+  },
+  row: {
+    flexDirection: 'row',
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+  },
+  rowVertical: {
+    flexDirection: 'column',
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    gap: 4,
+  },
+  rowCompact: {
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+  },
+  rowBorder: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#d0d7e2',
+  },
+  rowKey: {
+    width: 100,
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#4a5568',
+    marginRight: 8,
+  },
+  rowKeyCompact: {
+    width: 80,
+    fontSize: 11,
+  },
+  rowValue: {
+    flex: 1,
+    fontSize: 13,
+    color: '#212529',
+    lineHeight: 18,
+  },
+  nestedTable: {
+    backgroundColor: '#f8f9fb',
+    borderRadius: 4,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#d0d7e2',
+    overflow: 'hidden',
+  },
+  nestedTableCompact: {
+    borderRadius: 3,
+  },
+  nestedArray: {
+    backgroundColor: '#f8f9fb',
+    borderRadius: 4,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#d0d7e2',
+    overflow: 'hidden',
+  },
+  arrayItem: {
+    flexDirection: 'row',
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+  },
+  arrayItemVertical: {
+    flexDirection: 'column',
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    gap: 4,
+  },
+  arrayItemBorder: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#d0d7e2',
+  },
+  arrayIndex: {
+    width: 24,
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#9ca3af',
+    marginRight: 4,
+  },
+  arrayValue: {
+    flex: 1,
   },
   contentText: {
     fontSize: 14,
     color: '#212529',
     lineHeight: 20,
+  },
+  emptyText: {
+    fontSize: 12,
+    color: '#9ca3af',
+    fontStyle: 'italic',
   },
 });
 

--- a/src/components/CustomAgentforceView.tsx
+++ b/src/components/CustomAgentforceView.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
+ *
+ * Example custom view provider component for Agentforce SDK.
+ *
+ * When the Custom View Provider feature flag is enabled and this component
+ * is registered, the native SDK delegates rendering of specified component
+ * types to this React Native view instead of the built-in native views.
+ *
+ * Register with AppRegistry and configure via AgentforceService:
+ *   AppRegistry.registerComponent('CustomAgentforceView', () => CustomAgentforceView);
+ *   AgentforceService.setViewProviderDelegate({
+ *     componentTypes: ['copilot/richText', 'copilot/markdown'],
+ *     reactComponentName: 'CustomAgentforceView',
+ *   });
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import type { ViewProviderComponentData } from 'react-native-agentforce';
+
+/**
+ * Props passed from the native BridgeViewProvider via RCTRootView / ReactRootView.
+ * Matches the ViewProviderComponentData type.
+ */
+interface CustomAgentforceViewProps {
+  definition?: string;
+  name?: string;
+  properties?: Record<string, unknown>;
+  subComponents?: ViewProviderComponentData[];
+}
+
+const CustomAgentforceView: React.FC<CustomAgentforceViewProps> = ({
+  definition = 'unknown',
+  properties = {},
+}) => {
+  // Extract text content from common property patterns
+  const textContent =
+    (properties.text as string) ??
+    (properties.value as string) ??
+    (properties.content as string) ??
+    (properties.label as string) ??
+    JSON.stringify(properties, null, 2);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.badge}>
+        <Text style={styles.badgeText}>Custom RN View</Text>
+      </View>
+      <Text style={styles.definitionText}>{definition}</Text>
+      <ScrollView style={styles.contentScroll} nestedScrollEnabled>
+        <Text style={styles.contentText}>{textContent}</Text>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#f0f4ff',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#4a90d9',
+    padding: 12,
+    margin: 4,
+  },
+  badge: {
+    backgroundColor: '#4a90d9',
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    alignSelf: 'flex-start',
+    marginBottom: 6,
+  },
+  badgeText: {
+    color: '#ffffff',
+    fontSize: 10,
+    fontWeight: '700',
+  },
+  definitionText: {
+    fontSize: 11,
+    color: '#6c757d',
+    marginBottom: 4,
+    fontFamily: 'monospace',
+  },
+  contentScroll: {
+    maxHeight: 200,
+  },
+  contentText: {
+    fontSize: 14,
+    color: '#212529',
+    lineHeight: 20,
+  },
+});
+
+export default CustomAgentforceView;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -119,8 +119,10 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
       const flags = await AgentforceService.getFeatureFlags();
       if (flags.enableCustomViewProvider) {
         await AgentforceService.setViewProviderDelegate({
-          componentTypes: ['copilot/richText', 'copilot/markdown'],
-          reactComponentName: 'CustomAgentforceView',
+          componentMap: {
+            'copilot/richText': 'CustomAgentforceView',
+            'copilot/markdown': 'CustomAgentforceView',
+          },
         });
       }
     } catch (error) {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -96,11 +96,14 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
     AgentforceService.setLoggerDelegate(agentforceLogger);
     // Register navigation delegate so SDK navigation requests are forwarded to JS
     AgentforceService.setNavigationDelegate(agentforceNavigation);
+    // Register custom view provider if enabled via feature flag
+    registerViewProviderIfEnabled();
     checkConfigurations();
 
     return () => {
       AgentforceService.clearLoggerDelegate();
       AgentforceService.clearNavigationDelegate();
+      AgentforceService.clearViewProviderDelegate();
     };
   }, []);
 
@@ -110,6 +113,20 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
     });
     return unsubscribe;
   }, [navigation]);
+
+  const registerViewProviderIfEnabled = async () => {
+    try {
+      const flags = await AgentforceService.getFeatureFlags();
+      if (flags.enableCustomViewProvider) {
+        await AgentforceService.setViewProviderDelegate({
+          componentTypes: ['copilot/richText', 'copilot/markdown'],
+          reactComponentName: 'CustomAgentforceView',
+        });
+      }
+    } catch (error) {
+      console.warn('Failed to register view provider:', error);
+    }
+  };
 
   const checkConfigurations = async () => {
     setIsChecking(true);

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -55,6 +55,7 @@ const FLAG_KEYS: (keyof FeatureFlags)[] = [
   'enableMultiModalInput',
   'enablePDFUpload',
   'enableVoice',
+  'enableCustomViewProvider',
 ];
 
 const FLAG_LABELS: Record<keyof FeatureFlags, string> = {
@@ -62,6 +63,7 @@ const FLAG_LABELS: Record<keyof FeatureFlags, string> = {
   enableMultiModalInput: 'Multi-modal input',
   enablePDFUpload: 'PDF upload',
   enableVoice: 'Voice',
+  enableCustomViewProvider: 'Custom View Provider',
 };
 
 const FLAG_HINTS: Record<keyof FeatureFlags, string> = {
@@ -69,6 +71,7 @@ const FLAG_HINTS: Record<keyof FeatureFlags, string> = {
   enableMultiModalInput: 'Enable image/file input in addition to text',
   enablePDFUpload: 'Allow PDF file uploads',
   enableVoice: 'Enable immersive voice',
+  enableCustomViewProvider: 'Override SDK output views with React Native components',
 };
 
 interface SettingsScreenProps {
@@ -289,6 +292,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         enableMultiModalInput: false,
         enablePDFUpload: false,
         enableVoice: false,
+        enableCustomViewProvider: false,
       });
     }
   };


### PR DESCRIPTION
## Summary
- Creates `CustomAgentforceView` React Native component that renders in place of native SDK views
- Registers it via `AppRegistry.registerComponent()` in `index.js`
- HomeScreen checks `enableCustomViewProvider` feature flag on mount
- When enabled, registers the delegate for `copilot/richText` and `copilot/markdown` types
- Cleans up on unmount via `clearViewProviderDelegate()`

## Stack
PR 6/6 (final) in the `viewprovider` stack. Depends on PRs #30-#34.

## Test plan
- [ ] With "Custom View Provider" flag OFF: conversation renders native SDK views (no change)
- [ ] With flag ON: `copilot/richText` and `copilot/markdown` components render as React Native views with blue "Custom RN View" badge
- [ ] Custom view receives `definition` and `properties` props from native
- [ ] Toggling the flag and relaunching conversation switches between native and custom views

## How to test end-to-end
1. Launch the app
2. Go to Settings > Flags > enable "Custom View Provider"
3. Configure and launch a conversation
4. Agent responses containing rich text or markdown should render with the blue "Custom RN View" badge