### PR TITLE
Add ViewProvider delegate methods to AgentforceService

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -168,11 +168,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setLogger(bridgeLogger)
                     .setNavigation(bridgeNavigation)
                 permissions?.let { agentforceConfigBuilder.setPermission(it) }
-                if (bridgeViewProvider.isRegistered) {
-                    agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
-                } else {
-                    Log.w(TAG, "No view provider registered at configure() time. Call registerViewProvider() before configure() if you want custom views.")
-                }
+                // Always attach bridgeViewProvider so late registrations take effect.
+                // canHandle() returns false when the map is empty, matching no-provider behavior.
+                agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
                 val agentforceConfig = agentforceConfigBuilder.build()
 
                 val sdkMode = AgentforceMode.ServiceAgent(
@@ -249,11 +247,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setLogger(bridgeLogger)
                     .setNavigation(bridgeNavigation)
                 permissions?.let { agentforceConfigBuilder.setPermission(it) }
-                if (bridgeViewProvider.isRegistered) {
-                    agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
-                } else {
-                    Log.w(TAG, "No view provider registered at configure() time. Call registerViewProvider() before configure() if you want custom views.")
-                }
+                // Always attach bridgeViewProvider so late registrations take effect.
+                // canHandle() returns false when the map is empty, matching no-provider behavior.
+                agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
                 val agentforceConfig = agentforceConfigBuilder.build()
 
                 // Use FullConfig mode for Employee Agent
@@ -573,9 +569,6 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             return
         }
 
-        if (AgentforceClientHolder.isConfigured) {
-            Log.w(TAG, "registerViewProvider called after configure(). The view provider will not take effect until the next configure() call.")
-        }
         bridgeViewProvider.register(componentMap)
         val keysArray = Arguments.createArray().apply {
             componentMap.keys.forEach { pushString(it) }

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -173,14 +173,12 @@ class AgentforceModule: RCTEventEmitter {
             serviceApiURL: config.serviceApiURL
         )
 
-        if !bridgeViewProvider.isRegistered {
-            print("[AgentforceModule] ⚠️ No view provider registered at configure() time. Call registerViewProvider() before configure() if you want custom views.")
-        }
-
+        // Always pass bridgeViewProvider so late registrations take effect.
+        // canHandle() returns false when the map is empty, matching nil behavior.
         agentforceClient = AgentforceClient(
             credentialProvider: credentialProvider,
             mode: .fullConfig(fullConfiguration),
-            viewProvider: bridgeViewProvider.isRegistered ? bridgeViewProvider : nil
+            viewProvider: bridgeViewProvider
         )
     }
 
@@ -252,15 +250,12 @@ class AgentforceModule: RCTEventEmitter {
             salesforceLogger: bridgeLogger
         )
 
-        if !bridgeViewProvider.isRegistered {
-            print("[AgentforceModule] ⚠️ No view provider registered at configure() time. Call registerViewProvider() before configure() if you want custom views.")
-        }
-
-        // Initialize Agentforce Client with fullConfig mode (explicit config + feature flags).
+        // Always pass bridgeViewProvider so late registrations take effect.
+        // canHandle() returns false when the map is empty, matching nil behavior.
         agentforceClient = AgentforceClient(
             credentialProvider: credentialProvider,
             mode: .fullConfig(fullConfiguration),
-            viewProvider: bridgeViewProvider.isRegistered ? bridgeViewProvider : nil
+            viewProvider: bridgeViewProvider
         )
     }
 
@@ -785,7 +780,8 @@ class AgentforceModule: RCTEventEmitter {
     // MARK: - View Provider
 
     /// Register a React Native component as a custom view provider for specified types.
-    /// Must be called before configure() so the provider is attached at SDK init time.
+    /// Can be called before or after configure() — the provider is always attached to the
+    /// client and canHandle() checks the map dynamically.
     @objc
     func registerViewProvider(
         _ config: NSDictionary,
@@ -797,9 +793,6 @@ class AgentforceModule: RCTEventEmitter {
               !componentMap.isEmpty else {
             reject("INVALID_CONFIG", "Must provide a non-empty componentMap dictionary", nil)
             return
-        }
-        if agentforceClient != nil {
-            print("[AgentforceModule] ⚠️ registerViewProvider called after configure(). The view provider will not take effect until the next configure() call.")
         }
         bridgeViewProvider.register(componentMap: componentMap)
         resolve(["success": true, "registeredTypes": Array(componentMap.keys)])

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -278,8 +278,10 @@ class AgentforceService {
    * @example
    * ```typescript
    * AgentforceService.setViewProviderDelegate({
-   *   componentTypes: ['copilot/richText', 'copilot/markdown'],
-   *   reactComponentName: 'CustomAgentforceView',
+   *   componentMap: {
+   *     'copilot/richText': 'CustomRichTextView',
+   *     'copilot/markdown': 'CustomMarkdownView',
+   *   },
    * });
    * ```
    */
@@ -293,11 +295,10 @@ class AgentforceService {
 
     try {
       await AgentforceModule.registerViewProvider({
-        componentTypes: delegate.componentTypes,
-        reactComponentName: delegate.reactComponentName,
+        componentMap: delegate.componentMap,
       });
       console.log(
-        `[AgentforceService] View provider registered for ${delegate.componentTypes.length} types`,
+        `[AgentforceService] View provider registered for ${Object.keys(delegate.componentMap).length} types`,
       );
     } catch (error) {
       console.error('[AgentforceService] Failed to register view provider:', error);

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -270,8 +270,8 @@ class AgentforceService {
    * Register a view provider delegate to override native SDK output views
    * with custom React Native components.
    *
-   * Must be called before `configure()` so the native provider is attached
-   * at SDK initialization time.
+   * Can be called before or after `configure()` — the native provider is
+   * always attached to the client and checks the component map dynamically.
    *
    * @param delegate - View provider delegate configuration
    *
@@ -398,18 +398,6 @@ class AgentforceService {
       console.log(
         `[AgentforceService] Configured successfully (mode: ${configWithFlags.type})`,
       );
-
-      // Re-register the view provider if one was set before this configure() call,
-      // since the native client was recreated and lost the previous registration.
-      if (this.viewProviderDelegate) {
-        try {
-          await AgentforceModule.registerViewProvider({
-            componentMap: this.viewProviderDelegate.componentMap,
-          });
-        } catch (err) {
-          console.warn('[AgentforceService] Failed to re-register view provider after configure:', err);
-        }
-      }
 
       return result?.success ?? true;
     } catch (error) {

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -32,6 +32,7 @@ import type {
   AgentforceContextVariable,
   AgentforceContextVariableType,
 } from '../types/AgentforceContext';
+import { ViewProviderDelegate, ViewProviderComponentData } from '../types/ViewProviderDelegate';
 
 const { AgentforceModule } = NativeModules;
 
@@ -40,6 +41,7 @@ export type { ServiceAgentConfig, EmployeeAgentConfig, AgentConfig, FeatureFlags
 export type { LoggerDelegate, LogLevel };
 export type { NavigationDelegate, NavigationRequest };
 export type { AgentforceAdditionalContext, AgentforceContextVariable };
+export type { ViewProviderDelegate, ViewProviderComponentData };
 
 /**
  * Native module event names
@@ -121,6 +123,11 @@ class AgentforceService {
    * Subscription for navigation request events
    */
   private navigationSubscription: EmitterSubscription | null = null;
+
+  /**
+   * View provider delegate configuration (registered component types + React component name)
+   */
+  private viewProviderDelegate: ViewProviderDelegate | null = null;
 
   /**
    * Track if service has been initialized
@@ -257,6 +264,64 @@ class AgentforceService {
         this.navigationDelegate?.onNavigate(event);
       },
     );
+  }
+
+  /**
+   * Register a view provider delegate to override native SDK output views
+   * with custom React Native components.
+   *
+   * Must be called before `configure()` so the native provider is attached
+   * at SDK initialization time.
+   *
+   * @param delegate - View provider delegate configuration
+   *
+   * @example
+   * ```typescript
+   * AgentforceService.setViewProviderDelegate({
+   *   componentTypes: ['copilot/richText', 'copilot/markdown'],
+   *   reactComponentName: 'CustomAgentforceView',
+   * });
+   * ```
+   */
+  async setViewProviderDelegate(delegate: ViewProviderDelegate): Promise<void> {
+    this.viewProviderDelegate = delegate;
+
+    if (!AgentforceModule?.registerViewProvider) {
+      console.warn('[AgentforceService] registerViewProvider not available on native module');
+      return;
+    }
+
+    try {
+      await AgentforceModule.registerViewProvider({
+        componentTypes: delegate.componentTypes,
+        reactComponentName: delegate.reactComponentName,
+      });
+      console.log(
+        `[AgentforceService] View provider registered for ${delegate.componentTypes.length} types`,
+      );
+    } catch (error) {
+      console.error('[AgentforceService] Failed to register view provider:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Clear the registered view provider delegate.
+   * After clearing, the native SDK will render its built-in views for all types.
+   */
+  async clearViewProviderDelegate(): Promise<void> {
+    this.viewProviderDelegate = null;
+
+    if (!AgentforceModule?.clearViewProvider) {
+      return;
+    }
+
+    try {
+      await AgentforceModule.clearViewProvider();
+      console.log('[AgentforceService] View provider delegate cleared');
+    } catch (error) {
+      console.warn('[AgentforceService] Failed to clear view provider:', error);
+    }
   }
 
   /**
@@ -808,6 +873,8 @@ class AgentforceService {
     this.navigationSubscription?.remove();
     this.navigationSubscription = null;
     this.navigationDelegate = null;
+
+    this.viewProviderDelegate = null;
 
     this.eventEmitter = null;
     this.initialized = false;

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -32,7 +32,7 @@ import type {
   AgentforceContextVariable,
   AgentforceContextVariableType,
 } from '../types/AgentforceContext';
-import { ViewProviderDelegate, ViewProviderComponentData } from '../types/ViewProviderDelegate';
+import { ViewProviderDelegate } from '../types/ViewProviderDelegate';
 
 const { AgentforceModule } = NativeModules;
 
@@ -41,7 +41,7 @@ export type { ServiceAgentConfig, EmployeeAgentConfig, AgentConfig, FeatureFlags
 export type { LoggerDelegate, LogLevel };
 export type { NavigationDelegate, NavigationRequest };
 export type { AgentforceAdditionalContext, AgentforceContextVariable };
-export type { ViewProviderDelegate, ViewProviderComponentData };
+export type { ViewProviderDelegate };
 
 /**
  * Native module event names
@@ -398,6 +398,19 @@ class AgentforceService {
       console.log(
         `[AgentforceService] Configured successfully (mode: ${configWithFlags.type})`,
       );
+
+      // Re-register the view provider if one was set before this configure() call,
+      // since the native client was recreated and lost the previous registration.
+      if (this.viewProviderDelegate) {
+        try {
+          await AgentforceModule.registerViewProvider({
+            componentMap: this.viewProviderDelegate.componentMap,
+          });
+        } catch (err) {
+          console.warn('[AgentforceService] Failed to re-register view provider after configure:', err);
+        }
+      }
+
       return result?.success ?? true;
     } catch (error) {
       console.error('[AgentforceService] Configuration failed:', error);
@@ -875,6 +888,10 @@ class AgentforceService {
     this.navigationSubscription = null;
     this.navigationDelegate = null;
 
+    // Clear native view provider registration before nulling the JS reference
+    if (this.viewProviderDelegate) {
+      this.clearViewProviderDelegate().catch(() => {});
+    }
     this.viewProviderDelegate = null;
 
     this.eventEmitter = null;


### PR DESCRIPTION
## Stack: viewprovider (PR 4 of 6)

| # | PR | Status |
|---|-----|--------|
|   1 | [#43 add viewprovider types and enablecustomviewprovider feature flag](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/43) | Open |
|   2 | [#44 ios viewprovider bridge](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/44) | Open |
|   3 | [#45 android viewprovider bridge](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/45) | Open |
| > 4 | [#46 js viewprovider service](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/46) | Open |
|   5 | [#47 settings toggle](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/47) | Open |
|   6 | [#48 example usage](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/48) | Open |

---

## Summary
- Adds `setViewProviderDelegate(delegate)` to register React Native component types with native SDK
- Adds `clearViewProviderDelegate()` to remove registration
- Calls `registerViewProvider` / `clearViewProvider` native methods
- Cleans up delegate reference in `destroy()`
## Stack
PR 4/6 in the `viewprovider` stack.
## Test plan
- [ ] `setViewProviderDelegate` calls native registerViewProvider
- [ ] `clearViewProviderDelegate` calls native clearViewProvider
- [ ] destroy() clears the delegate reference
- [ ] Graceful fallback when native methods are unavailable