### PR TITLE
@W-21447619 Implement the AgentforceHiddenPreChatFieldDelegate

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -185,12 +185,13 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     serviceAgentConfiguration = sdkServiceConfig,
                     agentforceConfiguration = agentforceConfig
                 )
-                
+
                 // Initialize client
                 val client = AgentforceClient()
                 client.init(
                     agentforceMode = sdkMode,
-                    application = reactApplicationContext.applicationContext as Application
+                    application = reactApplicationContext.applicationContext as Application,
+                    hiddenPreChatFieldDelegate = bridgeHiddenPreChat
                 )
                 
                 AgentforceClientHolder.setClient(client)
@@ -637,11 +638,6 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
 
     /**
      * Pre-register hidden prechat field values for the next Service Agent session.
-     *
-     * TODO: Implement AgentforceHiddenPreChatFieldDelegate on BridgeHiddenPreChat
-     * and pass to client.init(hiddenPreChatFieldDelegate = bridgeHiddenPreChat).
-     * See iOS BridgeHiddenPreChat.swift for reference. Until then, fields are
-     * stored but not sent to the SDK.
      */
     @ReactMethod
     fun registerHiddenPreChatFields(fields: ReadableMap, promise: Promise) {

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeHiddenPreChat.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeHiddenPreChat.kt
@@ -2,20 +2,13 @@
  * Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
  *
  * React Native bridge for hidden prechat field delegate
- *
- * TODO: Implement AgentforceHiddenPreChatFieldDelegate interface.
- * See BridgeHiddenPreChat.swift (iOS) for the reference implementation.
- *
- * Expected behavior:
- * - Store fields set via setFields()
- * - Implement AgentforceHiddenPreChatFieldDelegate.agentforce() to return
- *   only values for fields the SDK requests (filter stored map by requested field names)
- * - Return null when no fields are stored or no requested fields match
- * - Use @Volatile for thread-safe reads (matches BridgeLogger pattern)
  */
 package com.salesforce.android.reactagentforce
 
-class BridgeHiddenPreChat {
+import com.salesforce.android.agentforceservice.coresdk.AgentforceHiddenPreChatField
+import com.salesforce.android.agentforceservice.coresdk.AgentforceHiddenPreChatFieldDelegate
+
+class BridgeHiddenPreChat : AgentforceHiddenPreChatFieldDelegate {
 
     @Volatile
     private var fields: Map<String, String> = emptyMap()
@@ -25,4 +18,17 @@ class BridgeHiddenPreChat {
     }
 
     fun getFields(): Map<String, String> = fields
+
+    override suspend fun agentforce(
+        hiddenPreChatField: List<AgentforceHiddenPreChatField>
+    ): Map<String, String>? {
+        val stored = fields
+        if (stored.isEmpty()) return null
+
+        val result = mutableMapOf<String, String>()
+        for (field in hiddenPreChatField) {
+            stored[field.name]?.let { result[field.name] = it }
+        }
+        return result.ifEmpty { null }
+    }
 }


### PR DESCRIPTION
## Implementation Plan

Make `BridgeHiddenPreChat` implement the `AgentforceHiddenPreChatFieldDelegate` interface so that hidden prechat field values registered from JavaScript are actually sent to the Agentforce SDK during Service Agent session initialization. Currently the fields are stored but never forwarded to the SDK.

### Files Modified (Summary)

| File | Change |
|------|--------|
| `BridgeHiddenPreChat.kt` | Implement `AgentforceHiddenPreChatFieldDelegate`, add `agentforce()` override |
| `AgentforceModule.kt` | Pass `hiddenPreChatFieldDelegate = bridgeHiddenPreChat` in Service Agent `client.init()`, remove TODO comments |

### No JS/TS Changes Needed

The JavaScript layer (`AgentforceService.ts`, `HiddenPreChatFields.ts`, `SettingsScreen.tsx`) is already complete — it calls `registerHiddenPreChatFields()` and `getHiddenPreChatFields()` which work today. The only gap is on the native Android side.

