### PR TITLE
Add SDK version bump skill

### DIFF
--- a/.claude/skills/bump-sdk-version/README.md
+++ b/.claude/skills/bump-sdk-version/README.md
@@ -22,11 +22,11 @@ Or simply ask Claude to check for or apply SDK version updates — the skill tri
 
 ## External sources checked
 
-| Platform | Source | What's checked |
-|----------|--------|----------------|
-| iOS | [SalesforceMobileSDK-iOS-Specs](https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs) | Pod versions (AgentforceSDK, AgentforceService, AgentforceVoice) |
-| iOS | [AgentforceMobileSDK-iOS](https://github.com/salesforce/AgentforceMobileSDK-iOS) | Release notes |
-| Android | [AgentforceMobileSDK-Android](https://github.com/salesforce/AgentforceMobileSDK-Android) | Maven artifact versions + release notes |
+| Platform | Source                                                                                        | What's checked                                                   |
+| -------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| iOS      | [SalesforceMobileSDK-iOS-Specs](https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs) | Pod versions (AgentforceSDK, AgentforceService, AgentforceVoice) |
+| iOS      | [AgentforceMobileSDK-iOS](https://github.com/salesforce/AgentforceMobileSDK-iOS)              | Release notes                                                    |
+| Android  | [AgentforceMobileSDK-Android](https://github.com/salesforce/AgentforceMobileSDK-Android)      | Maven artifact versions + release notes                          |
 
 ## Local files modified
 

--- a/.claude/skills/bump-sdk-version/README.md
+++ b/.claude/skills/bump-sdk-version/README.md
@@ -1,0 +1,42 @@
+# bump-sdk-version
+
+A Claude Code skill that checks external Agentforce SDK repos for the latest versions and bumps the iOS/Android dependencies in this project.
+
+## What it does
+
+1. Reads current local SDK versions from `Podfile.common.rb` (iOS) and `build.gradle` (Android)
+2. Fetches the latest available versions from GitHub (specs repo + SDK READMEs)
+3. Surfaces release notes and flags breaking changes or new module requirements
+4. Applies version bumps after user confirmation
+5. Flags any code-level integration changes needed beyond config file updates
+
+## Usage
+
+In a Claude Code session within this repo, invoke the skill:
+
+```
+/bump-sdk-version
+```
+
+Or simply ask Claude to check for or apply SDK version updates — the skill triggers automatically based on context.
+
+## External sources checked
+
+| Platform | Source | What's checked |
+|----------|--------|----------------|
+| iOS | [SalesforceMobileSDK-iOS-Specs](https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs) | Pod versions (AgentforceSDK, AgentforceService, AgentforceVoice) |
+| iOS | [AgentforceMobileSDK-iOS](https://github.com/salesforce/AgentforceMobileSDK-iOS) | Release notes |
+| Android | [AgentforceMobileSDK-Android](https://github.com/salesforce/AgentforceMobileSDK-Android) | Maven artifact versions + release notes |
+
+## Local files modified
+
+- `ios/Podfile.common.rb` — iOS pod version pins
+- `AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec` — Pod dependencies
+- `AgentforceSDK-ReactNative-Bridge/android/build.gradle` — Maven dependency versions
+
+## After running
+
+1. `cd ios && pod install`
+2. Gradle sync in Android Studio
+3. Build and test both Service Agent and Employee Agent targets
+4. Review `git diff` before committing

--- a/.claude/skills/bump-sdk-version/SKILL.md
+++ b/.claude/skills/bump-sdk-version/SKILL.md
@@ -73,10 +73,13 @@ Show a clear comparison:
 ```
 Platform        | Dependency             | Current  | Latest   | Status
 iOS             | AgentforceSDK          | 15.2.6   | 15.7.6   | Update available
+iOS             | AgentforceService      | (transitive) | 5.3.3 | Informational
 iOS             | AgentforceVoice        | —        | 1.2.0    | New module (needs import)
 Android         | agentforce-sdk         | 14.177.0 | 15.0.2   | Update available
 Android         | agentforce-sdk-voice   | —        | 15.0.2   | New module (needs import)
 ```
+
+Always include `AgentforceService` in the comparison output even though it's a transitive dependency. This helps track which version of the service layer comes in with each bump.
 
 Summarize release notes highlights and flag anything that requires code changes beyond version strings.
 

--- a/.claude/skills/bump-sdk-version/SKILL.md
+++ b/.claude/skills/bump-sdk-version/SKILL.md
@@ -38,10 +38,12 @@ Release notes: https://github.com/salesforce/AgentforceMobileSDK-Android/release
 ## Local Files That Hold Version Declarations
 
 ### iOS
+
 - **`ios/Podfile.common.rb`** — Pod version pins (e.g., `pod 'AgentforceSDK', '15.2.6'`)
 - **`AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec`** — Pod dependencies in the `Core` subspec
 
 ### Android
+
 - **`AgentforceSDK-ReactNative-Bridge/android/build.gradle`** — Maven dependency versions (e.g., `api "com.salesforce.android.agentforcesdk:agentforce-sdk:14.177.0"`)
 
 ## Workflow
@@ -49,6 +51,7 @@ Release notes: https://github.com/salesforce/AgentforceMobileSDK-Android/release
 ### 1. Read current local versions
 
 Read the files above and extract:
+
 - iOS: `AgentforceSDK` version from `Podfile.common.rb`, whether `AgentforceVoice` pod exists
 - Android: `agentforce-sdk` version from bridge `build.gradle`, whether `agentforce-sdk-voice` exists
 
@@ -62,6 +65,7 @@ Use web fetch or the GitHub API to determine the latest available versions:
 ### 3. Fetch and summarize release notes
 
 Get the latest release from both SDK repos. Focus on:
+
 - Breaking changes or migration steps
 - New modules that need explicit import
 - API surface changes (renamed classes, new required configuration calls)
@@ -70,6 +74,7 @@ Get the latest release from both SDK repos. Focus on:
 ### 4. Present findings to the user
 
 Show a clear comparison:
+
 ```
 Platform        | Dependency             | Current  | Latest   | Status
 iOS             | AgentforceSDK          | 15.2.6   | 15.7.6   | Update available
@@ -86,13 +91,16 @@ Summarize release notes highlights and flag anything that requires code changes 
 ### 5. Apply updates (only after user confirms)
 
 **iOS — `Podfile.common.rb`:**
+
 - Update the `AgentforceSDK` version string
 - Add `AgentforceVoice` pod if it's a new module (insert after the `AgentforceSDK` line)
 
 **iOS — `ReactNativeAgentforce.podspec`:**
+
 - Add `core.dependency "AgentforceVoice"` in the Core subspec if the voice module is new
 
 **Android — bridge `build.gradle`:**
+
 - Update the `agentforce-sdk` version
 - Add `agentforce-sdk-voice` dependency if it's a new module (insert after the `agentforce-sdk` line)
 
@@ -101,9 +109,11 @@ Summarize release notes highlights and flag anything that requires code changes 
 Some version bumps require code changes beyond config files. Call these out explicitly so the user can handle them. Examples:
 
 - **Voice module (Android):** When adding `agentforce-sdk-voice`, the builder in `AgentforceModule.kt` needs:
+
   ```kotlin
   .setAgentforceVoiceModule(AgentforceVoiceProviderFactory(), AgentforceVoiceUIProvider())
   ```
+
   This goes in the `AgentforceConfiguration.builder(...)` chain.
 
 - **New pod sources (iOS):** Some pods require additional sources in the Podfile (already handled — `livekit/podspecs.git` is present).
@@ -119,24 +129,28 @@ If the user accepts, run the setup scripts first (these handle pod install, xcod
 The install scripts must run before the build commands — they handle platform-specific dependency resolution (pod install, xcodegen, gradle setup).
 
 **iOS (Service Agent):**
+
 ```bash
 node installios.js service
 npm run build:ios:service
 ```
 
 **iOS (Employee Agent):**
+
 ```bash
 node installios.js employee
 npm run build:ios:employee
 ```
 
 **Android (Service Agent):**
+
 ```bash
 node installandroid.js service
 npm run build:android:service
 ```
 
 **Android (Employee Agent):**
+
 ```bash
 node installandroid.js employee
 npm run build:android:employee
@@ -147,14 +161,34 @@ Build all four variants (Service + Employee on both platforms) to ensure the bum
 #### Handling build failures
 
 If builds fail:
+
 - Read the error output and identify whether the failure is related to the version bump (e.g., missing import, renamed API, incompatible dependency).
 - If the fix is straightforward (missing import, updated class name from release notes), offer to apply it.
 - If the failure is unrelated to the bump (pre-existing issue, environment problem), let the user know so they can decide how to proceed.
 - If the fix requires code-level changes (like the voice module `.setAgentforceVoiceModule(...)` call), apply them and re-run the build.
 
-### 8. Commit and push
+### 8. Run lint and format checks
 
-After all four variants build successfully, offer to commit and push the changes:
+Before committing, run the formatting and type checks to ensure the changes pass CI:
+
+```bash
+npm run lint
+npm run format
+npm run typecheck
+```
+
+If lint or format checks fail, fix them automatically:
+
+```bash
+npm run lint:fix
+npm run format:fix
+```
+
+Then re-run the checks to confirm they pass. If `typecheck` fails, the issue likely requires a manual code fix — surface the error to the user.
+
+### 9. Commit and push
+
+After all four variants build successfully and lint/format/typecheck pass, offer to commit and push the changes:
 
 1. Run `git diff` and show the user a summary of what changed.
 2. Verify no bootconfig files are staged (`ios/EmployeeAgent/bootconfig.plist`, `android/app/src/employeeAgent/res/values/bootconfig.xml`). If they are, unstage them with `git restore --staged`.

--- a/.claude/skills/bump-sdk-version/SKILL.md
+++ b/.claude/skills/bump-sdk-version/SKILL.md
@@ -105,14 +105,55 @@ Some version bumps require code changes beyond config files. Call these out expl
 
 - **New pod sources (iOS):** Some pods require additional sources in the Podfile (already handled — `livekit/podspecs.git` is present).
 
-### 7. Remind the user of next steps
+### 7. Offer a verification build
 
-After applying:
-1. `cd ios && pod install` (iOS)
-2. Gradle sync (Android)
-3. Build and test both Service Agent and Employee Agent targets
-4. Review `git diff` before committing
-5. Never commit bootconfig files
+After applying the version changes, ask the user if they'd like to run a local build on both platforms to catch compilation errors early.
+
+If the user accepts, run the setup scripts first (these handle pod install, xcodegen, gradle sync, etc.) and then the builds. Run iOS and Android in parallel where possible.
+
+#### Setup + Build Commands
+
+The install scripts must run before the build commands — they handle platform-specific dependency resolution (pod install, xcodegen, gradle setup).
+
+**iOS (Service Agent):**
+```bash
+node installios.js service
+npm run build:ios:service
+```
+
+**iOS (Employee Agent):**
+```bash
+node installios.js employee
+npm run build:ios:employee
+```
+
+**Android (Service Agent):**
+```bash
+node installandroid.js service
+npm run build:android:service
+```
+
+**Android (Employee Agent):**
+```bash
+node installandroid.js employee
+npm run build:android:employee
+```
+
+At minimum, build one variant per platform (Service Agent is lighter since it skips Mobile SDK). If the user wants thorough validation, build all four.
+
+#### Handling build failures
+
+If builds fail:
+- Read the error output and identify whether the failure is related to the version bump (e.g., missing import, renamed API, incompatible dependency).
+- If the fix is straightforward (missing import, updated class name from release notes), offer to apply it.
+- If the failure is unrelated to the bump (pre-existing issue, environment problem), let the user know so they can decide how to proceed.
+- If the fix requires code-level changes (like the voice module `.setAgentforceVoiceModule(...)` call), apply them and re-run the build.
+
+### 8. Remind the user of final steps
+
+After a successful build (or if the user skips the build step):
+1. Review `git diff` before committing
+2. Never commit bootconfig files
 
 ## Important Constraints
 

--- a/.claude/skills/bump-sdk-version/SKILL.md
+++ b/.claude/skills/bump-sdk-version/SKILL.md
@@ -152,11 +152,18 @@ If builds fail:
 - If the failure is unrelated to the bump (pre-existing issue, environment problem), let the user know so they can decide how to proceed.
 - If the fix requires code-level changes (like the voice module `.setAgentforceVoiceModule(...)` call), apply them and re-run the build.
 
-### 8. Remind the user of final steps
+### 8. Commit and push
 
-After a successful build (or if the user skips the build step):
-1. Review `git diff` before committing
-2. Never commit bootconfig files
+After all four variants build successfully, offer to commit and push the changes:
+
+1. Run `git diff` and show the user a summary of what changed.
+2. Verify no bootconfig files are staged (`ios/EmployeeAgent/bootconfig.plist`, `android/app/src/employeeAgent/res/values/bootconfig.xml`). If they are, unstage them with `git restore --staged`.
+3. Stage the relevant files (version config files + any code-level integration changes that were applied).
+4. Commit with a message like: `Bump Agentforce SDK: iOS <old> → <new>, Android <old> → <new>`
+5. Push to the current branch.
+6. If a PR doesn't exist yet for the branch, offer to create one.
+
+Only proceed with each step after user confirmation. Never force-push.
 
 ## Important Constraints
 

--- a/.claude/skills/bump-sdk-version/SKILL.md
+++ b/.claude/skills/bump-sdk-version/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: bump-sdk-version
+description: Bump Agentforce SDK versions for iOS and Android in this React Native project. Checks external repos for the latest releases, compares against local versions, surfaces release notes and breaking changes, and applies the updates. Use this skill when the user mentions upgrading, bumping, or updating the SDK version, checking for new SDK releases, or when they reference AgentforceSDK versioning. Also trigger when the user asks about the latest available SDK version or what changed in the newest release.
+---
+
+# Bump Agentforce SDK Versions
+
+This skill checks external Agentforce SDK repos for the latest versions, compares them against what's configured locally, shows release notes (especially breaking changes or new module requirements), and applies the version bumps to local config files.
+
+## Why this skill exists
+
+The Agentforce SDK ships independently for iOS and Android with different versioning schemes. A version bump isn't just changing a number — new releases may decouple modules (like the voice module split), add required dependencies, or change API surfaces. This skill handles the research, comparison, and mechanical updates so you can focus on integration-level changes that require judgment.
+
+## External Sources to Check
+
+### iOS
+
+Versions live in the CocoaPods specs repo. Each pod has a directory per version:
+
+- **AgentforceSDK** (main UI SDK): https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs/tree/master/AgentforceSDK
+- **AgentforceService** (headless/API layer, transitive): https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs/tree/master/AgentforceService
+- **AgentforceVoice** (voice module, opt-in): https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs/tree/master/AgentforceVoice
+
+Release notes: https://github.com/salesforce/AgentforceMobileSDK-iOS/releases/latest
+
+### Android
+
+Versions are published to Maven and documented in the SDK README:
+
+- **Repo:** https://github.com/salesforce/AgentforceMobileSDK-Android
+- **Maven repository:** `https://opensource.salesforce.com/AgentforceMobileSDK-Android/agentforce-sdk-repository`
+- **Artifacts:**
+  - `com.salesforce.android.agentforcesdk:agentforce-sdk` — core SDK
+  - `com.salesforce.android.agentforcesdk:agentforce-sdk-voice` — voice module (opt-in)
+
+Release notes: https://github.com/salesforce/AgentforceMobileSDK-Android/releases/latest
+
+## Local Files That Hold Version Declarations
+
+### iOS
+- **`ios/Podfile.common.rb`** — Pod version pins (e.g., `pod 'AgentforceSDK', '15.2.6'`)
+- **`AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec`** — Pod dependencies in the `Core` subspec
+
+### Android
+- **`AgentforceSDK-ReactNative-Bridge/android/build.gradle`** — Maven dependency versions (e.g., `api "com.salesforce.android.agentforcesdk:agentforce-sdk:14.177.0"`)
+
+## Workflow
+
+### 1. Read current local versions
+
+Read the files above and extract:
+- iOS: `AgentforceSDK` version from `Podfile.common.rb`, whether `AgentforceVoice` pod exists
+- Android: `agentforce-sdk` version from bridge `build.gradle`, whether `agentforce-sdk-voice` exists
+
+### 2. Fetch latest remote versions
+
+Use web fetch or the GitHub API to determine the latest available versions:
+
+- **iOS pods:** Fetch directory listings from the specs repo (each subfolder name is a version). The highest semver directory is the latest.
+- **Android:** Fetch the README from the Android SDK repo — it contains the canonical dependency declarations with current versions. Alternatively check the latest GitHub release tag.
+
+### 3. Fetch and summarize release notes
+
+Get the latest release from both SDK repos. Focus on:
+- Breaking changes or migration steps
+- New modules that need explicit import
+- API surface changes (renamed classes, new required configuration calls)
+- Deprecated APIs being removed
+
+### 4. Present findings to the user
+
+Show a clear comparison:
+```
+Platform        | Dependency             | Current  | Latest   | Status
+iOS             | AgentforceSDK          | 15.2.6   | 15.7.6   | Update available
+iOS             | AgentforceVoice        | —        | 1.2.0    | New module (needs import)
+Android         | agentforce-sdk         | 14.177.0 | 15.0.2   | Update available
+Android         | agentforce-sdk-voice   | —        | 15.0.2   | New module (needs import)
+```
+
+Summarize release notes highlights and flag anything that requires code changes beyond version strings.
+
+### 5. Apply updates (only after user confirms)
+
+**iOS — `Podfile.common.rb`:**
+- Update the `AgentforceSDK` version string
+- Add `AgentforceVoice` pod if it's a new module (insert after the `AgentforceSDK` line)
+
+**iOS — `ReactNativeAgentforce.podspec`:**
+- Add `core.dependency "AgentforceVoice"` in the Core subspec if the voice module is new
+
+**Android — bridge `build.gradle`:**
+- Update the `agentforce-sdk` version
+- Add `agentforce-sdk-voice` dependency if it's a new module (insert after the `agentforce-sdk` line)
+
+### 6. Flag code-level integration changes
+
+Some version bumps require code changes beyond config files. Call these out explicitly so the user can handle them. Examples:
+
+- **Voice module (Android):** When adding `agentforce-sdk-voice`, the builder in `AgentforceModule.kt` needs:
+  ```kotlin
+  .setAgentforceVoiceModule(AgentforceVoiceProviderFactory(), AgentforceVoiceUIProvider())
+  ```
+  This goes in the `AgentforceConfiguration.builder(...)` chain.
+
+- **New pod sources (iOS):** Some pods require additional sources in the Podfile (already handled — `livekit/podspecs.git` is present).
+
+### 7. Remind the user of next steps
+
+After applying:
+1. `cd ios && pod install` (iOS)
+2. Gradle sync (Android)
+3. Build and test both Service Agent and Employee Agent targets
+4. Review `git diff` before committing
+5. Never commit bootconfig files
+
+## Important Constraints
+
+- iOS and Android SDK version numbers use different schemes — they won't match. That's expected.
+- The `AgentforceService` pod is a transitive dependency (pulled in by `AgentforceSDK`). Don't add it explicitly unless the release notes say otherwise.
+- Never commit or push changes to bootconfig files (`ios/EmployeeAgent/bootconfig.plist`, `android/app/src/employeeAgent/res/values/bootconfig.xml`).
+- Always show the user what will change before modifying files.

--- a/.claude/skills/bump-sdk-version/SKILL.md
+++ b/.claude/skills/bump-sdk-version/SKILL.md
@@ -142,7 +142,7 @@ node installandroid.js employee
 npm run build:android:employee
 ```
 
-At minimum, build one variant per platform (Service Agent is lighter since it skips Mobile SDK). If the user wants thorough validation, build all four.
+Build all four variants (Service + Employee on both platforms) to ensure the bump doesn't break either integration path.
 
 #### Handling build failures
 

--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,8 @@ local.properties
 /packages/react-native/android/*
 !/packages/react-native/android/README.md
 .kotlin/
-/.claude
+/.claude/*
+!/.claude/skills/
 
 # Node
 node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@ node_modules/
 # Build outputs
 ios/build/
 android/build/
+AgentforceSDK-ReactNative-Bridge/android/build/
 android/.gradle/
 *.log
 

--- a/AgentforceSDK-ReactNative-Bridge/android/build.gradle
+++ b/AgentforceSDK-ReactNative-Bridge/android/build.gradle
@@ -49,7 +49,8 @@ repositories {
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
     implementation "com.facebook.react:react-android"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk:14.177.0"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk:15.0.2"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk-voice:15.0.2"
     // compileOnly: host app adds this for Employee Agent. Bridge compiles; host provides at runtime.
     compileOnly "com.salesforce.mobilesdk:SalesforceReact:13.1.1"
 

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -21,6 +21,8 @@ import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceConfigur
 import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceMode
 import com.salesforce.android.agentforcesdkimpl.configuration.ServiceAgentConfiguration
 import com.salesforce.android.agentforcesdkimpl.utils.AgentforceFeatureFlagSettings
+import com.salesforce.android.agentforcesdkvoice.AgentforceVoiceProviderFactory
+import com.salesforce.android.agentforcesdkvoice.AgentforceVoiceUIProvider
 import com.salesforce.android.agentforceservice.conversationservice.data.CopilotContextVariable
 import com.salesforce.android.agentforceservice.conversationservice.data.CopilotAdditionalContext
 import com.salesforce.android.reactagentforce.models.AgentMode as LocalAgentMode
@@ -179,6 +181,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setLogger(bridgeLogger)
                     .setNavigation(bridgeNavigation)
                 agentforceConfigBuilder.setPermission(permissions)
+                agentforceConfigBuilder.setAgentforceVoiceModule(AgentforceVoiceProviderFactory(), AgentforceVoiceUIProvider())
                 // Always attach bridgeViewProvider so late registrations take effect.
                 // canHandle() returns false when the map is empty, matching no-provider behavior.
                 agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
@@ -278,6 +281,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setNavigation(bridgeNavigation)
                     .setDataProvider(dataProvider)
                 agentforceConfigBuilder.setPermission(permissions)
+                agentforceConfigBuilder.setAgentforceVoiceModule(AgentforceVoiceProviderFactory(), AgentforceVoiceUIProvider())
                 // Always attach bridgeViewProvider so late registrations take effect.
                 // canHandle() returns false when the map is empty, matching no-provider behavior.
                 agentforceConfigBuilder.setViewProvider(bridgeViewProvider)

--- a/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
+++ b/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
@@ -34,6 +34,7 @@ Pod::Spec.new do |s|
     ]
     core.dependency "React-Core"
     core.dependency "AgentforceSDK"
+    core.dependency "AgentforceVoice"
   end
 
   # Optional: add for Employee Agent auth (OAuth via Salesforce Mobile SDK).

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -16,7 +16,8 @@ def shared_pods
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'AgentforceSDK', '15.2.6'
+  pod 'AgentforceSDK', '15.7.6'
+  pod 'AgentforceVoice'
   pod 'Messaging-InApp-Core', '> 1.10.0'
 
   # JWTKit is required by AgentforceService but not resolved automatically


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill (`/bump-sdk-version`) that automates checking for new Agentforce SDK releases, comparing versions, surfacing release notes, and applying version bumps across iOS and Android config files
- Bumps SDK versions: iOS AgentforceSDK 15.2.6 → 15.7.6, Android agentforce-sdk 14.177.0 → 15.0.2
- Adds voice module integration (AgentforceVoice for iOS, agentforce-sdk-voice for Android) including code-level wiring in `AgentforceModule.kt`

## Test plan
- [x] iOS Service Agent builds successfully
- [x] iOS Employee Agent builds successfully
- [x] Android Service Agent builds successfully
- [x] Android Employee Agent builds successfully
- [ ] Verify voice feature works end-to-end on a device with voice-enabled agent
- [ ] Verify existing Service Agent and Employee Agent flows are unaffected