### PR TITLE
Add UIDelegate forwarding bridge for agent response events

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,11 +1,11 @@
 name: PR Validation
 
-# Trigger on pull requests to dev and pushes to dev (for verification)
+# Trigger on pull requests to dev/main and pushes to dev/main (for verification)
 on:
   pull_request:
-    branches: [ dev ]
+    branches: [ dev, main ]
   push:
-    branches: [ dev ]
+    branches: [ dev, main ]
 
 # Cancel in-progress runs for the same PR/branch
 concurrency:

--- a/AgentforceSDK-ReactNative-Bridge/android/build.gradle
+++ b/AgentforceSDK-ReactNative-Bridge/android/build.gradle
@@ -49,7 +49,7 @@ repositories {
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
     implementation "com.facebook.react:react-android"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk:14.177.0"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk:14.177.2"
     // compileOnly: host app adds this for Employee Agent. Bridge compiles; host provides at runtime.
     compileOnly "com.salesforce.mobilesdk:SalesforceReact:13.1.1"
 

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -82,6 +82,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     // Bridge hidden prechat fields (Service Agent only)
     private val bridgeHiddenPreChat = BridgeHiddenPreChat()
 
+    // Bridge UI delegate for forwarding agent response events to JS
+    private val bridgeUIDelegate = BridgeUIDelegate(reactContext)
+
     // Coroutine scope for async operations
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
@@ -178,6 +181,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setCameraUriProvider(cameraUriProvider)
                     .setLogger(bridgeLogger)
                     .setNavigation(bridgeNavigation)
+                    .setDelegate(bridgeUIDelegate)
                 agentforceConfigBuilder.setPermission(permissions)
                 // Always attach bridgeViewProvider so late registrations take effect.
                 // canHandle() returns false when the map is empty, matching no-provider behavior.
@@ -277,6 +281,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setLogger(bridgeLogger)
                     .setNavigation(bridgeNavigation)
                     .setDataProvider(dataProvider)
+                    .setDelegate(bridgeUIDelegate)
                 agentforceConfigBuilder.setPermission(permissions)
                 // Always attach bridgeViewProvider so late registrations take effect.
                 // canHandle() returns false when the map is empty, matching no-provider behavior.
@@ -605,6 +610,23 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     fun enableNavigationForwarding(enabled: Boolean, promise: Promise) {
         bridgeNavigation.forwardingEnabled = enabled
         Log.d(TAG, "Navigation forwarding ${if (enabled) "enabled" else "disabled"}")
+        promise.resolve(true)
+    }
+
+    // endregion
+
+    // region Agent Response Forwarding
+
+    @ReactMethod
+    fun enableUIDelegateForwarding(enabled: Boolean, promise: Promise) {
+        bridgeUIDelegate.forwardingEnabled = enabled
+        Log.d(TAG, "UI delegate forwarding ${if (enabled) "enabled" else "disabled"}")
+        promise.resolve(true)
+    }
+
+    @ReactMethod
+    fun provideModifiedUtterance(requestId: String, modifiedUtterance: String, promise: Promise) {
+        bridgeUIDelegate.completeModification(requestId, modifiedUtterance)
         promise.resolve(true)
     }
 

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -626,8 +626,8 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun provideModifiedUtterance(requestId: String, modifiedUtterance: String, promise: Promise) {
-        bridgeUIDelegate.completeModification(requestId, modifiedUtterance)
-        promise.resolve(true)
+        val applied = bridgeUIDelegate.completeModification(requestId, modifiedUtterance)
+        promise.resolve(applied)
     }
 
     // endregion

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeUIDelegate.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeUIDelegate.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-present, salesforce.com, inc.
+ * Copyright (c) 2026-present, salesforce.com, inc.
  * All rights reserved.
  */
 package com.salesforce.android.reactagentforce
@@ -67,8 +67,10 @@ class BridgeUIDelegate(private val reactContext: ReactContext) : AgentforceUIDel
         }
     }
 
-    fun completeModification(requestId: String, modifiedUtterance: String) {
-        pendingModifications[requestId]?.complete(modifiedUtterance)
+    fun completeModification(requestId: String, modifiedUtterance: String): Boolean {
+        val deferred = pendingModifications[requestId] ?: return false
+        deferred.complete(modifiedUtterance)
+        return true
     }
 
     override fun didSendUtterance(agentforceUtterance: AgentforceUtterance) {

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeUIDelegate.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeUIDelegate.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc.
+ * All rights reserved.
+ */
+package com.salesforce.android.reactagentforce
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.salesforce.android.agentforcesdkimpl.AgentConversation
+import com.salesforce.android.agentforcesdkimpl.AgentforceConversation
+import com.salesforce.android.agentforcesdkimpl.AgentforceUIDelegate
+import com.salesforce.android.agentforceservice.AgentforceUtterance
+import com.salesforce.android.agentforceservice.conversationservice.data.AgentforceMessage
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeout
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+class BridgeUIDelegate(private val reactContext: ReactContext) : AgentforceUIDelegate {
+
+    @Volatile
+    var forwardingEnabled: Boolean = false
+
+    private val pendingModifications = ConcurrentHashMap<String, CompletableDeferred<String>>()
+
+    private val isoFormatter: SimpleDateFormat
+        get() = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+
+    private fun conversationIdString(conversation: AgentConversation): String {
+        return if (conversation is AgentforceConversation) {
+            conversation.id
+        } else {
+            conversation.hashCode().toString()
+        }
+    }
+
+    override suspend fun modifyUtteranceBeforeSending(agentforceUtterance: AgentforceUtterance): AgentforceUtterance {
+        if (!forwardingEnabled) return agentforceUtterance
+
+        val requestId = UUID.randomUUID().toString()
+        val deferred = CompletableDeferred<String>()
+        pendingModifications[requestId] = deferred
+
+        val params = Arguments.createMap().apply {
+            putString("requestId", requestId)
+            putString("utterance", agentforceUtterance.utterance)
+        }
+
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit("onModifyUtteranceRequest", params)
+
+        return try {
+            val modified = withTimeout(5000) { deferred.await() }
+            AgentforceUtterance(utterance = modified, agentforceAttachment = agentforceUtterance.agentforceAttachment)
+        } catch (_: Exception) {
+            agentforceUtterance
+        } finally {
+            pendingModifications.remove(requestId)
+        }
+    }
+
+    fun completeModification(requestId: String, modifiedUtterance: String) {
+        pendingModifications[requestId]?.complete(modifiedUtterance)
+    }
+
+    override fun didSendUtterance(agentforceUtterance: AgentforceUtterance) {
+        if (!forwardingEnabled) return
+
+        val params = Arguments.createMap().apply {
+            putString("utterance", agentforceUtterance.utterance)
+            putBoolean("hasAttachment", agentforceUtterance.agentforceAttachment != null)
+            putString("timestamp", isoFormatter.format(Date()))
+        }
+
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit("onUtteranceSent", params)
+    }
+
+    override fun userDidSwitchAgents(newConversation: AgentConversation) {
+        if (!forwardingEnabled) return
+
+        val params = Arguments.createMap().apply {
+            putString("conversationId", conversationIdString(newConversation))
+            putString("timestamp", isoFormatter.format(Date()))
+        }
+
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit("onAgentSwitch", params)
+    }
+
+    override fun didReceiveResponse(agentforceMessage: AgentforceMessage, conversation: AgentConversation) {
+        if (!forwardingEnabled) return
+
+        val params = Arguments.createMap().apply {
+            putString("responseId", agentforceMessage.id)
+            val text = agentforceMessage.message ?: agentforceMessage.text
+            if (text != null) {
+                putString("message", text)
+            } else {
+                putNull("message")
+            }
+            putString("type", agentforceMessage.type ?: "agent")
+            putString("conversationId", conversationIdString(conversation))
+            putString("timestamp", isoFormatter.format(Date(agentforceMessage.timeStamp)))
+        }
+
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit("onAgentResponse", params)
+    }
+}

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
@@ -109,6 +109,17 @@ RCT_EXTERN_METHOD(enableNavigationForwarding:(BOOL)enabled
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+// MARK: - Agent Response
+
+RCT_EXTERN_METHOD(enableUIDelegateForwarding:(BOOL)enabled
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(provideModifiedUtterance:(NSString *)requestId
+                  modifiedUtterance:(NSString *)modifiedUtterance
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 // MARK: - View Provider
 
 RCT_EXTERN_METHOD(registerViewProvider:(NSDictionary *)config

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -901,9 +901,11 @@ class AgentforceModule: RCTEventEmitter {
                 "utterance": utteranceText
             ])
 
-            // 3. Timeout: complete with nil if JS hasn't responded
-            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) { [weak self] in
-                guard let self else { return }
+            // 3. Timeout: complete with nil if JS hasn't responded.
+            // No [weak self] — the continuation MUST be resumed exactly once.
+            // If self were deallocated before the timeout, skipping resume
+            // would leave the CheckedContinuation un-resumed (undefined behavior).
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
                 let pending: ((String?) -> Void)? = self.modifyContinuationLock.withLock {
                     self.modifyContinuations.removeValue(forKey: requestId)
                 }
@@ -922,8 +924,12 @@ class AgentforceModule: RCTEventEmitter {
         let completion: ((String?) -> Void)? = modifyContinuationLock.withLock {
             modifyContinuations.removeValue(forKey: requestId)
         }
-        completion?(modifiedUtterance)
-        resolve(true)
+        if let completion {
+            completion(modifiedUtterance)
+            resolve(true)
+        } else {
+            resolve(false)
+        }
     }
 
     // MARK: - View Provider

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -81,8 +81,23 @@ class AgentforceModule: RCTEventEmitter {
         return true
     }
 
+    /// Stored UI delegate forwarding flag applied to each new voice delegate instance
+    private var _uiDelegateForwardingEnabled = false
+
+    /// Pending modify-utterance continuations keyed by requestId.
+    /// Value is called with the modified text, or nil on timeout.
+    private let modifyContinuationLock = NSLock()
+    private var modifyContinuations: [String: (String?) -> Void] = [:]
+
     override func supportedEvents() -> [String]! {
-        return ["onLogMessage", "onNavigationRequest"]
+        return [
+            "onLogMessage",
+            "onNavigationRequest",
+            "onAgentResponse",
+            "onUtteranceSent",
+            "onAgentSwitch",
+            "onModifyUtteranceRequest"
+        ]
     }
 
     override func startObserving() {
@@ -368,8 +383,10 @@ class AgentforceModule: RCTEventEmitter {
                     // Create voice delegate to handle voice button taps
                     let delegate = AgentforceVoiceDelegate(
                         agentforceClient: client,
-                        presentingViewController: nil // Will find topmost VC automatically
+                        presentingViewController: nil,
+                        module: self
                     )
+                    delegate.forwardingEnabled = _uiDelegateForwardingEnabled
                     self.voiceDelegate = delegate
 
                     let chatView = try client.createAgentforceChatView(
@@ -453,8 +470,10 @@ class AgentforceModule: RCTEventEmitter {
                     // Create voice delegate to handle voice button taps
                     let delegate = AgentforceVoiceDelegate(
                         agentforceClient: client,
-                        presentingViewController: nil // Will find topmost VC automatically
+                        presentingViewController: nil,
+                        module: self
                     )
+                    delegate.forwardingEnabled = _uiDelegateForwardingEnabled
                     self.voiceDelegate = delegate
 
                     let chatView = try client.createAgentforceChatView(
@@ -832,6 +851,79 @@ class AgentforceModule: RCTEventEmitter {
     func emitNavigationEvent(_ payload: [String: Any]) {
         guard listenerLock.withLock({ _hasListeners }) else { return }
         sendEvent(withName: "onNavigationRequest", body: payload)
+    }
+
+    // MARK: - Agent Response
+
+    @objc
+    func enableUIDelegateForwarding(
+        _ enabled: Bool,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        _uiDelegateForwardingEnabled = enabled
+        voiceDelegate?.forwardingEnabled = enabled
+        resolve(true)
+    }
+
+    func emitAgentResponseEvent(_ payload: [String: Any]) {
+        guard listenerLock.withLock({ _hasListeners }) else { return }
+        sendEvent(withName: "onAgentResponse", body: payload)
+    }
+
+    func emitUtteranceSentEvent(_ payload: [String: Any]) {
+        guard listenerLock.withLock({ _hasListeners }) else { return }
+        sendEvent(withName: "onUtteranceSent", body: payload)
+    }
+
+    func emitAgentSwitchEvent(_ payload: [String: Any]) {
+        guard listenerLock.withLock({ _hasListeners }) else { return }
+        sendEvent(withName: "onAgentSwitch", body: payload)
+    }
+
+    func emitModifyUtteranceRequest(_ payload: [String: Any]) {
+        guard listenerLock.withLock({ _hasListeners }) else { return }
+        sendEvent(withName: "onModifyUtteranceRequest", body: payload)
+    }
+
+    func awaitModifiedUtterance(requestId: String, utteranceText: String, timeout: TimeInterval) async -> String? {
+        await withCheckedContinuation { (continuation: CheckedContinuation<String?, Never>) in
+            // 1. Register continuation before emitting so early responses aren't lost
+            modifyContinuationLock.withLock {
+                modifyContinuations[requestId] = { text in
+                    continuation.resume(returning: text)
+                }
+            }
+
+            // 2. Emit request to JS
+            emitModifyUtteranceRequest([
+                "requestId": requestId,
+                "utterance": utteranceText
+            ])
+
+            // 3. Timeout: complete with nil if JS hasn't responded
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) { [weak self] in
+                guard let self else { return }
+                let pending: ((String?) -> Void)? = self.modifyContinuationLock.withLock {
+                    self.modifyContinuations.removeValue(forKey: requestId)
+                }
+                pending?(nil)
+            }
+        }
+    }
+
+    @objc
+    func provideModifiedUtterance(
+        _ requestId: String,
+        modifiedUtterance: String,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        let completion: ((String?) -> Void)? = modifyContinuationLock.withLock {
+            modifyContinuations.removeValue(forKey: requestId)
+        }
+        completion?(modifiedUtterance)
+        resolve(true)
     }
 
     // MARK: - View Provider

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceVoiceDelegate.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceVoiceDelegate.swift
@@ -130,10 +130,13 @@ public class AgentforceVoiceDelegate: AgentforceUIDelegate {
     public func didReceiveResponse(_ message: AgentforceMessage, from conversation: AgentConversation) {
         guard forwardingEnabled else { return }
 
+        // AgentforceSDK.AgentforceMessage does not yet expose `id` or `type`.
+        // Generate a local responseId and derive type from isUserMessage until
+        // the SDK surfaces those properties.
         let payload: [String: Any] = [
-            "responseId": message.id,
+            "responseId": UUID().uuidString,
             "message": message.message ?? NSNull(),
-            "type": message.type,
+            "type": message.isUserMessage ? "user" : "agent",
             "conversationId": conversation.conversationId.uuidString,
             "timestamp": ISO8601DateFormatter().string(from: Date())
         ]

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceVoiceDelegate.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceVoiceDelegate.swift
@@ -131,8 +131,9 @@ public class AgentforceVoiceDelegate: AgentforceUIDelegate {
         guard forwardingEnabled else { return }
 
         let payload: [String: Any] = [
+            "responseId": message.id,
             "message": message.message ?? NSNull(),
-            "type": "agent",
+            "type": message.type,
             "conversationId": conversation.conversationId.uuidString,
             "timestamp": ISO8601DateFormatter().string(from: Date())
         ]

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceVoiceDelegate.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceVoiceDelegate.swift
@@ -6,18 +6,28 @@
 import Foundation
 import UIKit
 import SwiftUI
-import AgentforceSDK
-import AgentforceService
+@preconcurrency import AgentforceSDK
+@preconcurrency import AgentforceService
 
 /// Delegate that handles voice interactions for the Agentforce SDK
 public class AgentforceVoiceDelegate: AgentforceUIDelegate {
 
     weak var agentforceClient: AgentforceClient?
     weak var presentingViewController: UIViewController?
+    weak var module: AgentforceModule?
 
-    public init(agentforceClient: AgentforceClient?, presentingViewController: UIViewController?) {
+    private let forwardingLock = NSLock()
+    private var _forwardingEnabled: Bool = false
+
+    var forwardingEnabled: Bool {
+        get { forwardingLock.withLock { _forwardingEnabled } }
+        set { forwardingLock.withLock { _forwardingEnabled = newValue } }
+    }
+
+    init(agentforceClient: AgentforceClient?, presentingViewController: UIViewController?, module: AgentforceModule? = nil) {
         self.agentforceClient = agentforceClient
         self.presentingViewController = presentingViewController
+        self.module = module
     }
 
     /// Called when the user taps the voice button in the chat UI
@@ -79,17 +89,54 @@ public class AgentforceVoiceDelegate: AgentforceUIDelegate {
         return topController
     }
 
-    // MARK: - Optional AgentforceUIDelegate methods (default implementations)
+    // MARK: - AgentforceUIDelegate forwarding methods
 
     public func modifyUtteranceBeforeSending(_ utterance: AgentforceUtterance) async -> AgentforceUtterance {
+        guard forwardingEnabled, let module = module else { return utterance }
+
+        let requestId = UUID().uuidString
+
+        // awaitModifiedUtterance registers the continuation then emits the request internally
+        let result = await module.awaitModifiedUtterance(
+            requestId: requestId,
+            utteranceText: utterance.utterance,
+            timeout: 5.0
+        )
+        if let modifiedText = result {
+            return AgentforceUtterance(utterance: modifiedText, attachment: utterance.attachment)
+        }
         return utterance
     }
 
     public func didSendUtterance(_ utterance: AgentforceUtterance) {
-        // No-op
+        guard forwardingEnabled else { return }
+
+        module?.emitUtteranceSentEvent([
+            "utterance": utterance.utterance,
+            "hasAttachment": utterance.attachment != nil,
+            "timestamp": ISO8601DateFormatter().string(from: Date())
+        ])
     }
 
     public func userDidSwitchAgents(newConversation: AgentConversation) {
-        // No-op
+        guard forwardingEnabled else { return }
+
+        module?.emitAgentSwitchEvent([
+            "conversationId": newConversation.conversationId.uuidString,
+            "timestamp": ISO8601DateFormatter().string(from: Date())
+        ])
+    }
+
+    public func didReceiveResponse(_ message: AgentforceMessage, from conversation: AgentConversation) {
+        guard forwardingEnabled else { return }
+
+        let payload: [String: Any] = [
+            "message": message.message ?? NSNull(),
+            "type": "agent",
+            "conversationId": conversation.conversationId.uuidString,
+            "timestamp": ISO8601DateFormatter().string(from: Date())
+        ]
+
+        module?.emitAgentResponseEvent(payload)
     }
 }

--- a/AgentforceSDK-ReactNative-Bridge/src/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/index.ts
@@ -35,6 +35,11 @@ export type {
   ViewProviderDelegate,
   ViewProviderComponentData,
   HiddenPreChatFields,
+  UIDelegate,
+  AgentResponseEvent,
+  UtteranceSentEvent,
+  AgentSwitchEvent,
+  ModifyUtteranceRequest,
 } from './types';
 export { isServiceAgentConfig, isEmployeeAgentConfig, isLegacyConfig } from './types';
 

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -44,7 +44,13 @@ export type { NavigationDelegate, NavigationRequest };
 export type { AgentforceAdditionalContext, AgentforceContextVariable };
 export type { ViewProviderDelegate };
 export type { HiddenPreChatFields };
-export type { UIDelegate, AgentResponseEvent, UtteranceSentEvent, AgentSwitchEvent, ModifyUtteranceRequest };
+export type {
+  UIDelegate,
+  AgentResponseEvent,
+  UtteranceSentEvent,
+  AgentSwitchEvent,
+  ModifyUtteranceRequest,
+};
 
 /**
  * Native module event names
@@ -312,7 +318,7 @@ class AgentforceService {
    */
   clearUIDelegate(): void {
     this.uiDelegate = null;
-    this.uiDelegateSubscriptions.forEach((s) => s.remove());
+    this.uiDelegateSubscriptions.forEach(s => s.remove());
     this.uiDelegateSubscriptions = [];
     AgentforceModule?.enableUIDelegateForwarding(false);
     console.log('[AgentforceService] UI delegate cleared');
@@ -322,37 +328,28 @@ class AgentforceService {
    * Set up listeners for all UI delegate events from native layer
    */
   private setupUIDelegateListeners(): void {
-    this.uiDelegateSubscriptions.forEach((s) => s.remove());
+    this.uiDelegateSubscriptions.forEach(s => s.remove());
     this.uiDelegateSubscriptions = [];
     if (!this.eventEmitter) {
       return;
     }
 
     this.uiDelegateSubscriptions.push(
-      this.eventEmitter.addListener(
-        EVENTS.AGENT_RESPONSE,
-        (event: AgentResponseEvent) => {
-          this.uiDelegate?.onAgentResponse(event);
-        },
-      ),
+      this.eventEmitter.addListener(EVENTS.AGENT_RESPONSE, (event: AgentResponseEvent) => {
+        this.uiDelegate?.onAgentResponse(event);
+      }),
     );
 
     this.uiDelegateSubscriptions.push(
-      this.eventEmitter.addListener(
-        EVENTS.UTTERANCE_SENT,
-        (event: UtteranceSentEvent) => {
-          this.uiDelegate?.onUtteranceSent?.(event);
-        },
-      ),
+      this.eventEmitter.addListener(EVENTS.UTTERANCE_SENT, (event: UtteranceSentEvent) => {
+        this.uiDelegate?.onUtteranceSent?.(event);
+      }),
     );
 
     this.uiDelegateSubscriptions.push(
-      this.eventEmitter.addListener(
-        EVENTS.AGENT_SWITCH,
-        (event: AgentSwitchEvent) => {
-          this.uiDelegate?.onAgentSwitch?.(event);
-        },
-      ),
+      this.eventEmitter.addListener(EVENTS.AGENT_SWITCH, (event: AgentSwitchEvent) => {
+        this.uiDelegate?.onAgentSwitch?.(event);
+      }),
     );
 
     this.uiDelegateSubscriptions.push(
@@ -1040,7 +1037,7 @@ class AgentforceService {
     this.navigationSubscription = null;
     this.navigationDelegate = null;
 
-    this.uiDelegateSubscriptions.forEach((s) => s.remove());
+    this.uiDelegateSubscriptions.forEach(s => s.remove());
     this.uiDelegateSubscriptions = [];
     this.uiDelegate = null;
 

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -27,6 +27,13 @@ import type {
 } from '../types/AgentforceContext';
 import { ViewProviderDelegate } from '../types/ViewProviderDelegate';
 import type { HiddenPreChatFields } from '../types/HiddenPreChatFields';
+import type {
+  UIDelegate,
+  AgentResponseEvent,
+  UtteranceSentEvent,
+  AgentSwitchEvent,
+  ModifyUtteranceRequest,
+} from '../types/UIDelegate';
 
 const { AgentforceModule } = NativeModules;
 
@@ -37,6 +44,7 @@ export type { NavigationDelegate, NavigationRequest };
 export type { AgentforceAdditionalContext, AgentforceContextVariable };
 export type { ViewProviderDelegate };
 export type { HiddenPreChatFields };
+export type { UIDelegate, AgentResponseEvent, UtteranceSentEvent, AgentSwitchEvent, ModifyUtteranceRequest };
 
 /**
  * Native module event names
@@ -44,6 +52,10 @@ export type { HiddenPreChatFields };
 const EVENTS = {
   LOG_MESSAGE: 'onLogMessage',
   NAVIGATION_REQUEST: 'onNavigationRequest',
+  AGENT_RESPONSE: 'onAgentResponse',
+  UTTERANCE_SENT: 'onUtteranceSent',
+  AGENT_SWITCH: 'onAgentSwitch',
+  MODIFY_UTTERANCE_REQUEST: 'onModifyUtteranceRequest',
 } as const;
 
 /**
@@ -119,6 +131,16 @@ class AgentforceService {
    * Subscription for navigation request events
    */
   private navigationSubscription: EmitterSubscription | null = null;
+
+  /**
+   * UI delegate for receiving agent response events
+   */
+  private uiDelegate: UIDelegate | null = null;
+
+  /**
+   * Subscriptions for UI delegate events (response, utterance sent, agent switch, modify utterance)
+   */
+  private uiDelegateSubscriptions: EmitterSubscription[] = [];
 
   /**
    * View provider delegate configuration (registered component types + React component name)
@@ -257,6 +279,96 @@ class AgentforceService {
       (event: NavigationRequest) => {
         this.navigationDelegate?.onNavigate(event);
       },
+    );
+  }
+
+  /**
+   * Register a UI delegate to receive agent response events from the native Agentforce SDK.
+   *
+   * Can be called before or after launching a conversation. Events are emitted only for
+   * complete (non-streaming) agent responses.
+   *
+   * @param delegate - UI delegate implementation
+   *
+   * @example
+   * ```typescript
+   * AgentforceService.setUIDelegate({
+   *   onAgentResponse(event) {
+   *     console.log(`Agent response: ${event.message}`);
+   *     console.log(`Conversation: ${event.conversationId}`);
+   *   },
+   * });
+   * ```
+   */
+  setUIDelegate(delegate: UIDelegate): void {
+    this.uiDelegate = delegate;
+    this.setupUIDelegateListeners();
+    AgentforceModule?.enableUIDelegateForwarding(true);
+    console.log('[AgentforceService] UI delegate registered');
+  }
+
+  /**
+   * Clear the registered UI delegate and stop receiving agent response events.
+   */
+  clearUIDelegate(): void {
+    this.uiDelegate = null;
+    this.uiDelegateSubscriptions.forEach((s) => s.remove());
+    this.uiDelegateSubscriptions = [];
+    AgentforceModule?.enableUIDelegateForwarding(false);
+    console.log('[AgentforceService] UI delegate cleared');
+  }
+
+  /**
+   * Set up listeners for all UI delegate events from native layer
+   */
+  private setupUIDelegateListeners(): void {
+    this.uiDelegateSubscriptions.forEach((s) => s.remove());
+    this.uiDelegateSubscriptions = [];
+    if (!this.eventEmitter) {
+      return;
+    }
+
+    this.uiDelegateSubscriptions.push(
+      this.eventEmitter.addListener(
+        EVENTS.AGENT_RESPONSE,
+        (event: AgentResponseEvent) => {
+          this.uiDelegate?.onAgentResponse(event);
+        },
+      ),
+    );
+
+    this.uiDelegateSubscriptions.push(
+      this.eventEmitter.addListener(
+        EVENTS.UTTERANCE_SENT,
+        (event: UtteranceSentEvent) => {
+          this.uiDelegate?.onUtteranceSent?.(event);
+        },
+      ),
+    );
+
+    this.uiDelegateSubscriptions.push(
+      this.eventEmitter.addListener(
+        EVENTS.AGENT_SWITCH,
+        (event: AgentSwitchEvent) => {
+          this.uiDelegate?.onAgentSwitch?.(event);
+        },
+      ),
+    );
+
+    this.uiDelegateSubscriptions.push(
+      this.eventEmitter.addListener(
+        EVENTS.MODIFY_UTTERANCE_REQUEST,
+        async (request: ModifyUtteranceRequest) => {
+          try {
+            const modified = this.uiDelegate?.modifyUtterance
+              ? await Promise.resolve(this.uiDelegate.modifyUtterance(request))
+              : request.utterance;
+            AgentforceModule?.provideModifiedUtterance(request.requestId, modified);
+          } catch {
+            AgentforceModule?.provideModifiedUtterance(request.requestId, request.utterance);
+          }
+        },
+      ),
     );
   }
 
@@ -927,6 +1039,10 @@ class AgentforceService {
     this.navigationSubscription?.remove();
     this.navigationSubscription = null;
     this.navigationDelegate = null;
+
+    this.uiDelegateSubscriptions.forEach((s) => s.remove());
+    this.uiDelegateSubscriptions = [];
+    this.uiDelegate = null;
 
     // Clear native view provider registration before nulling the JS reference
     if (this.viewProviderDelegate) {

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.UIDelegate.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.UIDelegate.test.ts
@@ -1,0 +1,178 @@
+type Listener = (event: any) => void;
+type ListenerEntry = { remove: jest.Mock };
+
+const listeners: Record<string, { listener: Listener; entry: ListenerEntry }[]> = {};
+
+jest.mock('react-native', () => {
+  const enableUIDelegateForwarding = jest.fn();
+  const enableLogForwarding = jest.fn();
+  const enableNavigationForwarding = jest.fn();
+  const provideModifiedUtterance = jest.fn();
+  const getFeatureFlags = jest.fn().mockResolvedValue({
+    enableMultiAgent: true,
+    enableMultiModalInput: false,
+    enablePDFUpload: false,
+    enableVoice: false,
+    enableCustomViewProvider: false,
+  });
+
+  return {
+    Platform: { OS: 'ios' },
+    NativeModules: {
+      AgentforceModule: {
+        enableUIDelegateForwarding,
+        enableLogForwarding,
+        enableNavigationForwarding,
+        provideModifiedUtterance,
+        getFeatureFlags,
+        addListener: jest.fn(),
+        removeListeners: jest.fn(),
+      },
+    },
+    NativeEventEmitter: jest.fn().mockImplementation(() => ({
+      addListener: jest.fn((eventName: string, listener: Listener) => {
+        if (!listeners[eventName]) listeners[eventName] = [];
+        const entry: ListenerEntry = { remove: jest.fn() };
+        listeners[eventName].push({ listener, entry });
+        return entry;
+      }),
+    })),
+  };
+});
+
+import { NativeModules } from 'react-native';
+import AgentforceService from '../AgentforceService';
+import type { UIDelegate, AgentResponseEvent, ModifyUtteranceRequest } from '../../types/UIDelegate';
+
+const nativeModule = NativeModules.AgentforceModule;
+
+function getListener(eventName: string): Listener | undefined {
+  const entries = listeners[eventName];
+  return entries?.[entries.length - 1]?.listener;
+}
+
+function getSubscriptionEntries(): ListenerEntry[] {
+  return Object.values(listeners).flatMap(arr => arr.map(e => e.entry));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  for (const key of Object.keys(listeners)) delete listeners[key];
+  AgentforceService.clearUIDelegate();
+});
+
+describe('UIDelegate forwarding', () => {
+  it('enables native forwarding and subscribes to all four events', () => {
+    const delegate: UIDelegate = { onAgentResponse: jest.fn() };
+
+    AgentforceService.setUIDelegate(delegate);
+
+    expect(nativeModule.enableUIDelegateForwarding).toHaveBeenCalledWith(true);
+    expect(Object.keys(listeners)).toEqual(
+      expect.arrayContaining([
+        'onAgentResponse',
+        'onUtteranceSent',
+        'onAgentSwitch',
+        'onModifyUtteranceRequest',
+      ]),
+    );
+  });
+
+  it('forwards onAgentResponse events to the delegate', () => {
+    const onAgentResponse = jest.fn();
+    AgentforceService.setUIDelegate({ onAgentResponse });
+
+    const event: AgentResponseEvent = {
+      responseId: 'r-1',
+      message: 'Hello',
+      type: 'agent',
+      conversationId: 'conv-1',
+      timestamp: '2026-05-14T00:00:00Z',
+    };
+
+    getListener('onAgentResponse')!(event);
+
+    expect(onAgentResponse).toHaveBeenCalledWith(event);
+  });
+
+  it('forwards onUtteranceSent events to the delegate', () => {
+    const onUtteranceSent = jest.fn();
+    AgentforceService.setUIDelegate({ onAgentResponse: jest.fn(), onUtteranceSent });
+
+    const event = { utterance: 'hi', hasAttachment: false, timestamp: '2026-05-14T00:00:00Z' };
+    getListener('onUtteranceSent')!(event);
+
+    expect(onUtteranceSent).toHaveBeenCalledWith(event);
+  });
+
+  it('forwards onAgentSwitch events to the delegate', () => {
+    const onAgentSwitch = jest.fn();
+    AgentforceService.setUIDelegate({ onAgentResponse: jest.fn(), onAgentSwitch });
+
+    const event = { conversationId: 'conv-2', timestamp: '2026-05-14T00:00:00Z' };
+    getListener('onAgentSwitch')!(event);
+
+    expect(onAgentSwitch).toHaveBeenCalledWith(event);
+  });
+
+  it('calls provideModifiedUtterance with the delegate return value', async () => {
+    const modifyUtterance = jest.fn(
+      (req: ModifyUtteranceRequest) => `modified: ${req.utterance}`,
+    );
+    AgentforceService.setUIDelegate({ onAgentResponse: jest.fn(), modifyUtterance });
+
+    const request: ModifyUtteranceRequest = { requestId: 'req-1', utterance: 'original' };
+    await getListener('onModifyUtteranceRequest')!(request);
+
+    expect(modifyUtterance).toHaveBeenCalledWith(request);
+    expect(nativeModule.provideModifiedUtterance).toHaveBeenCalledWith(
+      'req-1',
+      'modified: original',
+    );
+  });
+
+  it('falls back to original utterance when modifyUtterance throws', async () => {
+    const modifyUtterance = jest.fn(() => {
+      throw new Error('oops');
+    });
+    AgentforceService.setUIDelegate({ onAgentResponse: jest.fn(), modifyUtterance });
+
+    const request: ModifyUtteranceRequest = { requestId: 'req-2', utterance: 'keep me' };
+    await getListener('onModifyUtteranceRequest')!(request);
+
+    expect(nativeModule.provideModifiedUtterance).toHaveBeenCalledWith('req-2', 'keep me');
+  });
+
+  it('sends original utterance when no modifyUtterance handler is provided', async () => {
+    AgentforceService.setUIDelegate({ onAgentResponse: jest.fn() });
+
+    const request: ModifyUtteranceRequest = { requestId: 'req-3', utterance: 'pass through' };
+    await getListener('onModifyUtteranceRequest')!(request);
+
+    expect(nativeModule.provideModifiedUtterance).toHaveBeenCalledWith('req-3', 'pass through');
+  });
+
+  it('disables native forwarding and removes subscriptions on clearUIDelegate', () => {
+    AgentforceService.setUIDelegate({ onAgentResponse: jest.fn() });
+
+    const entries = getSubscriptionEntries();
+    expect(entries.length).toBeGreaterThanOrEqual(4);
+
+    AgentforceService.clearUIDelegate();
+
+    expect(nativeModule.enableUIDelegateForwarding).toHaveBeenLastCalledWith(false);
+    entries.forEach(e => expect(e.remove).toHaveBeenCalled());
+  });
+
+  it('supports async modifyUtterance handlers', async () => {
+    const modifyUtterance = jest.fn(
+      async (req: ModifyUtteranceRequest) => `async: ${req.utterance}`,
+    );
+    AgentforceService.setUIDelegate({ onAgentResponse: jest.fn(), modifyUtterance });
+
+    const request: ModifyUtteranceRequest = { requestId: 'req-4', utterance: 'hello' };
+    await getListener('onModifyUtteranceRequest')!(request);
+
+    expect(nativeModule.provideModifiedUtterance).toHaveBeenCalledWith('req-4', 'async: hello');
+  });
+});

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.UIDelegate.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.UIDelegate.test.ts
@@ -31,7 +31,9 @@ jest.mock('react-native', () => {
     },
     NativeEventEmitter: jest.fn().mockImplementation(() => ({
       addListener: jest.fn((eventName: string, listener: Listener) => {
-        if (!listeners[eventName]) listeners[eventName] = [];
+        if (!listeners[eventName]) {
+          listeners[eventName] = [];
+        }
         const entry: ListenerEntry = { remove: jest.fn() };
         listeners[eventName].push({ listener, entry });
         return entry;
@@ -42,7 +44,11 @@ jest.mock('react-native', () => {
 
 import { NativeModules } from 'react-native';
 import AgentforceService from '../AgentforceService';
-import type { UIDelegate, AgentResponseEvent, ModifyUtteranceRequest } from '../../types/UIDelegate';
+import type {
+  UIDelegate,
+  AgentResponseEvent,
+  ModifyUtteranceRequest,
+} from '../../types/UIDelegate';
 
 const nativeModule = NativeModules.AgentforceModule;
 
@@ -57,7 +63,9 @@ function getSubscriptionEntries(): ListenerEntry[] {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  for (const key of Object.keys(listeners)) delete listeners[key];
+  for (const key of Object.keys(listeners)) {
+    delete listeners[key];
+  }
   AgentforceService.clearUIDelegate();
 });
 
@@ -116,9 +124,7 @@ describe('UIDelegate forwarding', () => {
   });
 
   it('calls provideModifiedUtterance with the delegate return value', async () => {
-    const modifyUtterance = jest.fn(
-      (req: ModifyUtteranceRequest) => `modified: ${req.utterance}`,
-    );
+    const modifyUtterance = jest.fn((req: ModifyUtteranceRequest) => `modified: ${req.utterance}`);
     AgentforceService.setUIDelegate({ onAgentResponse: jest.fn(), modifyUtterance });
 
     const request: ModifyUtteranceRequest = { requestId: 'req-1', utterance: 'original' };

--- a/AgentforceSDK-ReactNative-Bridge/src/types/UIDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/UIDelegate.ts
@@ -1,0 +1,77 @@
+/**
+ * UI Delegate types for Agentforce SDK
+ *
+ * Allows JS to receive UI delegate events from the native Agentforce SDK:
+ * - Agent responses (complete, non-streaming)
+ * - Utterance sent notifications
+ * - Agent switch notifications
+ * - Utterance modification before sending (async request/response)
+ */
+
+export interface AgentResponseEvent {
+  /** Unique message identifier */
+  responseId: string;
+  /** The agent's response text (may be null for non-text responses) */
+  message: string | null;
+  /** Message type classification */
+  type: string;
+  /** Conversation that produced this response (UUID string) */
+  conversationId: string;
+  /** ISO 8601 timestamp */
+  timestamp?: string;
+}
+
+export interface UtteranceSentEvent {
+  /** The utterance text that was sent */
+  utterance: string;
+  /** Whether the utterance had an attachment */
+  hasAttachment: boolean;
+  /** ISO 8601 timestamp */
+  timestamp: string;
+}
+
+export interface AgentSwitchEvent {
+  /** Identifier of the new conversation after the switch */
+  conversationId: string;
+  /** ISO 8601 timestamp */
+  timestamp: string;
+}
+
+export interface ModifyUtteranceRequest {
+  /** Unique request ID — pass back in the return value */
+  requestId: string;
+  /** The original utterance text before modification */
+  utterance: string;
+}
+
+/**
+ * Delegate interface for receiving UI delegate events from the Agentforce SDK.
+ *
+ * Register using `AgentforceService.setUIDelegate()` before or after launching a conversation.
+ * All callbacks are optional except `onAgentResponse`.
+ *
+ * @example
+ * ```typescript
+ * AgentforceService.setUIDelegate({
+ *   onAgentResponse(event) {
+ *     console.log(`Agent said: ${event.message}`);
+ *   },
+ *   onUtteranceSent(event) {
+ *     console.log(`User sent: ${event.utterance}`);
+ *   },
+ *   onAgentSwitch(event) {
+ *     console.log(`Switched to conversation: ${event.conversationId}`);
+ *   },
+ *   modifyUtterance(request) {
+ *     return request.utterance.toUpperCase(); // modify the text
+ *   },
+ * });
+ * ```
+ */
+export interface UIDelegate {
+  onAgentResponse(event: AgentResponseEvent): void;
+  onUtteranceSent?(event: UtteranceSentEvent): void;
+  onAgentSwitch?(event: AgentSwitchEvent): void;
+  /** Return the modified utterance text, or the original to leave unchanged. */
+  modifyUtterance?(request: ModifyUtteranceRequest): string | Promise<string>;
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
@@ -36,3 +36,12 @@ export { ViewProviderDelegate, ViewProviderComponentData } from './ViewProviderD
 
 // Hidden prechat field types
 export type { HiddenPreChatFields } from './HiddenPreChatFields';
+
+// UI delegate types
+export type {
+  UIDelegate,
+  AgentResponseEvent,
+  UtteranceSentEvent,
+  AgentSwitchEvent,
+  ModifyUtteranceRequest,
+} from './UIDelegate';

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -16,7 +16,7 @@ def shared_pods
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'AgentforceSDK', '15.2.6'
+  pod 'AgentforceSDK', '15.2.8'
   pod 'Messaging-InApp-Core', '> 1.10.0'
 
   # JWTKit is required by AgentforceService but not resolved automatically

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -44,6 +44,11 @@ import {
   LogLevel,
   NavigationDelegate,
   NavigationRequest,
+  UIDelegate,
+  AgentResponseEvent,
+  UtteranceSentEvent,
+  AgentSwitchEvent,
+  ModifyUtteranceRequest,
 } from 'react-native-agentforce';
 import { UI_FEATURES } from '../config/AppConfig';
 import { getContextVariables } from '../store/ContextVariablesStore';
@@ -79,6 +84,23 @@ const agentforceNavigation: NavigationDelegate = {
   },
 };
 
+const agentforceUIDelegate: UIDelegate = {
+  onAgentResponse(event: AgentResponseEvent) {
+    console.log(`[Agentforce Response] ${event.type}: ${event.message}`);
+    console.log(`[Agentforce Response] conversationId=${event.conversationId}, responseId=${event.responseId}`);
+  },
+  onUtteranceSent(event: UtteranceSentEvent) {
+    console.log(`[Agentforce UtteranceSent] "${event.utterance}" hasAttachment=${event.hasAttachment}`);
+  },
+  onAgentSwitch(event: AgentSwitchEvent) {
+    console.log(`[Agentforce AgentSwitch] new conversationId=${event.conversationId}`);
+  },
+  modifyUtterance(request: ModifyUtteranceRequest) {
+    console.log(`[Agentforce ModifyUtterance] original="${request.utterance}"`);
+    return request.utterance;
+  },
+};
+
 const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   const [isServiceAgentConfigured, setIsServiceAgentConfigured] = useState(false);
   const [isEmployeeAgentConfigured, setIsEmployeeAgentConfigured] = useState(false);
@@ -90,6 +112,8 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
     AgentforceService.setLoggerDelegate(agentforceLogger);
     // Register navigation delegate so SDK navigation requests are forwarded to JS
     AgentforceService.setNavigationDelegate(agentforceNavigation);
+    // Register UI delegate so agent responses are forwarded to JS
+    AgentforceService.setUIDelegate(agentforceUIDelegate);
     // Register custom view provider if enabled, then check configurations.
     // Sequential to avoid a race where configure() runs before registration completes.
     const init = async () => {
@@ -101,6 +125,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
     return () => {
       AgentforceService.clearLoggerDelegate();
       AgentforceService.clearNavigationDelegate();
+      AgentforceService.clearUIDelegate();
       AgentforceService.clearViewProviderDelegate();
     };
   }, []);

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -87,10 +87,14 @@ const agentforceNavigation: NavigationDelegate = {
 const agentforceUIDelegate: UIDelegate = {
   onAgentResponse(event: AgentResponseEvent) {
     console.log(`[Agentforce Response] ${event.type}: ${event.message}`);
-    console.log(`[Agentforce Response] conversationId=${event.conversationId}, responseId=${event.responseId}`);
+    console.log(
+      `[Agentforce Response] conversationId=${event.conversationId}, responseId=${event.responseId}`,
+    );
   },
   onUtteranceSent(event: UtteranceSentEvent) {
-    console.log(`[Agentforce UtteranceSent] "${event.utterance}" hasAttachment=${event.hasAttachment}`);
+    console.log(
+      `[Agentforce UtteranceSent] "${event.utterance}" hasAttachment=${event.hasAttachment}`,
+    );
   },
   onAgentSwitch(event: AgentSwitchEvent) {
     console.log(`[Agentforce AgentSwitch] new conversationId=${event.conversationId}`);


### PR DESCRIPTION
## Summary
- Implements `UIDelegate` support across iOS, Android, and TypeScript layers to forward agent response events (`willPresentResponse` / `willPresentUtterance`) to the React Native JS layer, enabling response interception and modification.
- Adds new `BridgeUIDelegate` (Android) and extends `AgentforceModule.swift` (iOS) to wire delegate callbacks into React Native event emitters.
- Introduces `UIDelegate.ts` types and `AgentforceService.ts` methods for enabling/disabling forwarding and providing modified utterances from JS.
- Bumps Agentforce SDK from 14.177.0 to 14.177.2.

## Test plan
- [ ] Verify UIDelegate forwarding can be enabled/disabled from JS on both iOS and Android
- [ ] Confirm `willPresentResponse` events are emitted to JS when an agent responds
- [ ] Confirm `willPresentUtterance` events are emitted and modified utterances can be returned
- [ ] Verify existing conversation flow still works with forwarding disabled (no regression)
- [ ] Test Service Agent and Employee Agent targets