### PR TITLE
@W-21447618: [React Native Bridge - iOS] Add hiddenPreChatFieldDelegate support

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -74,6 +74,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     // Bridge view provider for delegating native SDK views to React Native components
     private val bridgeViewProvider = BridgeViewProvider(reactContext)
 
+    // Bridge hidden prechat fields (Service Agent only)
+    private val bridgeHiddenPreChat = BridgeHiddenPreChat()
+
     // Coroutine scope for async operations
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
@@ -616,6 +619,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         currentMode = null
         credentialProvider.reset()
         bridgeViewProvider.reset()
+        bridgeHiddenPreChat.setFields(emptyMap())
         employeePrefs.edit().remove(KEY_EMPLOYEE_AGENT_ID).apply()
         promise.resolve(Arguments.createMap().apply {
             putBoolean("success", true)
@@ -625,6 +629,38 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     // endregion
 
     // region Event Emitter Support
+    // endregion
+
+    // region Hidden PreChat Fields
+
+    /**
+     * Pre-register hidden prechat field values for the next Service Agent session.
+     *
+     * TODO: Implement AgentforceHiddenPreChatFieldDelegate on BridgeHiddenPreChat
+     * and pass to client.init(hiddenPreChatFieldDelegate = bridgeHiddenPreChat).
+     * See iOS BridgeHiddenPreChat.swift for reference. Until then, fields are
+     * stored but not sent to the SDK.
+     */
+    @ReactMethod
+    fun registerHiddenPreChatFields(fields: ReadableMap, promise: Promise) {
+        val map = mutableMapOf<String, String>()
+        val iterator = fields.keySetIterator()
+        while (iterator.hasNextKey()) {
+            val key = iterator.nextKey()
+            fields.getString(key)?.let { map[key] = it }
+        }
+        bridgeHiddenPreChat.setFields(map)
+        promise.resolve(null)
+    }
+
+    @ReactMethod
+    fun getHiddenPreChatFields(promise: Promise) {
+        val result = Arguments.createMap()
+        for ((key, value) in bridgeHiddenPreChat.getFields()) {
+            result.putString(key, value)
+        }
+        promise.resolve(result)
+    }
     // endregion
 
     // region Additional Context

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeHiddenPreChat.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeHiddenPreChat.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+ *
+ * React Native bridge for hidden prechat field delegate
+ *
+ * TODO: Implement AgentforceHiddenPreChatFieldDelegate interface.
+ * See BridgeHiddenPreChat.swift (iOS) for the reference implementation.
+ *
+ * Expected behavior:
+ * - Store fields set via setFields()
+ * - Implement AgentforceHiddenPreChatFieldDelegate.agentforce() to return
+ *   only values for fields the SDK requests (filter stored map by requested field names)
+ * - Return null when no fields are stored or no requested fields match
+ * - Use @Volatile for thread-safe reads (matches BridgeLogger pattern)
+ */
+package com.salesforce.android.reactagentforce
+
+class BridgeHiddenPreChat {
+
+    @Volatile
+    private var fields: Map<String, String> = emptyMap()
+
+    fun setFields(fields: Map<String, String>) {
+        this.fields = fields
+    }
+
+    fun getFields(): Map<String, String> = fields
+}

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
@@ -71,6 +71,15 @@ RCT_EXTERN_METHOD(closeConversation:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(startNewConversation:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+// MARK: - Hidden PreChat Fields
+
+RCT_EXTERN_METHOD(registerHiddenPreChatFields:(NSDictionary *)fields
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getHiddenPreChatFields:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 // MARK: - Additional Context
 
 RCT_EXTERN_METHOD(setAdditionalContext:(NSDictionary *)contextDict

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -42,6 +42,12 @@ class AgentforceModule: RCTEventEmitter {
     private let listenerLock = NSLock()
     private var _hasListeners = false
 
+    // MARK: - Hidden PreChat Fields
+
+    /// Bridge delegate for hidden prechat fields (Service Agent only).
+    /// Strongly retained here because AgentforceClient holds it as a weak reference.
+    private let bridgeHiddenPreChat = BridgeHiddenPreChat()
+
     // MARK: - Logging
 
     /// Bridge logger for forwarding SDK logs to JavaScript.
@@ -180,6 +186,7 @@ class AgentforceModule: RCTEventEmitter {
             mode: .fullConfig(fullConfiguration),
             viewProvider: bridgeViewProvider
         )
+        agentforceClient?.hiddenPreChatFieldDelegate = bridgeHiddenPreChat
     }
 
     // MARK: - Employee Agent Configuration
@@ -813,6 +820,7 @@ class AgentforceModule: RCTEventEmitter {
     private func cleanupClient() {
         currentConversation = nil
         agentforceClient = nil
+        bridgeHiddenPreChat.setFields([:])
     }
 
     /// Close the conversation
@@ -827,6 +835,36 @@ class AgentforceModule: RCTEventEmitter {
             dismissConversation()
             resolve(["success": true])
         }
+    }
+
+    // MARK: - Hidden PreChat Fields
+
+    /// Pre-register hidden prechat field values for the next Service Agent session.
+    @objc
+    func registerHiddenPreChatFields(
+        _ fields: NSDictionary,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        guard let dict = fields as? [String: String] else {
+            reject(
+                "INVALID_FIELDS",
+                "Hidden prechat fields must be a map of string keys to string values",
+                nil
+            )
+            return
+        }
+        bridgeHiddenPreChat.setFields(dict)
+        resolve(nil)
+    }
+
+    /// Get the currently registered hidden prechat field values.
+    @objc
+    func getHiddenPreChatFields(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        resolve(bridgeHiddenPreChat.getFields())
     }
 
     // MARK: - Additional Context

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeHiddenPreChat.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeHiddenPreChat.swift
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+ *
+ * React Native bridge for hidden prechat field delegate
+ */
+
+import Foundation
+import AgentforceSDK
+import AgentforceService
+
+/// Bridge delegate that returns pre-registered hidden prechat field values
+/// to the native Agentforce SDK during Service Agent session initialization.
+///
+/// JavaScript calls `registerHiddenPreChatFields({ key: value })` to store
+/// field values. When the SDK calls the delegate, only values for fields the
+/// SDK actually requests are returned; absent fields are omitted.
+///
+/// Must be strongly retained on the module because `AgentforceClient` holds
+/// `hiddenPreChatFieldDelegate` as a weak reference.
+class BridgeHiddenPreChat: NSObject, AgentforceHiddenPreChatFieldDelegate {
+
+    // MARK: - Properties
+
+    private let lock = NSLock()
+    private var _fields: [String: String] = [:]
+
+    // MARK: - Public API
+
+    /// Replace the stored field values. Pass an empty dictionary to clear.
+    func setFields(_ fields: [String: String]) {
+        lock.withLock { _fields = fields }
+    }
+
+    /// Return a snapshot of the current field values.
+    func getFields() -> [String: String] {
+        lock.withLock { _fields }
+    }
+
+    // MARK: - AgentforceHiddenPreChatFieldDelegate
+
+    func agentforce(
+        didRequestHiddenPreChatValues requestedFields: [AgentforceHiddenPreChatField]
+    ) async -> [String: String]? {
+        let stored = lock.withLock { _fields }
+        guard !stored.isEmpty else { return nil }
+
+        var result: [String: String] = [:]
+        for field in requestedFields {
+            if let value = stored[field.name] {
+                result[field.name] = value
+            }
+        }
+        return result.isEmpty ? nil : result
+    }
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/index.ts
@@ -17,7 +17,7 @@ export {
 } from './services/EmployeeAgentAuth';
 export type { AuthCredentials } from './services/EmployeeAgentAuth';
 
-export type { ServiceAgentConfig, EmployeeAgentConfig, AgentConfig, FeatureFlags, LegacyServiceAgentConfig, ConfigurationResult, ConfigurationInfo, LoggerDelegate, LogLevel, NavigationDelegate, NavigationRequest, AgentforceAdditionalContext, AgentforceContextVariable, AgentforceContextVariableType, ViewProviderDelegate, ViewProviderComponentData } from './types';
+export type { ServiceAgentConfig, EmployeeAgentConfig, AgentConfig, FeatureFlags, LegacyServiceAgentConfig, ConfigurationResult, ConfigurationInfo, LoggerDelegate, LogLevel, NavigationDelegate, NavigationRequest, AgentforceAdditionalContext, AgentforceContextVariable, AgentforceContextVariableType, ViewProviderDelegate, ViewProviderComponentData, HiddenPreChatFields } from './types';
 export { isServiceAgentConfig, isEmployeeAgentConfig, isLegacyConfig } from './types';
 
 export {

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -33,6 +33,7 @@ import type {
   AgentforceContextVariableType,
 } from '../types/AgentforceContext';
 import { ViewProviderDelegate } from '../types/ViewProviderDelegate';
+import type { HiddenPreChatFields } from '../types/HiddenPreChatFields';
 
 const { AgentforceModule } = NativeModules;
 
@@ -42,6 +43,7 @@ export type { LoggerDelegate, LogLevel };
 export type { NavigationDelegate, NavigationRequest };
 export type { AgentforceAdditionalContext, AgentforceContextVariable };
 export type { ViewProviderDelegate };
+export type { HiddenPreChatFields };
 
 /**
  * Native module event names
@@ -835,6 +837,86 @@ class AgentforceService {
     } catch (error) {
       console.error('[AgentforceService] Failed to set additional context:', error);
       throw error;
+    }
+  }
+
+  /**
+   * Pre-register hidden prechat field values for Service Agent conversations.
+   *
+   * Call this before `launchConversation()` to supply values for prechat fields
+   * hidden from the end user (e.g. ContactId, AccountId, session tokens).
+   * When the SDK initializes a Service Agent session, these values are returned
+   * to the native delegate automatically.
+   *
+   * Fields not present in the provided map are omitted (not sent as empty strings),
+   * so the SDK treats them as unset.
+   *
+   * @remarks Service Agent only. Has no effect for Employee Agent conversations.
+   *
+   * @param fields - Map of field developer names to string values
+   *
+   * @example
+   * ```typescript
+   * await AgentforceService.registerHiddenPreChatFields({
+   *   ContactId: '003xx0000001234',
+   *   AccountId: '001xx0000005678',
+   * });
+   * await AgentforceService.launchConversation();
+   * ```
+   */
+  async registerHiddenPreChatFields(fields: HiddenPreChatFields): Promise<void> {
+    if (Platform.OS !== 'android' && Platform.OS !== 'ios') {
+      return;
+    }
+
+    if (!AgentforceModule) {
+      console.warn('[AgentforceService] Native module not available');
+      return;
+    }
+
+    try {
+      await AgentforceModule.registerHiddenPreChatFields(fields);
+      const count = Object.keys(fields).length;
+      console.log(
+        `[AgentforceService] Hidden prechat fields registered: ${count} field(s)`,
+      );
+    } catch (error) {
+      console.error(
+        '[AgentforceService] Failed to register hidden prechat fields:',
+        error,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Clear all pre-registered hidden prechat field values.
+   *
+   * @remarks Service Agent only.
+   */
+  async clearHiddenPreChatFields(): Promise<void> {
+    await this.registerHiddenPreChatFields({});
+  }
+
+  /**
+   * Get the currently registered hidden prechat field values.
+   *
+   * @returns The stored field map, or an empty object if none registered.
+   */
+  async getHiddenPreChatFields(): Promise<HiddenPreChatFields> {
+    if (Platform.OS !== 'android' && Platform.OS !== 'ios') {
+      return {};
+    }
+
+    if (!AgentforceModule?.getHiddenPreChatFields) {
+      return {};
+    }
+
+    try {
+      const fields = await AgentforceModule.getHiddenPreChatFields();
+      return (fields as HiddenPreChatFields) ?? {};
+    } catch {
+      return {};
     }
   }
 

--- a/AgentforceSDK-ReactNative-Bridge/src/types/HiddenPreChatFields.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/HiddenPreChatFields.ts
@@ -1,0 +1,18 @@
+/**
+ * Hidden prechat field values for Service Agent conversations.
+ *
+ * Maps field developer names to their string values. These values are
+ * submitted with the prechat form but are not visible to the end user.
+ *
+ * @remarks Service Agent only. Has no effect for Employee Agent conversations.
+ *
+ * @example
+ * ```typescript
+ * const fields: HiddenPreChatFields = {
+ *   ContactId: '003xx0000001234',
+ *   AccountId: '001xx0000005678',
+ *   Subject: 'Mobile App Support',
+ * };
+ * ```
+ */
+export type HiddenPreChatFields = Record<string, string>;

--- a/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
@@ -33,3 +33,6 @@ export {
 
 // View provider delegate types
 export { ViewProviderDelegate, ViewProviderComponentData } from './ViewProviderDelegate';
+
+// Hidden prechat field types
+export type { HiddenPreChatFields } from './HiddenPreChatFields';

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -45,7 +45,7 @@ import {
   getEmployeeAgentCredentials,
   refreshEmployeeAgentCredentials,
 } from 'react-native-agentforce';
-import type { FeatureFlags } from 'react-native-agentforce';
+import type { FeatureFlags, HiddenPreChatFields } from 'react-native-agentforce';
 import { UI_FEATURES } from '../config/AppConfig';
 
 type TabType = 'service' | 'employee' | 'features';
@@ -105,11 +105,16 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
   const [featureFlags, setFeatureFlags] = useState<FeatureFlags | null>(null);
   const [savingFlags, setSavingFlags] = useState(false);
 
+  const [hiddenPreChatFields, setHiddenPreChatFields] = useState<HiddenPreChatFields>({});
+  const [newFieldName, setNewFieldName] = useState('');
+  const [newFieldValue, setNewFieldValue] = useState('');
+
   useEffect(() => {
     loadSavedConfiguration();
     loadStoredEmployeeAgentId();
     checkAuthStatus();
     loadFeatureFlags();
+    loadHiddenPreChatFields();
   }, []);
 
   useEffect(() => {
@@ -187,6 +192,9 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
     if (!validateServiceInputs()) return;
     setLoading(true);
     try {
+      // Register hidden prechat fields before configuring
+      await AgentforceService.registerHiddenPreChatFields(hiddenPreChatFields);
+
       // Get current feature flags to preserve user settings
       const featureFlags = await AgentforceService.getFeatureFlags();
 
@@ -223,6 +231,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
           setServiceApiURL('');
           setOrganizationId('');
           setEsDeveloperName('');
+          setHiddenPreChatFields({});
         },
       },
     ]);
@@ -295,6 +304,47 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         enableCustomViewProvider: false,
       });
     }
+  };
+
+  const loadHiddenPreChatFields = async () => {
+    try {
+      const fields = await AgentforceService.getHiddenPreChatFields();
+      setHiddenPreChatFields(fields);
+    } catch {
+      setHiddenPreChatFields({});
+    }
+  };
+
+  const handleAddPreChatField = () => {
+    const name = newFieldName.trim();
+    const value = newFieldValue.trim();
+    if (!name || !value) return;
+    setHiddenPreChatFields(prev => ({ ...prev, [name]: value }));
+    setNewFieldName('');
+    setNewFieldValue('');
+  };
+
+  const handleRemovePreChatField = (name: string) => {
+    setHiddenPreChatFields(prev => {
+      const next = { ...prev };
+      delete next[name];
+      return next;
+    });
+  };
+
+  const handleClearAllPreChatFields = () => {
+    Alert.alert('Clear Hidden Fields', 'Remove all hidden prechat fields?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Clear',
+        style: 'destructive',
+        onPress: () => setHiddenPreChatFields({}),
+      },
+    ]);
+  };
+
+  const handleQuickAddField = (name: string) => {
+    setNewFieldName(name);
   };
 
   const handleToggleFeatureFlag = async (
@@ -370,6 +420,102 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
     </View>
   );
 
+  const QUICK_ADD_FIELDS = ['ContactId', 'AccountId', 'Subject', 'Email'];
+
+  const renderHiddenPreChatFieldsSection = () => {
+    const fieldEntries = Object.entries(hiddenPreChatFields);
+    const fieldCount = fieldEntries.length;
+
+    return (
+      <View style={styles.formContainer}>
+        <View style={styles.preChatHeader}>
+          <Text style={styles.label}>Hidden PreChat Fields</Text>
+          {fieldCount > 0 && (
+            <View style={styles.badge}>
+              <Text style={styles.badgeText}>{fieldCount}</Text>
+            </View>
+          )}
+        </View>
+        <Text style={styles.hint}>
+          Key-value pairs sent as hidden prechat fields during Service Agent session start.
+        </Text>
+
+        {fieldCount === 0 ? (
+          <Text style={styles.emptyFieldsText}>No fields configured</Text>
+        ) : (
+          <View style={styles.fieldList}>
+            {fieldEntries.map(([name, value]) => (
+              <View key={name} style={styles.fieldRow}>
+                <View style={styles.fieldInfo}>
+                  <Text style={styles.fieldName}>{name}</Text>
+                  <Text style={styles.fieldValue} numberOfLines={1}>{value}</Text>
+                </View>
+                <TouchableOpacity
+                  onPress={() => handleRemovePreChatField(name)}
+                  style={styles.deleteButton}
+                >
+                  <Text style={styles.deleteButtonText}>X</Text>
+                </TouchableOpacity>
+              </View>
+            ))}
+          </View>
+        )}
+
+        <View style={styles.addFieldRow}>
+          <TextInput
+            style={[styles.input, styles.addFieldInput]}
+            value={newFieldName}
+            onChangeText={setNewFieldName}
+            placeholder="Field name"
+            placeholderTextColor="#999"
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+          <TextInput
+            style={[styles.input, styles.addFieldInput]}
+            value={newFieldValue}
+            onChangeText={setNewFieldValue}
+            placeholder="Value"
+            placeholderTextColor="#999"
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+          <TouchableOpacity
+            style={[
+              styles.addFieldButton,
+              (!newFieldName.trim() || !newFieldValue.trim()) && styles.buttonDisabled,
+            ]}
+            onPress={handleAddPreChatField}
+            disabled={!newFieldName.trim() || !newFieldValue.trim()}
+          >
+            <Text style={styles.addFieldButtonText}>Add</Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.quickAddRow}>
+          {QUICK_ADD_FIELDS.map(name => (
+            <TouchableOpacity
+              key={name}
+              style={styles.quickAddChip}
+              onPress={() => handleQuickAddField(name)}
+            >
+              <Text style={styles.quickAddChipText}>{name}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        {fieldCount > 0 && (
+          <TouchableOpacity
+            style={styles.clearFieldsButton}
+            onPress={handleClearAllPreChatFields}
+          >
+            <Text style={styles.clearFieldsButtonText}>Clear All Fields</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    );
+  };
+
   const renderServiceAgentTab = () => (
     <ScrollView
       style={styles.tabContent}
@@ -441,6 +587,8 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
           />
         </View>
       </View>
+
+      {renderHiddenPreChatFieldsSection()}
 
       <View style={styles.buttonContainer}>
         <TouchableOpacity
@@ -843,6 +991,123 @@ const styles = StyleSheet.create({
     marginTop: 8,
     fontSize: 13,
     color: '#28a745',
+  },
+  preChatHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  badge: {
+    backgroundColor: '#7B1FA2',
+    borderRadius: 10,
+    minWidth: 20,
+    height: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: 8,
+    paddingHorizontal: 6,
+  },
+  badgeText: {
+    color: '#ffffff',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  emptyFieldsText: {
+    fontSize: 14,
+    color: '#999',
+    fontStyle: 'italic',
+    marginTop: 8,
+    marginBottom: 12,
+  },
+  fieldList: {
+    marginTop: 8,
+    marginBottom: 12,
+  },
+  fieldRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: '#f1f3f4',
+  },
+  fieldInfo: {
+    flex: 1,
+  },
+  fieldName: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#212529',
+  },
+  fieldValue: {
+    fontSize: 13,
+    color: '#6c757d',
+    marginTop: 2,
+  },
+  deleteButton: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: '#f8d7da',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: 8,
+  },
+  deleteButtonText: {
+    color: '#dc3545',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  addFieldRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 12,
+  },
+  addFieldInput: {
+    flex: 1,
+    marginBottom: 0,
+  },
+  addFieldButton: {
+    backgroundColor: '#7B1FA2',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  addFieldButtonText: {
+    color: '#ffffff',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  quickAddRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginBottom: 12,
+  },
+  quickAddChip: {
+    backgroundColor: '#f3e5f5',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#CE93D8',
+  },
+  quickAddChipText: {
+    fontSize: 12,
+    color: '#7B1FA2',
+    fontWeight: '500',
+  },
+  clearFieldsButton: {
+    paddingVertical: 10,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#dc3545',
+    borderRadius: 8,
+  },
+  clearFieldsButtonText: {
+    color: '#dc3545',
+    fontSize: 14,
+    fontWeight: '500',
   },
   flagRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary

Add `hiddenPreChatFieldDelegate` support to the React Native bridge (iOS fully implemented, Android stubbed for separate PR).

Hidden prechat fields are key-value pairs submitted invisibly during Service Agent session initialization (e.g. `ContactId`, `AccountId`). JavaScript pre-registers values via `registerHiddenPreChatFields()`, and the native bridge delegate returns them to the SDK when requested.

### Changes

**TypeScript layer**
- New `HiddenPreChatFields` type (`Record<string, string>`)
- `AgentforceService.registerHiddenPreChatFields()`, `clearHiddenPreChatFields()`, `getHiddenPreChatFields()`

**iOS (complete)**
- `BridgeHiddenPreChat` — implements `AgentforceHiddenPreChatFieldDelegate`, thread-safe via `NSLock`, filters returned values to only SDK-requested fields
- `AgentforceModule` — stores delegate (strongly retained since SDK holds weak ref), wires it in `configureServiceAgent()`, clears on cleanup
- `AgentforceModule.m` — ObjC bridge registrations

**Android (stubs)**
- `BridgeHiddenPreChat.kt` — storage only, TODO for delegate interface implementation
- `AgentforceModule.kt` — `@ReactMethod` stubs that store/retrieve fields

**Settings UI**
- Hidden PreChat Fields editor in the Service Agent tab: add/remove fields, quick-add chips (ContactId, AccountId, Subject, Email), Clear All. Fields are registered on Save Configuration.

### Test

Verified end-to-end on iOS simulator — SDK logs confirm delegate is called and field values are populated in the MIAW routing attributes:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-10 at 14 46 39" src="https://github.com/user-attachments/assets/c7908998-956c-43a2-adc3-373f11b2187c" />

```
 LOG  [2026-03-10T20:46:46.891Z][Agentforce DEBUG] Retrieved and cached remote configuration: true
 LOG  [2026-03-10T20:46:46.892Z][Agentforce INFO] Only hidden pre-chat fields, submitting automatically
 LOG  [2026-03-10T20:46:46.892Z][Agentforce DEBUG] Core SDK requested hidden prechat values for 2 fields
 LOG  [2026-03-10T20:46:46.892Z][Agentforce INFO] Started new Bots Runtime session with id: Optional("FF5279BF-663F-4104-B2F3-B12D89755C38")
 LOG  [2026-03-10T20:46:46.892Z][Agentforce DEBUG] Requesting hidden prechat values from delegate for fields: ["Time_Zone", "Test1"]
 LOG  [2026-03-10T20:46:46.892Z][Agentforce INFO] Service agent session started with ID: FF5279BF-663F-4104-B2F3-B12D89755C38
 LOG  [2026-03-10T20:46:46.892Z][Agentforce DEBUG] Setting hidden prechat value for field 'Time_Zone': 'MDT'
 LOG  [2026-03-10T20:46:46.892Z][Agentforce INFO] Processing 1 messages from session response (resuming: true)
 LOG  [2026-03-10T20:46:46.892Z][Agentforce DEBUG] Setting hidden prechat value for field 'Test1': 'Goose'
 LOG  [2026-03-10T20:46:46.892Z][Agentforce INFO] Populated 2 hidden prechat field values
```