### PR TITLE
Bump SDK versions to 260.2

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/build.gradle
+++ b/AgentforceSDK-ReactNative-Bridge/android/build.gradle
@@ -49,7 +49,7 @@ repositories {
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
     implementation "com.facebook.react:react-android"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk:14.146.2"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk:14.177.0"
     // compileOnly: host app adds this for Employee Agent. Bridge compiles; host provides at runtime.
     compileOnly "com.salesforce.mobilesdk:SalesforceReact:13.1.1"
 

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -16,7 +16,7 @@ def shared_pods
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'AgentforceSDK', '15.0.7'
+  pod 'AgentforceSDK', '15.2.6'
   pod 'Messaging-InApp-Core', '> 1.10.0'
 
   # JWTKit is required by AgentforceService but not resolved automatically


### PR DESCRIPTION
This PR updates the AgentforceSDK versions on both platforms to 260.2 to consume the latest fixes in the new releases.