### PR TITLE
Add Custom View Provider toggle to Settings feature flags

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -45,6 +45,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         private const val KEY_ENABLE_MULTI_MODAL_INPUT = "enableMultiModalInput"
         private const val KEY_ENABLE_PDF_UPLOAD = "enablePDFUpload"
         private const val KEY_ENABLE_VOICE = "enableVoice"
+        private const val KEY_ENABLE_CUSTOM_VIEW_PROVIDER = "enableCustomViewProvider"
     }
 
     private val employeePrefs: SharedPreferences
@@ -443,7 +444,8 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         val enableMultiAgent: Boolean,
         val enableMultiModalInput: Boolean,
         val enablePDFUpload: Boolean,
-        val enableVoice: Boolean
+        val enableVoice: Boolean,
+        val enableCustomViewProvider: Boolean
     )
 
     private fun getFeatureFlagsFromConfigOrPrefs(config: ReadableMap): FeatureFlags {
@@ -453,14 +455,16 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                 enableMultiAgent = featureFlagsMap.hasKey("enableMultiAgent") && featureFlagsMap.getBoolean("enableMultiAgent"),
                 enableMultiModalInput = featureFlagsMap.hasKey("enableMultiModalInput") && featureFlagsMap.getBoolean("enableMultiModalInput"),
                 enablePDFUpload = featureFlagsMap.hasKey("enablePDFUpload") && featureFlagsMap.getBoolean("enablePDFUpload"),
-                enableVoice = featureFlagsMap.hasKey("enableVoice") && featureFlagsMap.getBoolean("enableVoice")
+                enableVoice = featureFlagsMap.hasKey("enableVoice") && featureFlagsMap.getBoolean("enableVoice"),
+                enableCustomViewProvider = featureFlagsMap.hasKey("enableCustomViewProvider") && featureFlagsMap.getBoolean("enableCustomViewProvider")
             )
         } else {
             FeatureFlags(
                 enableMultiAgent = featureFlagsPrefs.getBoolean(KEY_ENABLE_MULTI_AGENT, true),
                 enableMultiModalInput = featureFlagsPrefs.getBoolean(KEY_ENABLE_MULTI_MODAL_INPUT, false),
                 enablePDFUpload = featureFlagsPrefs.getBoolean(KEY_ENABLE_PDF_UPLOAD, false),
-                enableVoice = featureFlagsPrefs.getBoolean(KEY_ENABLE_VOICE, false)
+                enableVoice = featureFlagsPrefs.getBoolean(KEY_ENABLE_VOICE, false),
+                enableCustomViewProvider = featureFlagsPrefs.getBoolean(KEY_ENABLE_CUSTOM_VIEW_PROVIDER, false)
             )
         }
     }
@@ -471,6 +475,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             .putBoolean(KEY_ENABLE_MULTI_MODAL_INPUT, flags.enableMultiModalInput)
             .putBoolean(KEY_ENABLE_PDF_UPLOAD, flags.enablePDFUpload)
             .putBoolean(KEY_ENABLE_VOICE, flags.enableVoice)
+            .putBoolean(KEY_ENABLE_CUSTOM_VIEW_PROVIDER, flags.enableCustomViewProvider)
             .apply()
     }
 
@@ -481,6 +486,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             putBoolean("enableMultiModalInput", featureFlagsPrefs.getBoolean(KEY_ENABLE_MULTI_MODAL_INPUT, false))
             putBoolean("enablePDFUpload", featureFlagsPrefs.getBoolean(KEY_ENABLE_PDF_UPLOAD, false))
             putBoolean("enableVoice", featureFlagsPrefs.getBoolean(KEY_ENABLE_VOICE, false))
+            putBoolean("enableCustomViewProvider", featureFlagsPrefs.getBoolean(KEY_ENABLE_CUSTOM_VIEW_PROVIDER, false))
         })
     }
 
@@ -491,6 +497,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             .putBoolean(KEY_ENABLE_MULTI_MODAL_INPUT, flags.hasKey("enableMultiModalInput") && flags.getBoolean("enableMultiModalInput"))
             .putBoolean(KEY_ENABLE_PDF_UPLOAD, flags.hasKey("enablePDFUpload") && flags.getBoolean("enablePDFUpload"))
             .putBoolean(KEY_ENABLE_VOICE, flags.hasKey("enableVoice") && flags.getBoolean("enableVoice"))
+            .putBoolean(KEY_ENABLE_CUSTOM_VIEW_PROVIDER, flags.hasKey("enableCustomViewProvider") && flags.getBoolean("enableCustomViewProvider"))
             .apply()
         promise.resolve(null)
     }

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -45,6 +45,8 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         private const val KEY_ENABLE_MULTI_MODAL_INPUT = "enableMultiModalInput"
         private const val KEY_ENABLE_PDF_UPLOAD = "enablePDFUpload"
         private const val KEY_ENABLE_VOICE = "enableVoice"
+        // Advisory only — gating is done on the JS side (HomeScreen checks this flag
+        // before calling setViewProviderDelegate). The native layer does not gate on it.
         private const val KEY_ENABLE_CUSTOM_VIEW_PROVIDER = "enableCustomViewProvider"
     }
 

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -55,6 +55,7 @@ const FLAG_KEYS: (keyof FeatureFlags)[] = [
   'enableMultiModalInput',
   'enablePDFUpload',
   'enableVoice',
+  'enableCustomViewProvider',
 ];
 
 const FLAG_LABELS: Record<keyof FeatureFlags, string> = {
@@ -62,6 +63,7 @@ const FLAG_LABELS: Record<keyof FeatureFlags, string> = {
   enableMultiModalInput: 'Multi-modal input',
   enablePDFUpload: 'PDF upload',
   enableVoice: 'Voice',
+  enableCustomViewProvider: 'Custom View Provider',
 };
 
 const FLAG_HINTS: Record<keyof FeatureFlags, string> = {
@@ -69,6 +71,7 @@ const FLAG_HINTS: Record<keyof FeatureFlags, string> = {
   enableMultiModalInput: 'Enable image/file input in addition to text',
   enablePDFUpload: 'Allow PDF file uploads',
   enableVoice: 'Enable immersive voice',
+  enableCustomViewProvider: 'Override SDK output views with React Native components',
 };
 
 interface SettingsScreenProps {
@@ -289,6 +292,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         enableMultiModalInput: false,
         enablePDFUpload: false,
         enableVoice: false,
+        enableCustomViewProvider: false,
       });
     }
   };


### PR DESCRIPTION
## Stack: viewprovider (PR 5 of 6)

| # | PR | Status |
|---|-----|--------|
|   1 | [#43 add viewprovider types and enablecustomviewprovider feature flag](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/43) | Open |
|   2 | [#44 ios viewprovider bridge](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/44) | Open |
|   3 | [#45 android viewprovider bridge](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/45) | Open |
|   4 | [#46 js viewprovider service](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/46) | Open |
| > 5 | [#47 settings toggle](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/47) | Open |
|   6 | [#48 example usage](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/48) | Open |

---

## Summary
- Adds `enableCustomViewProvider` toggle to the Feature Flags tab in Settings
- Persists the flag via UserDefaults (iOS) and SharedPreferences (Android)
- Reads/writes in `getFeatureFlags`, `setFeatureFlags`, and `configure` paths on both platforms
## Stack
PR 5/6 in the `viewprovider` stack.
## Test plan
- [ ] New "Custom View Provider" toggle appears in Settings > Flags tab
- [ ] Toggle persists across app restarts
- [ ] Flag value flows through to native configure() calls
- [ ] Default is off (false)