### PR TITLE
Add Android BridgeViewProvider for React Native view overrides

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -21,8 +21,6 @@ import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceConfigur
 import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceMode
 import com.salesforce.android.agentforcesdkimpl.configuration.ServiceAgentConfiguration
 import com.salesforce.android.agentforcesdkimpl.utils.AgentforceFeatureFlagSettings
-import com.salesforce.android.agentforceservice.conversationservice.data.CopilotAdditionalContext
-import com.salesforce.android.agentforceservice.conversationservice.data.CopilotContextVariable
 import com.salesforce.android.reactagentforce.models.AgentMode as LocalAgentMode
 import com.salesforce.android.reactagentforce.models.EmployeeAgentModeConfig
 import com.salesforce.android.reactagentforce.models.ServiceAgentModeConfig
@@ -79,7 +77,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     override fun getName(): String = MODULE_NAME
 
     // region Unified Configuration Method
-
+    
     /**
      * Configure the SDK with either Service or Employee agent settings.
      * Expects a map with 'type' field set to 'service' or 'employee'.
@@ -109,6 +107,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             else -> promise.reject("INVALID_CONFIG", "Invalid type '$type'. Must be 'service' or 'employee'")
         }
     }
+
     // endregion
 
     // region Service Agent Configuration
@@ -121,16 +120,13 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         }
         
         Log.d(TAG, "Configuring Service Agent - Org: ${serviceConfig.organizationId}")
-
-        // Only cleanup if switching from Employee mode
-        if (currentMode is LocalAgentMode.Employee) {
-            Log.d(TAG, "⚠️ Switching from Employee to Service mode - cleaning up")
-            AgentforceClientHolder.clear()
-        }
-
+        
         // Configure unified credential provider
         credentialProvider.configure(serviceConfig)
         currentMode = LocalAgentMode.Service(serviceConfig)
+        
+        // Clear existing client
+        AgentforceClientHolder.clear()
         
         // Also update the legacy ViewModel for backward compatibility
         ensureViewModel()
@@ -174,6 +170,8 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                 permissions?.let { agentforceConfigBuilder.setPermission(it) }
                 if (bridgeViewProvider.isRegistered) {
                     agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
+                } else {
+                    Log.w(TAG, "No view provider registered at configure() time. Call registerViewProvider() before configure() if you want custom views.")
                 }
                 val agentforceConfig = agentforceConfigBuilder.build()
 
@@ -202,6 +200,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             }
         }
     }
+
     // endregion
 
     // region Employee Agent Configuration
@@ -215,19 +214,16 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         
         Log.d(TAG, "Configuring Employee Agent - Org: ${employeeConfig.organizationId}, User: ${employeeConfig.userId}")
 
-        // Only cleanup if switching from Service mode
-        if (currentMode is LocalAgentMode.Service) {
-            Log.d(TAG, "⚠️ Switching from Service to Employee mode - cleaning up")
-            AgentforceClientHolder.clear()
-        }
-
         // Configure unified credential provider for Employee Agent mode
         // UnifiedCredentialProvider will fetch fresh tokens from Mobile SDK automatically
         credentialProvider.configure(employeeConfig)
         currentMode = LocalAgentMode.Employee(employeeConfig)
-
+        
         // Persist employee agentId (editable in Settings tab)
         employeePrefs.edit().putString(KEY_EMPLOYEE_AGENT_ID, employeeConfig.agentId ?: "").apply()
+        
+        // Clear existing client
+        AgentforceClientHolder.clear()
         
         scope.launch {
             try {
@@ -255,6 +251,8 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                 permissions?.let { agentforceConfigBuilder.setPermission(it) }
                 if (bridgeViewProvider.isRegistered) {
                     agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
+                } else {
+                    Log.w(TAG, "No view provider registered at configure() time. Call registerViewProvider() before configure() if you want custom views.")
                 }
                 val agentforceConfig = agentforceConfigBuilder.build()
 
@@ -283,6 +281,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             }
         }
     }
+
     // endregion
 
     // region Legacy Configuration (Backward Compatibility)
@@ -301,9 +300,10 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             putString("organizationId", organizationId)
             putString("esDeveloperName", esDeveloperName)
         }
-
+        
         configureServiceAgent(config, promise)
     }
+
     // endregion
 
     // region Conversation Methods
@@ -389,6 +389,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             putBoolean("success", true)
         })
     }
+
     // endregion
 
     // region Configuration Query Methods
@@ -438,17 +439,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun setEmployeeAgentId(agentId: String, promise: Promise) {
-        val oldAgentId = employeePrefs.getString(KEY_EMPLOYEE_AGENT_ID, "") ?: ""
-        val newAgentId = agentId.trim()
-
-        employeePrefs.edit().putString(KEY_EMPLOYEE_AGENT_ID, newAgentId).apply()
-
-        // Clear conversation if agent ID changed
-        if (oldAgentId != newAgentId) {
-            Log.d(TAG, "⚠️ Agent ID changed ('$oldAgentId' → '$newAgentId') - clearing conversation")
-            AgentforceClientHolder.clear()
-        }
-
+        employeePrefs.edit().putString(KEY_EMPLOYEE_AGENT_ID, agentId ?: "").apply()
         promise.resolve(null)
     }
 
@@ -499,21 +490,12 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun setFeatureFlags(flags: ReadableMap, promise: Promise) {
-        // Get new flags
-        val newMultiAgent = flags.hasKey("enableMultiAgent") && flags.getBoolean("enableMultiAgent")
-        val newMultiModal = flags.hasKey("enableMultiModalInput") && flags.getBoolean("enableMultiModalInput")
-        val newPDF = flags.hasKey("enablePDFUpload") && flags.getBoolean("enablePDFUpload")
-        val newVoice = flags.hasKey("enableVoice") && flags.getBoolean("enableVoice")
-
-        // Save new flags (will take effect on next app restart / new conversation)
         featureFlagsPrefs.edit()
-            .putBoolean(KEY_ENABLE_MULTI_AGENT, newMultiAgent)
-            .putBoolean(KEY_ENABLE_MULTI_MODAL_INPUT, newMultiModal)
-            .putBoolean(KEY_ENABLE_PDF_UPLOAD, newPDF)
-            .putBoolean(KEY_ENABLE_VOICE, newVoice)
+            .putBoolean(KEY_ENABLE_MULTI_AGENT, flags.hasKey("enableMultiAgent") && flags.getBoolean("enableMultiAgent"))
+            .putBoolean(KEY_ENABLE_MULTI_MODAL_INPUT, flags.hasKey("enableMultiModalInput") && flags.getBoolean("enableMultiModalInput"))
+            .putBoolean(KEY_ENABLE_PDF_UPLOAD, flags.hasKey("enablePDFUpload") && flags.getBoolean("enablePDFUpload"))
+            .putBoolean(KEY_ENABLE_VOICE, flags.hasKey("enableVoice") && flags.getBoolean("enableVoice"))
             .apply()
-
-        Log.d(TAG, "Feature flags saved (will apply on app restart)")
         promise.resolve(null)
     }
 
@@ -543,6 +525,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     fun isInitialized(promise: Promise) {
         promise.resolve(AgentforceClientHolder.isConfigured)
     }
+
     // endregion
 
     // region Log Forwarding
@@ -553,6 +536,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         Log.d(TAG, "Log forwarding ${if (enabled) "enabled" else "disabled"}")
         promise.resolve(true)
     }
+
     // endregion
 
     // region Navigation Forwarding
@@ -563,9 +547,10 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         Log.d(TAG, "Navigation forwarding ${if (enabled) "enabled" else "disabled"}")
         promise.resolve(true)
     }
+
     // endregion
 
-    // MARK: - View Provider
+    // region View Provider
 
     @ReactMethod
     fun registerViewProvider(config: ReadableMap, promise: Promise) {
@@ -588,10 +573,16 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             return
         }
 
+        if (AgentforceClientHolder.isConfigured) {
+            Log.w(TAG, "registerViewProvider called after configure(). The view provider will not take effect until the next configure() call.")
+        }
         bridgeViewProvider.register(componentMap)
+        val keysArray = Arguments.createArray().apply {
+            componentMap.keys.forEach { pushString(it) }
+        }
         promise.resolve(Arguments.createMap().apply {
             putBoolean("success", true)
-            putInt("registeredCount", componentMap.size)
+            putArray("registeredTypes", keysArray)
         })
     }
 
@@ -603,7 +594,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         })
     }
 
-    // MARK: - Cleanup
+    // endregion
+
+    // region Cleanup
 
     @ReactMethod
     fun closeConversation(promise: Promise) {
@@ -626,6 +619,10 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             putBoolean("success", true)
         })
     }
+
+    // endregion
+
+    // region Event Emitter Support
     // endregion
 
     // region Additional Context
@@ -732,7 +729,6 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     }
     // endregion
 
-    // region Event Emitter Support
 
     @ReactMethod
     fun addListener(eventName: String) {
@@ -743,6 +739,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     fun removeListeners(count: Int) {
         // Required for RN event emitter
     }
+
     // endregion
 
     // region Helper Methods
@@ -766,5 +763,6 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         scope.cancel()
         viewModel = null
     }
+
     // endregion
 }

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -569,19 +569,29 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun registerViewProvider(config: ReadableMap, promise: Promise) {
-        val types = config.getArray("componentTypes")
-        val componentName = config.getString("reactComponentName")
+        val mapData = config.getMap("componentMap")
 
-        if (types == null || types.size() == 0 || componentName.isNullOrEmpty()) {
-            promise.reject("INVALID_CONFIG", "Must provide componentTypes array and reactComponentName")
+        if (mapData == null) {
+            promise.reject("INVALID_CONFIG", "Must provide a non-empty componentMap dictionary")
             return
         }
 
-        val typeList = (0 until types.size()).mapNotNull { types.getString(it) }
-        bridgeViewProvider.register(typeList, componentName)
+        val componentMap = mutableMapOf<String, String>()
+        val iterator = mapData.keySetIterator()
+        while (iterator.hasNextKey()) {
+            val key = iterator.nextKey()
+            mapData.getString(key)?.let { componentMap[key] = it }
+        }
+
+        if (componentMap.isEmpty()) {
+            promise.reject("INVALID_CONFIG", "Must provide a non-empty componentMap dictionary")
+            return
+        }
+
+        bridgeViewProvider.register(componentMap)
         promise.resolve(Arguments.createMap().apply {
             putBoolean("success", true)
-            putArray("registeredTypes", Arguments.fromList(typeList))
+            putInt("registeredCount", componentMap.size)
         })
     }
 

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -26,6 +26,7 @@ import com.salesforce.android.agentforceservice.conversationservice.data.Copilot
 import com.salesforce.android.reactagentforce.models.AgentMode as LocalAgentMode
 import com.salesforce.android.reactagentforce.models.EmployeeAgentModeConfig
 import com.salesforce.android.reactagentforce.models.ServiceAgentModeConfig
+import com.salesforce.android.reactagentforce.providers.BridgeViewProvider
 import com.salesforce.android.reactagentforce.providers.UnifiedCredentialProvider
 import kotlinx.coroutines.*
 
@@ -68,6 +69,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
 
     // Bridge navigation for forwarding SDK navigation requests to JS
     private val bridgeNavigation = BridgeNavigation(reactContext)
+
+    // Bridge view provider for delegating native SDK views to React Native components
+    private val bridgeViewProvider = BridgeViewProvider(reactContext)
 
     // Coroutine scope for async operations
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
@@ -168,6 +172,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setLogger(bridgeLogger)
                     .setNavigation(bridgeNavigation)
                 permissions?.let { agentforceConfigBuilder.setPermission(it) }
+                if (bridgeViewProvider.isRegistered) {
+                    agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
+                }
                 val agentforceConfig = agentforceConfigBuilder.build()
 
                 val sdkMode = AgentforceMode.ServiceAgent(
@@ -246,6 +253,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setLogger(bridgeLogger)
                     .setNavigation(bridgeNavigation)
                 permissions?.let { agentforceConfigBuilder.setPermission(it) }
+                if (bridgeViewProvider.isRegistered) {
+                    agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
+                }
                 val agentforceConfig = agentforceConfigBuilder.build()
 
                 // Use FullConfig mode for Employee Agent
@@ -555,7 +565,35 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     }
     // endregion
 
-    // region Cleanup
+    // MARK: - View Provider
+
+    @ReactMethod
+    fun registerViewProvider(config: ReadableMap, promise: Promise) {
+        val types = config.getArray("componentTypes")
+        val componentName = config.getString("reactComponentName")
+
+        if (types == null || types.size() == 0 || componentName.isNullOrEmpty()) {
+            promise.reject("INVALID_CONFIG", "Must provide componentTypes array and reactComponentName")
+            return
+        }
+
+        val typeList = (0 until types.size()).mapNotNull { types.getString(it) }
+        bridgeViewProvider.register(typeList, componentName)
+        promise.resolve(Arguments.createMap().apply {
+            putBoolean("success", true)
+            putArray("registeredTypes", Arguments.fromList(typeList))
+        })
+    }
+
+    @ReactMethod
+    fun clearViewProvider(promise: Promise) {
+        bridgeViewProvider.reset()
+        promise.resolve(Arguments.createMap().apply {
+            putBoolean("success", true)
+        })
+    }
+
+    // MARK: - Cleanup
 
     @ReactMethod
     fun closeConversation(promise: Promise) {
@@ -572,6 +610,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         viewModel?.resetConfiguration()
         currentMode = null
         credentialProvider.reset()
+        bridgeViewProvider.reset()
         employeePrefs.edit().remove(KEY_EMPLOYEE_AGENT_ID).apply()
         promise.resolve(Arguments.createMap().apply {
             putBoolean("success", true)

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Bridges the native AgentforceViewProvider interface to React Native.
+ * When enabled, delegates rendering of specified component types to a
+ * registered React Native component via ReactRootView.
+ */
+package com.salesforce.android.reactagentforce.providers
+
+import android.os.Bundle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactRootView
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableMap
+import com.salesforce.android.agentforcesdk.components.models.AgentforceComponent
+import com.salesforce.android.agentforcesdk.components.models.AgentforceViewProvider
+
+/**
+ * Implements AgentforceViewProvider by delegating to a React Native component.
+ * Component types are registered synchronously from JS; rendering uses ReactRootView.
+ */
+class BridgeViewProvider(
+    private val reactContext: ReactApplicationContext
+) : AgentforceViewProvider {
+
+    /** Set of component definition strings this provider handles */
+    private var registeredTypes: MutableSet<String> = mutableSetOf()
+
+    /** The React Native component name to render for matching types */
+    private var reactComponentName: String = ""
+
+    /** Register component types and the React component to render them. */
+    fun register(componentTypes: List<String>, reactComponentName: String) {
+        this.registeredTypes = componentTypes.toMutableSet()
+        this.reactComponentName = reactComponentName
+    }
+
+    /** Clear all registrations */
+    fun reset() {
+        registeredTypes.clear()
+        reactComponentName = ""
+    }
+
+    val isRegistered: Boolean
+        get() = registeredTypes.isNotEmpty() && reactComponentName.isNotEmpty()
+
+    // MARK: - AgentforceViewProvider
+
+    override fun canHandle(definition: String): Boolean {
+        return registeredTypes.contains(definition)
+    }
+
+    @Composable
+    override fun GetView(modifier: Modifier, view: AgentforceComponent) {
+        val props = componentToBundle(view)
+        AndroidView(
+            modifier = modifier,
+            factory = { context ->
+                ReactRootView(context).apply {
+                    val reactApp = reactContext.applicationContext as? ReactApplication
+                    val reactHost = reactApp?.reactHost
+                    // Start the React surface with the registered component name and props
+                    startReactApplication(
+                        reactHost?.currentReactContext?.catalystInstance?.let {
+                            // For modern RN, get the instance manager from the host
+                            (reactApp as? ReactApplication)?.reactNativeHost?.reactInstanceManager
+                        },
+                        reactComponentName,
+                        props
+                    )
+                }
+            }
+        )
+    }
+
+    /** Convert AgentforceComponent to a Bundle for React Native initial properties */
+    private fun componentToBundle(component: AgentforceComponent): Bundle {
+        return Bundle().apply {
+            putString("definition", component.definition)
+            component.name?.let { putString("name", it) }
+            putBundle("properties", mapToBundle(component.properties))
+            if (component.subComponents.isNotEmpty()) {
+                val subArray = component.subComponents.mapIndexed { i, sub ->
+                    componentToBundle(sub)
+                }.toTypedArray()
+                putParcelableArray("subComponents", subArray)
+            }
+        }
+    }
+
+    /** Recursively convert a Map to a Bundle */
+    private fun mapToBundle(map: Map<String, Any>): Bundle {
+        return Bundle().apply {
+            for ((key, value) in map) {
+                when (value) {
+                    is String -> putString(key, value)
+                    is Int -> putInt(key, value)
+                    is Long -> putLong(key, value)
+                    is Double -> putDouble(key, value)
+                    is Float -> putFloat(key, value)
+                    is Boolean -> putBoolean(key, value)
+                    is Map<*, *> -> {
+                        @Suppress("UNCHECKED_CAST")
+                        putBundle(key, mapToBundle(value as Map<String, Any>))
+                    }
+                    is List<*> -> {
+                        // Convert list to array of strings as a safe fallback
+                        putStringArray(key, value.map { it?.toString() ?: "" }.toTypedArray())
+                    }
+                    else -> putString(key, value.toString())
+                }
+            }
+        }
+    }
+}

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
@@ -102,15 +102,40 @@ class BridgeViewProvider(
                         putBundle(key, mapToBundle(value as Map<String, Any>))
                     }
                     is List<*> -> {
-                        // Coerces all elements to strings via toString(). Numeric/nested
-                        // type information is lost — acceptable for the current SDK contract
-                        // where list properties are display-only string sequences.
-                        putStringArray(key, value.map { it?.toString() ?: "" }.toTypedArray())
+                        putParcelableArray(key, listToBundleArray(value))
                     }
                     else -> putString(key, value.toString())
                 }
             }
         }
+    }
+
+    /**
+     * Convert a heterogeneous list to an array of Bundles.
+     * Each element is wrapped in a Bundle with a "value" key for primitives,
+     * or inlined for Map elements, preserving type information across the bridge.
+     */
+    private fun listToBundleArray(list: List<*>): Array<Bundle> {
+        return list.map { item ->
+            when (item) {
+                is Map<*, *> -> {
+                    @Suppress("UNCHECKED_CAST")
+                    mapToBundle(item as Map<String, Any>)
+                }
+                else -> Bundle().apply {
+                    when (item) {
+                        is String -> putString("value", item)
+                        is Int -> putInt("value", item)
+                        is Long -> putLong("value", item)
+                        is Double -> putDouble("value", item)
+                        is Float -> putFloat("value", item)
+                        is Boolean -> putBoolean("value", item)
+                        is List<*> -> putParcelableArray("value", listToBundleArray(item))
+                        else -> putString("value", item?.toString() ?: "")
+                    }
+                }
+            }
+        }.toTypedArray()
     }
 
     // endregion

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
@@ -19,6 +19,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.salesforce.android.agentforcesdk.components.models.AgentforceComponent
 import com.salesforce.android.agentforcesdk.components.models.AgentforceViewProvider
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Implements AgentforceViewProvider by delegating to a React Native component.
@@ -28,12 +29,17 @@ class BridgeViewProvider(
     private val reactContext: ReactApplicationContext
 ) : AgentforceViewProvider {
 
-    /** Maps component definition strings to their React Native component names */
-    private var componentMap: MutableMap<String, String> = mutableMapOf()
+    /**
+     * Maps component definition strings to their React Native component names.
+     * Thread-safe: `canHandle` may be called from the SDK rendering thread while
+     * `register`/`reset` are called from the JS thread.
+     */
+    private val componentMap: ConcurrentHashMap<String, String> = ConcurrentHashMap()
 
     /** Register a 1:1 mapping of component types to React component names. */
     fun register(componentMap: Map<String, String>) {
-        this.componentMap = componentMap.toMutableMap()
+        this.componentMap.clear()
+        this.componentMap.putAll(componentMap)
     }
 
     /** Clear all registrations */
@@ -44,7 +50,7 @@ class BridgeViewProvider(
     val isRegistered: Boolean
         get() = componentMap.isNotEmpty()
 
-    // MARK: - AgentforceViewProvider
+    // region AgentforceViewProvider
 
     override fun canHandle(definition: String): Boolean {
         return componentMap.containsKey(definition)
@@ -59,18 +65,11 @@ class BridgeViewProvider(
             factory = { context ->
                 ReactRootView(context).apply {
                     val reactApp = reactContext.applicationContext as? ReactApplication
-                    val reactHost = reactApp?.reactHost
-                    // Start the React surface with the per-type component name and props
-                    startReactApplication(
-                        reactHost?.currentReactContext?.catalystInstance?.let {
-                            // For modern RN, get the instance manager from the host
-                            (reactApp as? ReactApplication)?.reactNativeHost?.reactInstanceManager
-                        },
-                        moduleName,
-                        props
-                    )
+                    val instanceManager = reactApp?.reactNativeHost?.reactInstanceManager
+                    startReactApplication(instanceManager, moduleName, props)
                 }
-            }
+            },
+            onRelease = { view -> view.unmountReactApplication() }
         )
     }
 
@@ -81,9 +80,7 @@ class BridgeViewProvider(
             component.name?.let { putString("name", it) }
             putBundle("properties", mapToBundle(component.properties))
             if (component.subComponents.isNotEmpty()) {
-                val subArray = component.subComponents.mapIndexed { i, sub ->
-                    componentToBundle(sub)
-                }.toTypedArray()
+                val subArray = component.subComponents.map { componentToBundle(it) }.toTypedArray()
                 putParcelableArray("subComponents", subArray)
             }
         }
@@ -105,7 +102,9 @@ class BridgeViewProvider(
                         putBundle(key, mapToBundle(value as Map<String, Any>))
                     }
                     is List<*> -> {
-                        // Convert list to array of strings as a safe fallback
+                        // Coerces all elements to strings via toString(). Numeric/nested
+                        // type information is lost — acceptable for the current SDK contract
+                        // where list properties are display-only string sequences.
                         putStringArray(key, value.map { it?.toString() ?: "" }.toTypedArray())
                     }
                     else -> putString(key, value.toString())
@@ -113,4 +112,6 @@ class BridgeViewProvider(
             }
         }
     }
+
+    // endregion
 }

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
@@ -28,35 +28,31 @@ class BridgeViewProvider(
     private val reactContext: ReactApplicationContext
 ) : AgentforceViewProvider {
 
-    /** Set of component definition strings this provider handles */
-    private var registeredTypes: MutableSet<String> = mutableSetOf()
+    /** Maps component definition strings to their React Native component names */
+    private var componentMap: MutableMap<String, String> = mutableMapOf()
 
-    /** The React Native component name to render for matching types */
-    private var reactComponentName: String = ""
-
-    /** Register component types and the React component to render them. */
-    fun register(componentTypes: List<String>, reactComponentName: String) {
-        this.registeredTypes = componentTypes.toMutableSet()
-        this.reactComponentName = reactComponentName
+    /** Register a 1:1 mapping of component types to React component names. */
+    fun register(componentMap: Map<String, String>) {
+        this.componentMap = componentMap.toMutableMap()
     }
 
     /** Clear all registrations */
     fun reset() {
-        registeredTypes.clear()
-        reactComponentName = ""
+        componentMap.clear()
     }
 
     val isRegistered: Boolean
-        get() = registeredTypes.isNotEmpty() && reactComponentName.isNotEmpty()
+        get() = componentMap.isNotEmpty()
 
     // MARK: - AgentforceViewProvider
 
     override fun canHandle(definition: String): Boolean {
-        return registeredTypes.contains(definition)
+        return componentMap.containsKey(definition)
     }
 
     @Composable
     override fun GetView(modifier: Modifier, view: AgentforceComponent) {
+        val moduleName = componentMap[view.definition] ?: return
         val props = componentToBundle(view)
         AndroidView(
             modifier = modifier,
@@ -64,13 +60,13 @@ class BridgeViewProvider(
                 ReactRootView(context).apply {
                     val reactApp = reactContext.applicationContext as? ReactApplication
                     val reactHost = reactApp?.reactHost
-                    // Start the React surface with the registered component name and props
+                    // Start the React surface with the per-type component name and props
                     startReactApplication(
                         reactHost?.currentReactContext?.catalystInstance?.let {
                             // For modern RN, get the instance manager from the host
                             (reactApp as? ReactApplication)?.reactNativeHost?.reactInstanceManager
                         },
-                        reactComponentName,
+                        moduleName,
                         props
                     )
                 }

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/providers/BridgeViewProvider.kt
@@ -19,7 +19,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.salesforce.android.agentforcesdk.components.models.AgentforceComponent
 import com.salesforce.android.agentforcesdk.components.models.AgentforceViewProvider
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Implements AgentforceViewProvider by delegating to a React Native component.
@@ -31,34 +31,33 @@ class BridgeViewProvider(
 
     /**
      * Maps component definition strings to their React Native component names.
-     * Thread-safe: `canHandle` may be called from the SDK rendering thread while
-     * `register`/`reset` are called from the JS thread.
+     * Uses AtomicReference to swap the entire immutable map in one shot, so
+     * `canHandle` never sees a partially-updated (empty) map during registration.
      */
-    private val componentMap: ConcurrentHashMap<String, String> = ConcurrentHashMap()
+    private val componentMap: AtomicReference<Map<String, String>> = AtomicReference(emptyMap())
 
     /** Register a 1:1 mapping of component types to React component names. */
     fun register(componentMap: Map<String, String>) {
-        this.componentMap.clear()
-        this.componentMap.putAll(componentMap)
+        this.componentMap.set(componentMap.toMap())
     }
 
     /** Clear all registrations */
     fun reset() {
-        componentMap.clear()
+        componentMap.set(emptyMap())
     }
 
     val isRegistered: Boolean
-        get() = componentMap.isNotEmpty()
+        get() = componentMap.get().isNotEmpty()
 
     // region AgentforceViewProvider
 
     override fun canHandle(definition: String): Boolean {
-        return componentMap.containsKey(definition)
+        return componentMap.get().containsKey(definition)
     }
 
     @Composable
     override fun GetView(modifier: Modifier, view: AgentforceComponent) {
-        val moduleName = componentMap[view.definition] ?: return
+        val moduleName = componentMap.get()[view.definition] ?: return
         val props = componentToBundle(view)
         AndroidView(
             modifier = modifier,

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -21,7 +21,7 @@ import SalesforceSDKCore
 /// Supports both Service Agent (guest) and Employee Agent (authenticated) modes
 @objc(AgentforceModule)
 class AgentforceModule: RCTEventEmitter {
-    
+
     // MARK: - Properties
 
     /// Unified credential provider for both Service and Employee agents
@@ -87,7 +87,7 @@ class AgentforceModule: RCTEventEmitter {
     }
 
     // MARK: - Unified Configuration Method
-    
+
     /// Configure the SDK with either Service or Employee agent settings.
     /// Expects a dictionary with 'type' field set to 'service' or 'employee'.
     /// This is the new unified configuration method.
@@ -102,18 +102,18 @@ class AgentforceModule: RCTEventEmitter {
             reject("INVALID_CONFIG", "Missing 'type' field (must be 'service' or 'employee')", nil)
             return
         }
-        
+
         Task { @MainActor in
             do {
                 switch type {
                 case "service":
                     try await configureServiceAgent(configDict)
                     resolve(["success": true, "mode": "service"])
-                    
+
                 case "employee":
                     try await configureEmployeeAgent(configDict)
                     resolve(["success": true, "mode": "employee"])
-                    
+
                 default:
                     reject("INVALID_CONFIG", "Invalid type '\(type)'. Must be 'service' or 'employee'", nil)
                 }
@@ -123,9 +123,9 @@ class AgentforceModule: RCTEventEmitter {
             }
         }
     }
-    
+
     // MARK: - Service Agent Configuration
-    
+
     private func configureServiceAgent(_ configDict: [String: Any]) async throws {
         guard let config = ServiceAgentModeConfig.from(dictionary: configDict) else {
             throw AgentConfigError.missingRequiredField("serviceApiURL, organizationId, or esDeveloperName")
@@ -134,7 +134,7 @@ class AgentforceModule: RCTEventEmitter {
         guard URL(string: config.serviceApiURL) != nil else {
             throw AgentConfigError.missingRequiredField("serviceApiURL must be a valid URL (e.g. https://your-site.salesforce.com)")
         }
-        
+
         // Only cleanup if switching from Employee mode
         if case .employee = currentMode {
             print("[AgentforceModule] ⚠️ Switching from Employee to Service mode - cleaning up")
@@ -144,7 +144,7 @@ class AgentforceModule: RCTEventEmitter {
         // Configure unified credential provider for Service Agent mode
         credentialProvider.configure(serviceAgent: config)
         currentMode = .service(config: config)
-        
+
         // Also update the legacy ServiceAgentManager for backward compatibility
         await MainActor.run {
             ServiceAgentManager.shared.configure(
@@ -153,7 +153,7 @@ class AgentforceModule: RCTEventEmitter {
                 siteUrl: config.serviceApiURL
             )
         }
-        
+
         // Using fullConfig instead of .serviceAgent() to inject bridgeLogger and bridgeNavigation.
         // TODO: Migrate to .serviceAgent(config) when ServiceAgentConfiguration supports logger/navigation parameters.
         let serviceUser = User(
@@ -185,7 +185,7 @@ class AgentforceModule: RCTEventEmitter {
     }
 
     // MARK: - Employee Agent Configuration
-    
+
     private func configureEmployeeAgent(_ configDict: [String: Any]) async throws {
         guard let config = EmployeeAgentModeConfig.from(dictionary: configDict) else {
             throw AgentConfigError.missingRequiredField("instanceUrl, organizationId, userId, agentId, or accessToken")
@@ -229,7 +229,7 @@ class AgentforceModule: RCTEventEmitter {
             username: userId,
             displayName: userId
         )
-        
+
         let flags = getFeatureFlagsFromConfigOrUserDefaults(configDict)
         let featureFlagSettings = AgentforceFeatureFlagSettings(
             enableMultiModalInput: flags.enableMultiModalInput,
@@ -240,7 +240,7 @@ class AgentforceModule: RCTEventEmitter {
             enableOnboarding: false,
             internalFlags: [:]
         )
-        
+
         // Build full configuration so we control agentforceFeatureFlagSettings.
         // Passing nil for optional params uses SDK defaults (network, imageProvider, theme, etc.).
         let fullConfiguration = AgentforceConfiguration(
@@ -251,7 +251,7 @@ class AgentforceModule: RCTEventEmitter {
             salesforceNavigation: bridgeNavigation,
             salesforceLogger: bridgeLogger
         )
-        
+
         if !bridgeViewProvider.isRegistered {
             print("[AgentforceModule] ⚠️ No view provider registered at configure() time. Call registerViewProvider() before configure() if you want custom views.")
         }
@@ -265,7 +265,7 @@ class AgentforceModule: RCTEventEmitter {
     }
 
     // MARK: - Legacy Configuration Method (Backward Compatibility)
-    
+
     /// Configure Service Agent (JavaScript-friendly interface)
     /// This is the legacy method for backward compatibility
     @objc
@@ -283,10 +283,10 @@ class AgentforceModule: RCTEventEmitter {
             "organizationId": organizationId,
             "esDeveloperName": esDeveloperName
         ]
-        
+
         configureWithConfig(config as NSDictionary, resolver: resolve, rejecter: reject)
     }
-    
+
     /// Legacy method for initializing Service Agent
     @objc
     func initializeServiceAgent(
@@ -303,12 +303,12 @@ class AgentforceModule: RCTEventEmitter {
             "organizationId": orgUrl,
             "esDeveloperName": devName
         ]
-        
+
         configureWithConfig(config as NSDictionary, resolver: resolve, rejecter: reject)
     }
-    
+
     // MARK: - Conversation Methods (Unified for both modes)
-    
+
     /// Launch the conversation UI - works for both Service and Employee agents
     @objc
     func launchConversation(
@@ -343,7 +343,7 @@ class AgentforceModule: RCTEventEmitter {
                     resolve(["success": true])
                     return
                 }
-                
+
                 // Fall back to legacy ServiceAgentManager path
                 if !ServiceAgentManager.shared.isInitialized {
                     guard ServiceAgentManager.shared.isConfigured else {
@@ -351,7 +351,7 @@ class AgentforceModule: RCTEventEmitter {
                     }
                     try ServiceAgentManager.shared.initializeSDK()
                 }
-                
+
                 guard let client = ServiceAgentManager.shared.getClient() else {
                     throw ServiceAgentError.sdkNotInitialized
                 }
@@ -375,7 +375,7 @@ class AgentforceModule: RCTEventEmitter {
                         }
                     }
                 )
-                
+
                 presentConversationView(chatView)
                 resolve(["success": true])
             } catch {
@@ -390,7 +390,7 @@ class AgentforceModule: RCTEventEmitter {
             }
         }
     }
-    
+
     /// Start a new conversation (closes existing one and launches fresh)
     @objc
     func startNewConversation(
@@ -401,7 +401,7 @@ class AgentforceModule: RCTEventEmitter {
             do {
                 // Close existing conversation
                 await closeCurrentConversation()
-                
+
                 // Try new unified path first
                 if let client = agentforceClient, let mode = currentMode {
                     let conversation = try getOrCreateConversation(client: client, mode: mode, forceNew: true)
@@ -423,12 +423,12 @@ class AgentforceModule: RCTEventEmitter {
                             }
                         }
                     )
-                    
+
                     presentConversationView(chatView)
                     resolve(["success": true])
                     return
                 }
-                
+
                 // Fall back to legacy path
                 if !ServiceAgentManager.shared.isInitialized {
                     guard ServiceAgentManager.shared.isConfigured else {
@@ -436,7 +436,7 @@ class AgentforceModule: RCTEventEmitter {
                     }
                     try ServiceAgentManager.shared.initializeSDK()
                 }
-                
+
                 guard let client = ServiceAgentManager.shared.getClient() else {
                     throw ServiceAgentError.sdkNotInitialized
                 }
@@ -460,7 +460,7 @@ class AgentforceModule: RCTEventEmitter {
                         }
                     }
                 )
-                
+
                 presentConversationView(chatView)
                 resolve(["success": true])
             } catch {
@@ -469,9 +469,9 @@ class AgentforceModule: RCTEventEmitter {
             }
         }
     }
-    
+
     // MARK: - Conversation Helpers
-    
+
     private func getOrCreateConversation(client: AgentforceClient, mode: AgentMode, forceNew: Bool = false) throws -> AgentConversation {
         // Return existing if available and not forcing new
         if !forceNew, let existing = currentConversation {
@@ -513,7 +513,7 @@ class AgentforceModule: RCTEventEmitter {
         currentConversation = conversation
         return conversation
     }
-    
+
     private func closeCurrentConversation() async {
         if let conversation = currentConversation {
             do {
@@ -524,9 +524,9 @@ class AgentforceModule: RCTEventEmitter {
         }
         currentConversation = nil
     }
-    
+
     // MARK: - Configuration Query Methods
-    
+
     /// Check if SDK is configured
     @objc
     func isConfigured(
@@ -544,7 +544,7 @@ class AgentforceModule: RCTEventEmitter {
             resolve(configured)
         }
     }
-    
+
     /// Get stored Employee Agent ID (set in Settings > Employee Agent tab)
     @objc
     func getEmployeeAgentId(
@@ -554,7 +554,7 @@ class AgentforceModule: RCTEventEmitter {
         let agentId = UserDefaults.standard.string(forKey: "EmployeeAgentId") ?? ""
         resolve(agentId)
     }
-    
+
     /// Set Employee Agent ID (from Settings > Employee Agent tab)
     @objc
     func setEmployeeAgentId(
@@ -578,21 +578,21 @@ class AgentforceModule: RCTEventEmitter {
             resolve(nil)
         }
     }
-    
+
     private static let featureFlagKeys = (
         enableMultiAgent: "AgentforceFF_enableMultiAgent",
         enableMultiModalInput: "AgentforceFF_enableMultiModalInput",
         enablePDFUpload: "AgentforceFF_enablePDFUpload",
         enableVoice: "AgentforceFF_enableVoice"
     )
-    
+
     private struct FeatureFlags {
         let enableMultiAgent: Bool
         let enableMultiModalInput: Bool
         let enablePDFUpload: Bool
         let enableVoice: Bool
     }
-    
+
     private func getFeatureFlagsFromConfigOrUserDefaults(_ configDict: [String: Any]) -> FeatureFlags {
         if let featureFlags = configDict["featureFlags"] as? [String: Any] {
             return FeatureFlags(
@@ -610,14 +610,14 @@ class AgentforceModule: RCTEventEmitter {
             enableVoice: ud.object(forKey: Self.featureFlagKeys.enableVoice) == nil ? false : ud.bool(forKey: Self.featureFlagKeys.enableVoice)
         )
     }
-    
+
     private func saveFeatureFlagsToUserDefaults(_ flags: FeatureFlags) {
         UserDefaults.standard.set(flags.enableMultiAgent, forKey: Self.featureFlagKeys.enableMultiAgent)
         UserDefaults.standard.set(flags.enableMultiModalInput, forKey: Self.featureFlagKeys.enableMultiModalInput)
         UserDefaults.standard.set(flags.enablePDFUpload, forKey: Self.featureFlagKeys.enablePDFUpload)
         UserDefaults.standard.set(flags.enableVoice, forKey: Self.featureFlagKeys.enableVoice)
     }
-    
+
     @objc
     func getFeatureFlags(
         _ resolve: @escaping RCTPromiseResolveBlock,
@@ -661,7 +661,7 @@ class AgentforceModule: RCTEventEmitter {
             resolve(nil)
         }
     }
-    
+
     /// Get current configuration values (legacy format for backward compatibility)
     @objc
     func getConfiguration(
@@ -679,7 +679,7 @@ class AgentforceModule: RCTEventEmitter {
                 resolve(configDict)
                 return
             }
-            
+
             // Fall back to legacy ServiceAgentManager
             let config: [String: String] = [
                 "serviceApiURL": ServiceAgentManager.shared.siteUrl,
@@ -689,7 +689,7 @@ class AgentforceModule: RCTEventEmitter {
             resolve(config)
         }
     }
-    
+
     /// Get detailed configuration info including mode
     @objc
     func getConfigurationInfo(
@@ -717,7 +717,7 @@ class AgentforceModule: RCTEventEmitter {
             }
         }
     }
-    
+
     /// Check if SDK is initialized and ready
     @objc
     func isInitialized(
@@ -821,7 +821,7 @@ class AgentforceModule: RCTEventEmitter {
         currentConversation = nil
         agentforceClient = nil
     }
-    
+
     /// Close the conversation
     @objc
     func closeConversation(
@@ -963,35 +963,35 @@ class AgentforceModule: RCTEventEmitter {
             resolve(["success": true])
         }
     }
-    
+
     // MARK: - UI Presentation Helpers
-    
+
     @MainActor
     private func presentConversationView<Content: View>(_ conversationView: Content) {
         guard let rootViewController = getRootViewController() else {
             print("[AgentforceModule] ⚠️ Could not find root view controller")
             return
         }
-        
+
         let hostingController = UIHostingController(rootView: conversationView)
         hostingController.modalPresentationStyle = .fullScreen
         hostingController.modalTransitionStyle = .coverVertical
-        
+
         rootViewController.present(hostingController, animated: true)
     }
-    
+
     @MainActor
     private func dismissConversation() {
         guard let rootViewController = getRootViewController() else {
             print("[AgentforceModule] ⚠️ Could not find root view controller for dismissal")
             return
         }
-        
+
         if rootViewController.presentedViewController != nil {
             rootViewController.dismiss(animated: true)
         }
     }
-    
+
     @MainActor
     private func getRootViewController() -> UIViewController? {
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,


### PR DESCRIPTION
## Stack: viewprovider (PR 3 of 6)

| # | PR | Status |
|---|-----|--------|
|   1 | [#43 add viewprovider types and enablecustomviewprovider feature flag](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/43) | Open |
|   2 | [#44 ios viewprovider bridge](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/44) | Open |
| > 3 | [#45 android viewprovider bridge](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/45) | Open |
|   4 | [#46 js viewprovider service](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/46) | Open |
|   5 | [#47 settings toggle](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/47) | Open |
|   6 | [#48 example usage](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/48) | Open |

---

## Summary
- Creates `BridgeViewProvider.kt` implementing `AgentforceViewProvider` interface
- `canHandle(definition:)` checks against pre-registered component type strings from JS
- `GetView()` renders a `ReactRootView` inside a Compose `AndroidView`
- Adds `registerViewProvider` / `clearViewProvider` React methods to `AgentforceModule`
- Passes the view provider to `AgentforceConfiguration.Builder` when registered
## Stack
PR 3/6 in the `viewprovider` stack.
## Test plan
- [ ] Android build compiles with new BridgeViewProvider
- [ ] registerViewProvider accepts componentTypes + reactComponentName
- [ ] clearViewProvider resets registration
- [ ] Without registration, configuration builder skips setViewProvider (no behavior change)