### PR TITLE
Fix record rendering issues on iOS and Android by correcting UI API query parameter handling

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNetwork.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNetwork.kt
@@ -62,14 +62,26 @@ class BridgeNetwork(private val restClient: RestClient) : Network {
             NetworkRequest.Method.HEAD -> RestRequest.RestMethod.HEAD
         }
 
-        // Create RestRequest - use body constructor if body exists, else query params constructor
+        // Append query params to the path as a query string.
+        // RestRequest(RestMethod, String, Map) treats the Map as additionalHttpHeaders,
+        // NOT query parameters, so we must encode them into the URL path ourselves.
+        val fullPath = if (queryParams.isNotEmpty()) {
+            val separator = if (path.contains("?")) "&" else "?"
+            val queryString = queryParams.entries.joinToString("&") { (k, v) ->
+                "${java.net.URLEncoder.encode(k, "UTF-8")}=${java.net.URLEncoder.encode(v.toString(), "UTF-8")}"
+            }
+            "$path$separator$queryString"
+        } else {
+            path
+        }
+
+        // Create RestRequest - use body constructor if body exists, else path-only constructor
         val restRequest = if (body != null && body!!.isNotEmpty()) {
             val mediaType = contentType?.toMediaType()
             val requestBody = body!!.toRequestBody(mediaType)
-            RestRequest(restMethod, path, requestBody)
+            RestRequest(restMethod, fullPath, requestBody)
         } else {
-            val queryMap = queryParams.mapValues { it.value.toString() }.toMutableMap()
-            RestRequest(restMethod, path, queryMap)
+            RestRequest(restMethod, fullPath)
         }
 
         // Add custom headers

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeDataProvider.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeDataProvider.swift
@@ -36,8 +36,21 @@ struct BridgeDataProvider: AgentforceDataProviding {
         cachePolicy: AgentforceCachePolicy,
         transactionId: String?
     ) async throws -> AgentforceRecordRepresentation {
-        let fieldsParam = fields.isEmpty ? "" : "?fields=" + fields.joined(separator: ",")
+        // Ensure Id is always included (required by UI API)
+        var fieldsToRequest = fields.isEmpty ? ["Id", "Name"] : fields
+        if !fieldsToRequest.contains("Id") {
+            fieldsToRequest.insert("Id", at: 0)
+        }
+
+        // UI API requires qualified field names (ObjectType.FieldName)
+        let qualifiedFields = fieldsToRequest.map { field in
+            // If already qualified (contains a dot), use as-is; otherwise qualify it
+            field.contains(".") ? field : "\(objectType).\(field)"
+        }
+
+        let fieldsParam = "?fields=" + qualifiedFields.joined(separator: ",")
         let path = "/services/data/\(Self.apiVersion)/ui-api/records/\(recordId)\(fieldsParam)"
+
         let request = createNetworkRequest(path: path)
         let (data, _) = try await network.data(for: request)
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
@@ -51,18 +64,23 @@ struct BridgeDataProvider: AgentforceDataProviding {
         cachePolicy: AgentforceCachePolicy,
         transactionId: String?
     ) async throws -> AgentforceRecordRepresentation {
-        let modesParam = modes.isEmpty ? "" : "?modes=" + modes.map { $0.rawValue }.joined(separator: ",")
-        let path = "/services/data/\(Self.apiVersion)/ui-api/record-ui/\(recordId)\(modesParam)"
+        // UI API record-ui endpoint requires layoutTypes parameter for single records
+        // If no layoutType specified, fall back to records endpoint with fields
+        let path: String
+        if !layoutType.isEmpty {
+            let encodedLayoutType = layoutType.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? layoutType
+            path = "/services/data/\(Self.apiVersion)/ui-api/records/\(recordId)?layoutTypes=\(encodedLayoutType)"
+        } else {
+            // Fallback: request common fields including Name
+            path = "/services/data/\(Self.apiVersion)/ui-api/records/\(recordId)?fields=Id,Name"
+        }
 
         let request = createNetworkRequest(path: path)
         let (data, _) = try await network.data(for: request)
 
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
-        // record-ui returns { "record": {...}, "layout": {...}, ... }
-        if let recordData = json["record"] as? [String: Any] {
-            return try parseRecordRepresentation(from: recordData)
-        }
-        throw DataProviderError.invalidResponse
+        // Both records and record-ui endpoints return the record directly in the response
+        return try parseRecordRepresentation(from: json)
     }
 
     func records(
@@ -73,7 +91,18 @@ struct BridgeDataProvider: AgentforceDataProviding {
         transactionId: String?
     ) async throws -> [AgentforceUIAPIRecord] {
         let recordIdsParam = recordIds.joined(separator: ",")
-        let fieldsParam = fields.isEmpty ? "" : "&fields=" + fields.joined(separator: ",")
+
+        // UI API requires qualified field names (ObjectType.FieldName) when using fields parameter
+        let fieldsParam: String
+        if !fields.isEmpty {
+            let qualifiedFields = fields.map { field in
+                field.contains(".") ? field : "\(objectType).\(field)"
+            }
+            fieldsParam = "&fields=" + qualifiedFields.joined(separator: ",")
+        } else {
+            fieldsParam = ""
+        }
+
         let path = "/services/data/\(Self.apiVersion)/ui-api/records/batch/\(recordIdsParam)\(fieldsParam)"
 
         let request = createNetworkRequest(path: path)
@@ -93,9 +122,21 @@ struct BridgeDataProvider: AgentforceDataProviding {
         cachePolicy: AgentforceCachePolicy,
         transactionId: String?
     ) async throws -> [AgentforceUIAPIRecord] {
+        // UI API does not have a record-ui/batch endpoint, only records/batch
+        // Use records/batch with layoutTypes or fields parameter
         let recordIdsParam = recordIds.joined(separator: ",")
-        let modesParam = modes.map { "?modes=" + $0.map { $0.rawValue }.joined(separator: ",") } ?? ""
-        let path = "/services/data/\(Self.apiVersion)/ui-api/record-ui/batch/\(recordIdsParam)\(modesParam)"
+
+        // If layoutType is provided and not empty, use it; otherwise request all fields
+        let queryParam: String
+        if !layoutType.isEmpty {
+            let encodedLayoutType = layoutType.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? layoutType
+            queryParam = "layoutTypes=\(encodedLayoutType)"
+        } else {
+            // Fallback: request common fields to satisfy API requirements
+            queryParam = "fields=Id,Name,Type"
+        }
+
+        let path = "/services/data/\(Self.apiVersion)/ui-api/records/batch/\(recordIdsParam)?\(queryParam)"
 
         let request = createNetworkRequest(path: path)
         let (data, _) = try await network.data(for: request)
@@ -103,7 +144,9 @@ struct BridgeDataProvider: AgentforceDataProviding {
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
         if let results = json["results"] as? [[String: Any]] {
             return try results.compactMap { resultItem in
-                if let recordData = resultItem["record"] as? [String: Any] {
+                // records/batch returns the record directly in each result, not nested under "record"
+                if let statusCode = resultItem["statusCode"] as? Int, statusCode == 200,
+                   let recordData = resultItem["result"] as? [String: Any] {
                     return try parseUIAPIRecord(from: recordData)
                 }
                 return nil

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeDataProvider.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeDataProvider.swift
@@ -36,19 +36,23 @@ struct BridgeDataProvider: AgentforceDataProviding {
         cachePolicy: AgentforceCachePolicy,
         transactionId: String?
     ) async throws -> AgentforceRecordRepresentation {
-        // Ensure Id is always included (required by UI API)
-        var fieldsToRequest = fields.isEmpty ? ["Id", "Name"] : fields
-        if !fieldsToRequest.contains("Id") {
-            fieldsToRequest.insert("Id", at: 0)
+        // When fields is empty, omit the parameter and let the UI API return its defaults.
+        // This avoids hardcoding "Name" which doesn't exist on all objects (e.g., Task uses Subject).
+        let fieldsParam: String
+        if !fields.isEmpty {
+            var fieldsToRequest = fields
+            if !fieldsToRequest.contains("Id") {
+                fieldsToRequest.insert("Id", at: 0)
+            }
+            // UI API requires qualified field names (ObjectType.FieldName)
+            let qualifiedFields = fieldsToRequest.map { field in
+                field.contains(".") ? field : "\(objectType).\(field)"
+            }
+            fieldsParam = "?fields=" + qualifiedFields.joined(separator: ",")
+        } else {
+            fieldsParam = ""
         }
 
-        // UI API requires qualified field names (ObjectType.FieldName)
-        let qualifiedFields = fieldsToRequest.map { field in
-            // If already qualified (contains a dot), use as-is; otherwise qualify it
-            field.contains(".") ? field : "\(objectType).\(field)"
-        }
-
-        let fieldsParam = "?fields=" + qualifiedFields.joined(separator: ",")
         let path = "/services/data/\(Self.apiVersion)/ui-api/records/\(recordId)\(fieldsParam)"
 
         let request = createNetworkRequest(path: path)
@@ -64,15 +68,18 @@ struct BridgeDataProvider: AgentforceDataProviding {
         cachePolicy: AgentforceCachePolicy,
         transactionId: String?
     ) async throws -> AgentforceRecordRepresentation {
-        // UI API record-ui endpoint requires layoutTypes parameter for single records
-        // If no layoutType specified, fall back to records endpoint with fields
+        // Note: `modes` is not used. The records endpoint (used here instead of record-ui)
+        // does not support access modes.
+
+        // Uses the records endpoint with layoutTypes when available.
+        // When layoutType is empty, omit it and let the UI API return defaults
+        // rather than hardcoding field names that may not exist on all objects.
         let path: String
         if !layoutType.isEmpty {
             let encodedLayoutType = layoutType.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? layoutType
             path = "/services/data/\(Self.apiVersion)/ui-api/records/\(recordId)?layoutTypes=\(encodedLayoutType)"
         } else {
-            // Fallback: request common fields including Name
-            path = "/services/data/\(Self.apiVersion)/ui-api/records/\(recordId)?fields=Id,Name"
+            path = "/services/data/\(Self.apiVersion)/ui-api/records/\(recordId)"
         }
 
         let request = createNetworkRequest(path: path)
@@ -98,7 +105,7 @@ struct BridgeDataProvider: AgentforceDataProviding {
             let qualifiedFields = fields.map { field in
                 field.contains(".") ? field : "\(objectType).\(field)"
             }
-            fieldsParam = "&fields=" + qualifiedFields.joined(separator: ",")
+            fieldsParam = "?fields=" + qualifiedFields.joined(separator: ",")
         } else {
             fieldsParam = ""
         }
@@ -110,7 +117,13 @@ struct BridgeDataProvider: AgentforceDataProviding {
 
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
         if let results = json["results"] as? [[String: Any]] {
-            return try results.map { try parseUIAPIRecord(from: $0) }
+            return try results.compactMap { resultItem in
+                if let statusCode = resultItem["statusCode"] as? Int, statusCode == 200,
+                   let recordData = resultItem["result"] as? [String: Any] {
+                    return try parseUIAPIRecord(from: recordData)
+                }
+                return nil
+            }
         }
         return []
     }
@@ -122,21 +135,21 @@ struct BridgeDataProvider: AgentforceDataProviding {
         cachePolicy: AgentforceCachePolicy,
         transactionId: String?
     ) async throws -> [AgentforceUIAPIRecord] {
+        // Note: `modes` is not used. records/batch does not support access modes.
+
         // UI API does not have a record-ui/batch endpoint, only records/batch
-        // Use records/batch with layoutTypes or fields parameter
         let recordIdsParam = recordIds.joined(separator: ",")
 
-        // If layoutType is provided and not empty, use it; otherwise request all fields
+        // If layoutType is provided and not empty, use it; otherwise let the API return defaults
         let queryParam: String
         if !layoutType.isEmpty {
             let encodedLayoutType = layoutType.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? layoutType
-            queryParam = "layoutTypes=\(encodedLayoutType)"
+            queryParam = "?layoutTypes=\(encodedLayoutType)"
         } else {
-            // Fallback: request common fields to satisfy API requirements
-            queryParam = "fields=Id,Name,Type"
+            queryParam = ""
         }
 
-        let path = "/services/data/\(Self.apiVersion)/ui-api/records/batch/\(recordIdsParam)?\(queryParam)"
+        let path = "/services/data/\(Self.apiVersion)/ui-api/records/batch/\(recordIdsParam)\(queryParam)"
 
         let request = createNetworkRequest(path: path)
         let (data, _) = try await network.data(for: request)

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeNetwork.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeNetwork.swift
@@ -54,13 +54,24 @@ struct BridgeNetwork: SalesforceNetwork.Network {
         // placeholder:// URLs are from DataProvider - extract path so RestClient prepends instance URL
         // Other URLs (https://) should be used as-is (full URL for agent session API, etc.)
         let path: String
+        var queryParams: [String: String] = [:]
+
         if url.scheme == "placeholder" {
             path = url.path
+            // Extract query parameters from the URL
+            if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+               let queryItems = components.queryItems {
+                for item in queryItems {
+                    if let value = item.value {
+                        queryParams[item.name] = value
+                    }
+                }
+            }
         } else {
             path = url.absoluteString
         }
 
-        let restRequest = RestRequest(method: method, path: path, queryParams: [:])
+        let restRequest = RestRequest(method: method, path: path, queryParams: queryParams)
 
         restRequest.requiresAuthentication = request.requiresAuthentication ?? true
 


### PR DESCRIPTION
## Summary                                                                                            
  Record cards on both iOS and Android displayed generic or missing titles. Record cards displayed record IDs when records with the same name were identified.                                                                    
                                                                                                        
  ## Root Cause                                                                                         
  Both platforms had bugs in their network bridge layers that silently dropped UI API query parameters  
  (`fields`, `layoutTypes`):                                                                            
  - **iOS:** `BridgeNetwork` discarded query parameters from placeholder URLs, and `BridgeDataProvider`
  sent unqualified field names that the UI API rejected                                                 
  - **Android:** `BridgeNetwork` passed `queryParams` to a `RestRequest` constructor that interpreted
  them as HTTP headers                                                                                  
                                          
  ## Fix                                                                                                
  - **iOS:** Extract query parameters from placeholder URLs in `BridgeNetwork`, qualify field names as
  `ObjectType.FieldName` in `BridgeDataProvider`, and correct batch response parsing                    
  - **Android:** Encode `queryParams` into the URL path string instead of passing them to the
  headers-only `RestRequest` constructor