### PR TITLE
Add sfap_api to default OAuth scopes

### DIFF
--- a/android/app/src/employeeAgent/res/values/bootconfig.xml
+++ b/android/app/src/employeeAgent/res/values/bootconfig.xml
@@ -5,5 +5,6 @@
     <string-array name="oauthScopes">
         <item>api</item>
         <item>web</item>
+        <item>sfap_api</item>
     </string-array>
 </resources>

--- a/ios/EmployeeAgent/bootconfig.plist
+++ b/ios/EmployeeAgent/bootconfig.plist
@@ -10,6 +10,7 @@
 	<array>
 		<string>web</string>
 		<string>api</string>
+		<string>sfap_api</string>
 	</array>
 	<key>shouldAuthenticate</key>
 	<true/>

--- a/scripts/interactive-oauth.js
+++ b/scripts/interactive-oauth.js
@@ -83,8 +83,8 @@ async function promptOAuthConfig() {
       console.log('   ❌ Must be a valid URL');
     }
 
-    var scopesInput = await prompt(rl, '📝 OAuth Scopes (default: web,api): ');
-    config.scopes = scopesInput.length > 0 ? scopesInput : 'web,api';
+    var scopesInput = await prompt(rl, '📝 OAuth Scopes (default: web,api,sfap_api): ');
+    config.scopes = scopesInput.length > 0 ? scopesInput : 'web,api,sfap_api';
 
     var scopeList = config.scopes
       .split(',')
@@ -93,7 +93,7 @@ async function promptOAuthConfig() {
       })
       .filter(Boolean);
     if (scopeList.length === 0) {
-      config.scopes = 'web,api';
+      config.scopes = 'web,api,sfap_api';
     }
 
     console.log('\n✅ Configuration ready');


### PR DESCRIPTION
## Summary
- Adds `sfap_api` to the default OAuth scopes in the iOS boot config (`bootconfig.plist`), Android boot config (`bootconfig.xml`), and the interactive OAuth setup script (`interactive-oauth.js`).
- Default scopes are now `web`, `api`, and `sfap_api` across all three files.

## Test plan
- [ ] Verify iOS app authenticates with all three scopes
- [ ] Verify Android app authenticates with all three scopes
- [ ] Run `npm run setup` and confirm the interactive prompt shows `web,api,sfap_api` as the default