### PR TITLE
Add example CustomAgentforceView and wire ViewProvider in HomeScreen

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,5 +27,9 @@
 import 'react-native-gesture-handler';
 import { AppRegistry } from 'react-native';
 import App from './App';
+import CustomAgentforceView from './src/components/CustomAgentforceView';
 
 AppRegistry.registerComponent('ReactAgentforce', () => App);
+
+// Register the custom view provider component so native can render it via RCTRootView/ReactRootView
+AppRegistry.registerComponent('CustomAgentforceView', () => CustomAgentforceView);

--- a/src/components/ComplexAgentforceDataView.tsx
+++ b/src/components/ComplexAgentforceDataView.tsx
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
+ *
+ * A richer custom view provider component that renders nested objects and
+ * arrays as expandable key/value tables. Drop-in replacement for
+ * CustomAgentforceView when you need structured data display.
+ *
+ * Wire up the same way as CustomAgentforceView — see that file for the
+ * 3-step ViewProvider integration guide.
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import type { ViewProviderComponentData } from 'react-native-agentforce';
+
+interface ComplexAgentforceDataViewProps {
+  definition?: string;
+  name?: string;
+  properties?: Record<string, unknown>;
+  subComponents?: ViewProviderComponentData[];
+}
+
+/** Max nesting depth to prevent runaway recursion. */
+const MAX_DEPTH = 6;
+
+/** Check whether a value is a plain object (not an array). */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/** Format a leaf value as a string. */
+function formatLeaf(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  return String(value);
+}
+
+/** Whether a value will render as a nested block (table or array). */
+function isNestedValue(v: unknown, depth: number): boolean {
+  if (depth >= MAX_DEPTH) return false;
+  if (isPlainObject(v)) return Object.keys(v).length > 0;
+  if (Array.isArray(v)) return v.length > 0;
+  return false;
+}
+
+/**
+ * Recursively renders a value. Plain objects become nested key/value tables,
+ * arrays render each element, and primitives render as text.
+ */
+const ValueRenderer: React.FC<{ value: unknown; depth: number }> = ({
+  value,
+  depth,
+}) => {
+  const compact = depth >= 3; // tighter padding at deeper levels
+
+  if (isPlainObject(value) && depth < MAX_DEPTH) {
+    const entries = Object.entries(value);
+    if (entries.length === 0) return <Text style={styles.emptyText}>{'{ }'}</Text>;
+    return (
+      <View style={[styles.nestedTable, compact && styles.nestedTableCompact]}>
+        {entries.map(([k, v], i) => (
+          <PropertyRow key={k} label={k} value={v} depth={depth} isLast={i === entries.length - 1} />
+        ))}
+      </View>
+    );
+  }
+
+  if (Array.isArray(value) && depth < MAX_DEPTH) {
+    if (value.length === 0) return <Text style={styles.emptyText}>{'[ ]'}</Text>;
+    return (
+      <View style={[styles.nestedArray, compact && styles.nestedTableCompact]}>
+        {value.map((item, i) => {
+          const itemNested = isNestedValue(item, depth + 1);
+          return (
+            <View
+              key={i}
+              style={[
+                itemNested ? styles.arrayItemVertical : styles.arrayItem,
+                i < value.length - 1 && styles.arrayItemBorder,
+              ]}
+            >
+              <Text style={styles.arrayIndex}>{i}</Text>
+              <View style={itemNested ? undefined : styles.arrayValue}>
+                <ValueRenderer value={item} depth={depth + 1} />
+              </View>
+            </View>
+          );
+        })}
+      </View>
+    );
+  }
+
+  // Leaf value (or max depth reached — fall back to JSON)
+  const text =
+    depth >= MAX_DEPTH && typeof value === 'object'
+      ? JSON.stringify(value)
+      : formatLeaf(value);
+
+  return (
+    <Text style={styles.rowValue} selectable>
+      {text}
+    </Text>
+  );
+};
+
+/**
+ * Renders a single key/value row, stacking vertically when the value is a
+ * nested object/array so it can use the full width.
+ */
+const PropertyRow: React.FC<{
+  label: string;
+  value: unknown;
+  depth: number;
+  isLast: boolean;
+}> = ({ label, value, depth, isLast }) => {
+  const nested = isNestedValue(value, depth + 1);
+  const compact = depth >= 2;
+
+  return (
+    <View
+      style={[
+        nested ? styles.rowVertical : styles.row,
+        compact && styles.rowCompact,
+        !isLast && styles.rowBorder,
+      ]}
+    >
+      <Text
+        style={[styles.rowKey, compact && styles.rowKeyCompact]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+      <ValueRenderer value={value} depth={depth + 1} />
+    </View>
+  );
+};
+
+const ComplexAgentforceDataView: React.FC<ComplexAgentforceDataViewProps> = ({
+  definition = 'unknown',
+  properties = {},
+}) => {
+  const entries = Object.entries(properties);
+
+  // If the only meaningful property is a single text-like value, show it inline
+  const textKeys = ['text', 'value', 'content', 'label'];
+  const singleText =
+    entries.length === 1 &&
+    textKeys.includes(entries[0][0]) &&
+    typeof entries[0][1] === 'string'
+      ? (entries[0][1] as string)
+      : null;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <View style={styles.badge}>
+          <Text style={styles.badgeText}>Custom RN View</Text>
+        </View>
+        <Text style={styles.definitionText}>{definition}</Text>
+      </View>
+
+      {singleText ? (
+        <Text style={styles.contentText} selectable>
+          {singleText}
+        </Text>
+      ) : entries.length > 0 ? (
+        <ScrollView style={styles.contentScroll} nestedScrollEnabled>
+          <View style={styles.table}>
+            {entries.map(([key, val], idx) => (
+              <PropertyRow
+                key={key}
+                label={key}
+                value={val}
+                depth={0}
+                isLast={idx === entries.length - 1}
+              />
+            ))}
+          </View>
+        </ScrollView>
+      ) : (
+        <Text style={styles.emptyText}>No properties</Text>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#f0f4ff',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#4a90d9',
+    padding: 12,
+    margin: 4,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+    gap: 8,
+  },
+  badge: {
+    backgroundColor: '#4a90d9',
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  badgeText: {
+    color: '#ffffff',
+    fontSize: 10,
+    fontWeight: '700',
+  },
+  definitionText: {
+    fontSize: 11,
+    color: '#6c757d',
+    fontFamily: 'monospace',
+  },
+  contentScroll: {
+    maxHeight: 400,
+  },
+  table: {
+    backgroundColor: '#ffffff',
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#d0d7e2',
+    overflow: 'hidden',
+  },
+  row: {
+    flexDirection: 'row',
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+  },
+  rowVertical: {
+    flexDirection: 'column',
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    gap: 4,
+  },
+  rowCompact: {
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+  },
+  rowBorder: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#d0d7e2',
+  },
+  rowKey: {
+    width: 100,
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#4a5568',
+    marginRight: 8,
+  },
+  rowKeyCompact: {
+    width: 80,
+    fontSize: 11,
+  },
+  rowValue: {
+    flex: 1,
+    fontSize: 13,
+    color: '#212529',
+    lineHeight: 18,
+  },
+  nestedTable: {
+    backgroundColor: '#f8f9fb',
+    borderRadius: 4,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#d0d7e2',
+    overflow: 'hidden',
+  },
+  nestedTableCompact: {
+    borderRadius: 3,
+  },
+  nestedArray: {
+    backgroundColor: '#f8f9fb',
+    borderRadius: 4,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#d0d7e2',
+    overflow: 'hidden',
+  },
+  arrayItem: {
+    flexDirection: 'row',
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+  },
+  arrayItemVertical: {
+    flexDirection: 'column',
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    gap: 4,
+  },
+  arrayItemBorder: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#d0d7e2',
+  },
+  arrayIndex: {
+    width: 24,
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#9ca3af',
+    marginRight: 4,
+  },
+  arrayValue: {
+    flex: 1,
+  },
+  contentText: {
+    fontSize: 14,
+    color: '#212529',
+    lineHeight: 20,
+  },
+  emptyText: {
+    fontSize: 12,
+    color: '#9ca3af',
+    fontStyle: 'italic',
+  },
+});
+
+export default ComplexAgentforceDataView;

--- a/src/components/CustomAgentforceView.tsx
+++ b/src/components/CustomAgentforceView.tsx
@@ -3,18 +3,25 @@
  *
  * Example custom view provider component for Agentforce SDK.
  *
- * When the Custom View Provider feature flag is enabled and this component
- * is registered, the native SDK delegates rendering of specified component
- * types to this React Native view instead of the built-in native views.
+ * HOW VIEW PROVIDER WIRING WORKS (3 steps):
  *
- * Register with AppRegistry and configure via AgentforceService:
- *   AppRegistry.registerComponent('CustomAgentforceView', () => CustomAgentforceView);
- *   AgentforceService.setViewProviderDelegate({
- *     componentMap: {
- *       'copilot/richText': 'CustomAgentforceView',
- *       'copilot/markdown': 'CustomAgentforceView',
- *     },
- *   });
+ * 1. Register this component with AppRegistry (see index.js):
+ *      AppRegistry.registerComponent('CustomAgentforceView', () => CustomAgentforceView);
+ *
+ * 2. Tell the SDK which component types to delegate (see HomeScreen.tsx):
+ *      AgentforceService.setViewProviderDelegate({
+ *        componentMap: {
+ *          'copilot/richText': 'CustomAgentforceView',
+ *          'copilot/markdown': 'CustomAgentforceView',
+ *        },
+ *      });
+ *
+ * 3. This component receives ViewProviderComponentData as props (below).
+ *    The native SDK calls canHandle(definition) → true, then renders a
+ *    RCTRootView / ReactRootView with the matching component name.
+ *
+ * Everything below the props interface is example rendering logic — replace
+ * it with your own UI. The only requirement is accepting the props shape.
  */
 
 import React from 'react';
@@ -31,6 +38,11 @@ interface CustomAgentforceViewProps {
   properties?: Record<string, unknown>;
   subComponents?: ViewProviderComponentData[];
 }
+
+// ---------------------------------------------------------------------------
+// Rendering helpers below — this is example UI, not part of the ViewProvider
+// integration. Replace with your own rendering logic.
+// ---------------------------------------------------------------------------
 
 /** Max nesting depth to prevent runaway recursion. */
 const MAX_DEPTH = 6;

--- a/src/components/CustomAgentforceView.tsx
+++ b/src/components/CustomAgentforceView.tsx
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
  *
- * Example custom view provider component for Agentforce SDK.
+ * Minimal custom view provider component for Agentforce SDK.
  *
  * HOW VIEW PROVIDER WIRING WORKS (3 steps):
  *
@@ -17,21 +17,17 @@
  *      });
  *
  * 3. This component receives ViewProviderComponentData as props (below).
- *    The native SDK calls canHandle(definition) → true, then renders a
+ *    The native SDK calls canHandle(definition) -> true, then renders a
  *    RCTRootView / ReactRootView with the matching component name.
  *
- * Everything below the props interface is example rendering logic — replace
- * it with your own UI. The only requirement is accepting the props shape.
+ * For a richer version with nested key/value tables, see ComplexAgentforceDataView.
  */
 
 import React from 'react';
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import type { ViewProviderComponentData } from 'react-native-agentforce';
 
-/**
- * Props passed from the native BridgeViewProvider via RCTRootView / ReactRootView.
- * Matches the ViewProviderComponentData type.
- */
+/** Props passed from the native BridgeViewProvider via RCTRootView / ReactRootView. */
 interface CustomAgentforceViewProps {
   definition?: string;
   name?: string;
@@ -39,142 +35,10 @@ interface CustomAgentforceViewProps {
   subComponents?: ViewProviderComponentData[];
 }
 
-// ---------------------------------------------------------------------------
-// Rendering helpers below — this is example UI, not part of the ViewProvider
-// integration. Replace with your own rendering logic.
-// ---------------------------------------------------------------------------
-
-/** Max nesting depth to prevent runaway recursion. */
-const MAX_DEPTH = 6;
-
-/** Check whether a value is a plain object (not an array). */
-function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return v !== null && typeof v === 'object' && !Array.isArray(v);
-}
-
-/** Format a leaf value as a string. */
-function formatLeaf(value: unknown): string {
-  if (value === null || value === undefined) return '—';
-  if (typeof value === 'string') return value;
-  if (typeof value === 'boolean') return value ? 'true' : 'false';
-  return String(value);
-}
-
-/** Whether a value will render as a nested block (table or array). */
-function isNestedValue(v: unknown, depth: number): boolean {
-  if (depth >= MAX_DEPTH) return false;
-  if (isPlainObject(v)) return Object.keys(v).length > 0;
-  if (Array.isArray(v)) return v.length > 0;
-  return false;
-}
-
-/**
- * Recursively renders a value. Plain objects become nested key/value tables,
- * arrays render each element, and primitives render as text.
- */
-const ValueRenderer: React.FC<{ value: unknown; depth: number }> = ({
-  value,
-  depth,
-}) => {
-  const compact = depth >= 3; // tighter padding at deeper levels
-
-  if (isPlainObject(value) && depth < MAX_DEPTH) {
-    const entries = Object.entries(value);
-    if (entries.length === 0) return <Text style={styles.emptyText}>{'{ }'}</Text>;
-    return (
-      <View style={[styles.nestedTable, compact && styles.nestedTableCompact]}>
-        {entries.map(([k, v], i) => (
-          <PropertyRow key={k} label={k} value={v} depth={depth} isLast={i === entries.length - 1} />
-        ))}
-      </View>
-    );
-  }
-
-  if (Array.isArray(value) && depth < MAX_DEPTH) {
-    if (value.length === 0) return <Text style={styles.emptyText}>{'[ ]'}</Text>;
-    return (
-      <View style={[styles.nestedArray, compact && styles.nestedTableCompact]}>
-        {value.map((item, i) => {
-          const itemNested = isNestedValue(item, depth + 1);
-          return (
-            <View
-              key={i}
-              style={[
-                itemNested ? styles.arrayItemVertical : styles.arrayItem,
-                i < value.length - 1 && styles.arrayItemBorder,
-              ]}
-            >
-              <Text style={styles.arrayIndex}>{i}</Text>
-              <View style={itemNested ? undefined : styles.arrayValue}>
-                <ValueRenderer value={item} depth={depth + 1} />
-              </View>
-            </View>
-          );
-        })}
-      </View>
-    );
-  }
-
-  // Leaf value (or max depth reached — fall back to JSON)
-  const text =
-    depth >= MAX_DEPTH && typeof value === 'object'
-      ? JSON.stringify(value)
-      : formatLeaf(value);
-
-  return (
-    <Text style={styles.rowValue} selectable>
-      {text}
-    </Text>
-  );
-};
-
-/**
- * Renders a single key/value row, stacking vertically when the value is a
- * nested object/array so it can use the full width.
- */
-const PropertyRow: React.FC<{
-  label: string;
-  value: unknown;
-  depth: number;
-  isLast: boolean;
-}> = ({ label, value, depth, isLast }) => {
-  const nested = isNestedValue(value, depth + 1);
-  const compact = depth >= 2;
-
-  return (
-    <View
-      style={[
-        nested ? styles.rowVertical : styles.row,
-        compact && styles.rowCompact,
-        !isLast && styles.rowBorder,
-      ]}
-    >
-      <Text
-        style={[styles.rowKey, compact && styles.rowKeyCompact]}
-        numberOfLines={1}
-      >
-        {label}
-      </Text>
-      <ValueRenderer value={value} depth={depth + 1} />
-    </View>
-  );
-};
-
 const CustomAgentforceView: React.FC<CustomAgentforceViewProps> = ({
   definition = 'unknown',
   properties = {},
 }) => {
-  const entries = Object.entries(properties);
-
-  // If the only meaningful property is a single text-like value, show it inline
-  const textKeys = ['text', 'value', 'content', 'label'];
-  const singleText =
-    entries.length === 1 &&
-    textKeys.includes(entries[0][0]) &&
-    typeof entries[0][1] === 'string'
-      ? (entries[0][1] as string)
-      : null;
-
   return (
     <View style={styles.container}>
       <View style={styles.header}>
@@ -183,28 +47,9 @@ const CustomAgentforceView: React.FC<CustomAgentforceViewProps> = ({
         </View>
         <Text style={styles.definitionText}>{definition}</Text>
       </View>
-
-      {singleText ? (
-        <Text style={styles.contentText} selectable>
-          {singleText}
-        </Text>
-      ) : entries.length > 0 ? (
-        <ScrollView style={styles.contentScroll} nestedScrollEnabled>
-          <View style={styles.table}>
-            {entries.map(([key, val], idx) => (
-              <PropertyRow
-                key={key}
-                label={key}
-                value={val}
-                depth={0}
-                isLast={idx === entries.length - 1}
-              />
-            ))}
-          </View>
-        </ScrollView>
-      ) : (
-        <Text style={styles.emptyText}>No properties</Text>
-      )}
+      <Text style={styles.json} selectable>
+        {JSON.stringify(properties, null, 2)}
+      </Text>
     </View>
   );
 };
@@ -240,103 +85,11 @@ const styles = StyleSheet.create({
     color: '#6c757d',
     fontFamily: 'monospace',
   },
-  contentScroll: {
-    maxHeight: 400,
-  },
-  table: {
-    backgroundColor: '#ffffff',
-    borderRadius: 6,
-    borderWidth: 1,
-    borderColor: '#d0d7e2',
-    overflow: 'hidden',
-  },
-  row: {
-    flexDirection: 'row',
-    paddingVertical: 8,
-    paddingHorizontal: 10,
-  },
-  rowVertical: {
-    flexDirection: 'column',
-    paddingVertical: 8,
-    paddingHorizontal: 10,
-    gap: 4,
-  },
-  rowCompact: {
-    paddingVertical: 5,
-    paddingHorizontal: 8,
-  },
-  rowBorder: {
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#d0d7e2',
-  },
-  rowKey: {
-    width: 100,
+  json: {
     fontSize: 12,
-    fontWeight: '600',
-    color: '#4a5568',
-    marginRight: 8,
-  },
-  rowKeyCompact: {
-    width: 80,
-    fontSize: 11,
-  },
-  rowValue: {
-    flex: 1,
-    fontSize: 13,
     color: '#212529',
+    fontFamily: 'monospace',
     lineHeight: 18,
-  },
-  nestedTable: {
-    backgroundColor: '#f8f9fb',
-    borderRadius: 4,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: '#d0d7e2',
-    overflow: 'hidden',
-  },
-  nestedTableCompact: {
-    borderRadius: 3,
-  },
-  nestedArray: {
-    backgroundColor: '#f8f9fb',
-    borderRadius: 4,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: '#d0d7e2',
-    overflow: 'hidden',
-  },
-  arrayItem: {
-    flexDirection: 'row',
-    paddingVertical: 6,
-    paddingHorizontal: 8,
-  },
-  arrayItemVertical: {
-    flexDirection: 'column',
-    paddingVertical: 6,
-    paddingHorizontal: 8,
-    gap: 4,
-  },
-  arrayItemBorder: {
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#d0d7e2',
-  },
-  arrayIndex: {
-    width: 24,
-    fontSize: 11,
-    fontWeight: '600',
-    color: '#9ca3af',
-    marginRight: 4,
-  },
-  arrayValue: {
-    flex: 1,
-  },
-  contentText: {
-    fontSize: 14,
-    color: '#212529',
-    lineHeight: 20,
-  },
-  emptyText: {
-    fontSize: 12,
-    color: '#9ca3af',
-    fontStyle: 'italic',
   },
 });
 

--- a/src/components/CustomAgentforceView.tsx
+++ b/src/components/CustomAgentforceView.tsx
@@ -30,27 +30,167 @@ interface CustomAgentforceViewProps {
   subComponents?: ViewProviderComponentData[];
 }
 
+/** Max nesting depth to prevent runaway recursion. */
+const MAX_DEPTH = 6;
+
+/** Check whether a value is a plain object (not an array). */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/** Format a leaf value as a string. */
+function formatLeaf(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  return String(value);
+}
+
+/** Whether a value will render as a nested block (table or array). */
+function isNestedValue(v: unknown, depth: number): boolean {
+  if (depth >= MAX_DEPTH) return false;
+  if (isPlainObject(v)) return Object.keys(v).length > 0;
+  if (Array.isArray(v)) return v.length > 0;
+  return false;
+}
+
+/**
+ * Recursively renders a value. Plain objects become nested key/value tables,
+ * arrays render each element, and primitives render as text.
+ */
+const ValueRenderer: React.FC<{ value: unknown; depth: number }> = ({
+  value,
+  depth,
+}) => {
+  const compact = depth >= 3; // tighter padding at deeper levels
+
+  if (isPlainObject(value) && depth < MAX_DEPTH) {
+    const entries = Object.entries(value);
+    if (entries.length === 0) return <Text style={styles.emptyText}>{'{ }'}</Text>;
+    return (
+      <View style={[styles.nestedTable, compact && styles.nestedTableCompact]}>
+        {entries.map(([k, v], i) => (
+          <PropertyRow key={k} label={k} value={v} depth={depth} isLast={i === entries.length - 1} />
+        ))}
+      </View>
+    );
+  }
+
+  if (Array.isArray(value) && depth < MAX_DEPTH) {
+    if (value.length === 0) return <Text style={styles.emptyText}>{'[ ]'}</Text>;
+    return (
+      <View style={[styles.nestedArray, compact && styles.nestedTableCompact]}>
+        {value.map((item, i) => {
+          const itemNested = isNestedValue(item, depth + 1);
+          return (
+            <View
+              key={i}
+              style={[
+                itemNested ? styles.arrayItemVertical : styles.arrayItem,
+                i < value.length - 1 && styles.arrayItemBorder,
+              ]}
+            >
+              <Text style={styles.arrayIndex}>{i}</Text>
+              <View style={itemNested ? undefined : styles.arrayValue}>
+                <ValueRenderer value={item} depth={depth + 1} />
+              </View>
+            </View>
+          );
+        })}
+      </View>
+    );
+  }
+
+  // Leaf value (or max depth reached — fall back to JSON)
+  const text =
+    depth >= MAX_DEPTH && typeof value === 'object'
+      ? JSON.stringify(value)
+      : formatLeaf(value);
+
+  return (
+    <Text style={styles.rowValue} selectable>
+      {text}
+    </Text>
+  );
+};
+
+/**
+ * Renders a single key/value row, stacking vertically when the value is a
+ * nested object/array so it can use the full width.
+ */
+const PropertyRow: React.FC<{
+  label: string;
+  value: unknown;
+  depth: number;
+  isLast: boolean;
+}> = ({ label, value, depth, isLast }) => {
+  const nested = isNestedValue(value, depth + 1);
+  const compact = depth >= 2;
+
+  return (
+    <View
+      style={[
+        nested ? styles.rowVertical : styles.row,
+        compact && styles.rowCompact,
+        !isLast && styles.rowBorder,
+      ]}
+    >
+      <Text
+        style={[styles.rowKey, compact && styles.rowKeyCompact]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+      <ValueRenderer value={value} depth={depth + 1} />
+    </View>
+  );
+};
+
 const CustomAgentforceView: React.FC<CustomAgentforceViewProps> = ({
   definition = 'unknown',
   properties = {},
 }) => {
-  // Extract text content from common property patterns
-  const textContent =
-    (properties.text as string) ??
-    (properties.value as string) ??
-    (properties.content as string) ??
-    (properties.label as string) ??
-    JSON.stringify(properties, null, 2);
+  const entries = Object.entries(properties);
+
+  // If the only meaningful property is a single text-like value, show it inline
+  const textKeys = ['text', 'value', 'content', 'label'];
+  const singleText =
+    entries.length === 1 &&
+    textKeys.includes(entries[0][0]) &&
+    typeof entries[0][1] === 'string'
+      ? (entries[0][1] as string)
+      : null;
 
   return (
     <View style={styles.container}>
-      <View style={styles.badge}>
-        <Text style={styles.badgeText}>Custom RN View</Text>
+      <View style={styles.header}>
+        <View style={styles.badge}>
+          <Text style={styles.badgeText}>Custom RN View</Text>
+        </View>
+        <Text style={styles.definitionText}>{definition}</Text>
       </View>
-      <Text style={styles.definitionText}>{definition}</Text>
-      <ScrollView style={styles.contentScroll} nestedScrollEnabled>
-        <Text style={styles.contentText}>{textContent}</Text>
-      </ScrollView>
+
+      {singleText ? (
+        <Text style={styles.contentText} selectable>
+          {singleText}
+        </Text>
+      ) : entries.length > 0 ? (
+        <ScrollView style={styles.contentScroll} nestedScrollEnabled>
+          <View style={styles.table}>
+            {entries.map(([key, val], idx) => (
+              <PropertyRow
+                key={key}
+                label={key}
+                value={val}
+                depth={0}
+                isLast={idx === entries.length - 1}
+              />
+            ))}
+          </View>
+        </ScrollView>
+      ) : (
+        <Text style={styles.emptyText}>No properties</Text>
+      )}
     </View>
   );
 };
@@ -64,13 +204,17 @@ const styles = StyleSheet.create({
     padding: 12,
     margin: 4,
   },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+    gap: 8,
+  },
   badge: {
     backgroundColor: '#4a90d9',
     borderRadius: 4,
     paddingHorizontal: 8,
     paddingVertical: 2,
-    alignSelf: 'flex-start',
-    marginBottom: 6,
   },
   badgeText: {
     color: '#ffffff',
@@ -80,16 +224,105 @@ const styles = StyleSheet.create({
   definitionText: {
     fontSize: 11,
     color: '#6c757d',
-    marginBottom: 4,
     fontFamily: 'monospace',
   },
   contentScroll: {
-    maxHeight: 200,
+    maxHeight: 400,
+  },
+  table: {
+    backgroundColor: '#ffffff',
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#d0d7e2',
+    overflow: 'hidden',
+  },
+  row: {
+    flexDirection: 'row',
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+  },
+  rowVertical: {
+    flexDirection: 'column',
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    gap: 4,
+  },
+  rowCompact: {
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+  },
+  rowBorder: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#d0d7e2',
+  },
+  rowKey: {
+    width: 100,
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#4a5568',
+    marginRight: 8,
+  },
+  rowKeyCompact: {
+    width: 80,
+    fontSize: 11,
+  },
+  rowValue: {
+    flex: 1,
+    fontSize: 13,
+    color: '#212529',
+    lineHeight: 18,
+  },
+  nestedTable: {
+    backgroundColor: '#f8f9fb',
+    borderRadius: 4,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#d0d7e2',
+    overflow: 'hidden',
+  },
+  nestedTableCompact: {
+    borderRadius: 3,
+  },
+  nestedArray: {
+    backgroundColor: '#f8f9fb',
+    borderRadius: 4,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#d0d7e2',
+    overflow: 'hidden',
+  },
+  arrayItem: {
+    flexDirection: 'row',
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+  },
+  arrayItemVertical: {
+    flexDirection: 'column',
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    gap: 4,
+  },
+  arrayItemBorder: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#d0d7e2',
+  },
+  arrayIndex: {
+    width: 24,
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#9ca3af',
+    marginRight: 4,
+  },
+  arrayValue: {
+    flex: 1,
   },
   contentText: {
     fontSize: 14,
     color: '#212529',
     lineHeight: 20,
+  },
+  emptyText: {
+    fontSize: 12,
+    color: '#9ca3af',
+    fontStyle: 'italic',
   },
 });
 

--- a/src/components/CustomAgentforceView.tsx
+++ b/src/components/CustomAgentforceView.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
+ *
+ * Example custom view provider component for Agentforce SDK.
+ *
+ * When the Custom View Provider feature flag is enabled and this component
+ * is registered, the native SDK delegates rendering of specified component
+ * types to this React Native view instead of the built-in native views.
+ *
+ * Register with AppRegistry and configure via AgentforceService:
+ *   AppRegistry.registerComponent('CustomAgentforceView', () => CustomAgentforceView);
+ *   AgentforceService.setViewProviderDelegate({
+ *     componentTypes: ['copilot/richText', 'copilot/markdown'],
+ *     reactComponentName: 'CustomAgentforceView',
+ *   });
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import type { ViewProviderComponentData } from 'react-native-agentforce';
+
+/**
+ * Props passed from the native BridgeViewProvider via RCTRootView / ReactRootView.
+ * Matches the ViewProviderComponentData type.
+ */
+interface CustomAgentforceViewProps {
+  definition?: string;
+  name?: string;
+  properties?: Record<string, unknown>;
+  subComponents?: ViewProviderComponentData[];
+}
+
+const CustomAgentforceView: React.FC<CustomAgentforceViewProps> = ({
+  definition = 'unknown',
+  properties = {},
+}) => {
+  // Extract text content from common property patterns
+  const textContent =
+    (properties.text as string) ??
+    (properties.value as string) ??
+    (properties.content as string) ??
+    (properties.label as string) ??
+    JSON.stringify(properties, null, 2);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.badge}>
+        <Text style={styles.badgeText}>Custom RN View</Text>
+      </View>
+      <Text style={styles.definitionText}>{definition}</Text>
+      <ScrollView style={styles.contentScroll} nestedScrollEnabled>
+        <Text style={styles.contentText}>{textContent}</Text>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#f0f4ff',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#4a90d9',
+    padding: 12,
+    margin: 4,
+  },
+  badge: {
+    backgroundColor: '#4a90d9',
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    alignSelf: 'flex-start',
+    marginBottom: 6,
+  },
+  badgeText: {
+    color: '#ffffff',
+    fontSize: 10,
+    fontWeight: '700',
+  },
+  definitionText: {
+    fontSize: 11,
+    color: '#6c757d',
+    marginBottom: 4,
+    fontFamily: 'monospace',
+  },
+  contentScroll: {
+    maxHeight: 200,
+  },
+  contentText: {
+    fontSize: 14,
+    color: '#212529',
+    lineHeight: 20,
+  },
+});
+
+export default CustomAgentforceView;

--- a/src/components/CustomAgentforceView.tsx
+++ b/src/components/CustomAgentforceView.tsx
@@ -10,8 +10,10 @@
  * Register with AppRegistry and configure via AgentforceService:
  *   AppRegistry.registerComponent('CustomAgentforceView', () => CustomAgentforceView);
  *   AgentforceService.setViewProviderDelegate({
- *     componentTypes: ['copilot/richText', 'copilot/markdown'],
- *     reactComponentName: 'CustomAgentforceView',
+ *     componentMap: {
+ *       'copilot/richText': 'CustomAgentforceView',
+ *       'copilot/markdown': 'CustomAgentforceView',
+ *     },
  *   });
  */
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -119,8 +119,10 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
       const flags = await AgentforceService.getFeatureFlags();
       if (flags.enableCustomViewProvider) {
         await AgentforceService.setViewProviderDelegate({
-          componentTypes: ['copilot/richText', 'copilot/markdown'],
-          reactComponentName: 'CustomAgentforceView',
+          componentMap: {
+            'copilot/richText': 'CustomAgentforceView',
+            'copilot/markdown': 'CustomAgentforceView',
+          },
         });
       }
     } catch (error) {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -96,9 +96,13 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
     AgentforceService.setLoggerDelegate(agentforceLogger);
     // Register navigation delegate so SDK navigation requests are forwarded to JS
     AgentforceService.setNavigationDelegate(agentforceNavigation);
-    // Register custom view provider if enabled via feature flag
-    registerViewProviderIfEnabled();
-    checkConfigurations();
+    // Register custom view provider if enabled, then check configurations.
+    // Sequential to avoid a race where configure() runs before registration completes.
+    const init = async () => {
+      await registerViewProviderIfEnabled();
+      checkConfigurations();
+    };
+    init();
 
     return () => {
       AgentforceService.clearLoggerDelegate();

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -96,11 +96,14 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
     AgentforceService.setLoggerDelegate(agentforceLogger);
     // Register navigation delegate so SDK navigation requests are forwarded to JS
     AgentforceService.setNavigationDelegate(agentforceNavigation);
+    // Register custom view provider if enabled via feature flag
+    registerViewProviderIfEnabled();
     checkConfigurations();
 
     return () => {
       AgentforceService.clearLoggerDelegate();
       AgentforceService.clearNavigationDelegate();
+      AgentforceService.clearViewProviderDelegate();
     };
   }, []);
 
@@ -110,6 +113,20 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
     });
     return unsubscribe;
   }, [navigation]);
+
+  const registerViewProviderIfEnabled = async () => {
+    try {
+      const flags = await AgentforceService.getFeatureFlags();
+      if (flags.enableCustomViewProvider) {
+        await AgentforceService.setViewProviderDelegate({
+          componentTypes: ['copilot/richText', 'copilot/markdown'],
+          reactComponentName: 'CustomAgentforceView',
+        });
+      }
+    } catch (error) {
+      console.warn('Failed to register view provider:', error);
+    }
+  };
 
   const checkConfigurations = async () => {
     setIsChecking(true);


### PR DESCRIPTION
## Stack: viewprovider (PR 6 of 6)

| # | PR | Status |
|---|-----|--------|
|   1 | [#43 add viewprovider types and enablecustomviewprovider feature flag](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/43) | Open |
|   2 | [#44 ios viewprovider bridge](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/44) | Open |
|   3 | [#45 android viewprovider bridge](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/45) | Open |
|   4 | [#46 js viewprovider service](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/46) | Open |
|   5 | [#47 settings toggle](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/47) | Open |
| > 6 | [#48 example usage](https://github.com/salesforce/AgentforceMobileSDK-ReactNative/pull/48) | Open |

---

## Summary
- Creates `CustomAgentforceView` React Native component that renders in place of native SDK views
- Registers it via `AppRegistry.registerComponent()` in `index.js`
- HomeScreen checks `enableCustomViewProvider` feature flag on mount
- When enabled, registers the delegate for `copilot/richText` and `copilot/markdown` types
- Cleans up on unmount via `clearViewProviderDelegate()`
## Stack
PR 6/6 (final) in the `viewprovider` stack.
## Test plan
- [ ] With "Custom View Provider" flag OFF: conversation renders native SDK views (no change)
- [ ] With flag ON: `copilot/richText` and `copilot/markdown` components render as React Native views with blue "Custom RN View" badge
- [ ] Custom view receives `definition` and `properties` props from native
- [ ] Toggling the flag and relaunching conversation switches between native and custom views
## How to test end-to-end
1. Launch the app
2. Go to Settings > Flags > enable "Custom View Provider"
3. Configure and launch a conversation
4. Agent responses containing rich text or markdown should render with the blue "Custom RN View" badge