### PR TITLE
Detect Boost on Windows in installandroid.js

### DIFF
--- a/installandroid.js
+++ b/installandroid.js
@@ -202,12 +202,59 @@ if (!boostPath && platform === 'linux') {
   }
 }
 
+// Try Windows installation (BOOST_ROOT, vcpkg, or common install paths)
+if (!boostPath && platform === 'win32') {
+  var winBoostCandidates = [];
+
+  // 1. BOOST_ROOT env var (de-facto standard override)
+  if (process.env.BOOST_ROOT) {
+    winBoostCandidates.push(process.env.BOOST_ROOT);
+  }
+
+  // 2. vcpkg installations (env var, then common roots), across common triplets
+  var vcpkgTriplets = ['x64-windows', 'x86-windows', 'x64-windows-static', 'arm64-windows'];
+  var vcpkgRoots = [];
+  if (process.env.VCPKG_ROOT) {
+    vcpkgRoots.push(process.env.VCPKG_ROOT);
+  }
+  vcpkgRoots.push('C:\\vcpkg');
+  vcpkgRoots.push('C:\\src\\vcpkg');
+  if (process.env.USERPROFILE) {
+    vcpkgRoots.push(path.join(process.env.USERPROFILE, 'vcpkg'));
+  }
+  vcpkgRoots.forEach(function (root) {
+    vcpkgTriplets.forEach(function (triplet) {
+      winBoostCandidates.push(path.join(root, 'installed', triplet));
+    });
+  });
+
+  // 3. Common manual / Chocolatey install locations
+  winBoostCandidates.push('C:\\boost');
+  winBoostCandidates.push('C:\\Boost');
+  winBoostCandidates.push('C:\\local\\boost');
+
+  for (var j = 0; j < winBoostCandidates.length; j++) {
+    var winCandidate = winBoostCandidates[j];
+    if (!winCandidate) continue;
+    var winBoostInclude = path.join(winCandidate, 'include', 'boost');
+    if (fs.existsSync(winBoostInclude)) {
+      boostPath = winCandidate;
+      console.log('   ✅ Boost found at ' + boostPath + ' (Windows)');
+      break;
+    }
+  }
+}
+
 // Validation: error if still not found
 if (!boostPath) {
   if (platform === 'darwin') {
     console.error('❌ Boost not found. Install: brew install boost');
   } else if (platform === 'linux') {
     console.error('❌ Boost not found. Install: sudo apt-get install libboost-all-dev');
+  } else if (platform === 'win32') {
+    console.error('❌ Boost not found.');
+    console.error('   Install via vcpkg: vcpkg install boost');
+    console.error('   Or set BOOST_ROOT to a directory containing include\\boost.');
   } else {
     console.error('❌ Boost not found. Platform: ' + platform);
   }


### PR DESCRIPTION
## Summary
- `installandroid.js` only had Boost detection for `darwin` (Homebrew) and `linux` (apt). Windows users with Boost properly installed via vcpkg fell straight through to the generic `❌ Boost not found. Platform: win32` error.
- Adds a `win32` detection branch that probes, in priority order:
  1. `BOOST_ROOT` env var (de-facto override)
  2. vcpkg installs — `VCPKG_ROOT`, `C:\vcpkg`, `C:\src\vcpkg`, `%USERPROFILE%\vcpkg` — across common triplets (`x64-windows`, `x86-windows`, `x64-windows-static`, `arm64-windows`)
  3. Common manual / Chocolatey paths (`C:\boost`, `C:\Boost`, `C:\local\boost`)
- Each candidate is validated by checking for `<root>\include\boost` and the resolved root is written to `REACT_NATIVE_BOOST_PATH` in `android/local.properties` (same flow as macOS/Linux).
- Updated the failure message on Windows to point users at `vcpkg install boost` and the `BOOST_ROOT` override.
- All path construction uses `path.join` so separator handling is correct on Windows.

Fixes #81

## Caveats / Follow-ups
- The npm wrappers (`scripts/android-wrapper.sh`, `scripts/android-build-wrapper.sh`) are bash-only. Windows users will still need Git Bash to run `npm run android:*` end-to-end, or set `REACT_NATIVE_BOOST_PATH` in their environment manually before invoking `gradlew`. That's out of scope for this PR but worth a follow-up issue for full Windows parity.

## Test plan
- [ ] Smoke test on macOS: re-run `node installandroid.js employee` and confirm Homebrew detection still works (no regression).
- [ ] Smoke test on Linux/CI: confirm `apt` detection still works (no regression).
- [ ] Windows + vcpkg: install Boost via `vcpkg install boost`, run `node installandroid.js employee`, confirm detection succeeds and `REACT_NATIVE_BOOST_PATH` is written to `android/local.properties`.
- [ ] Windows + `BOOST_ROOT`: set `BOOST_ROOT` to a directory containing `include\boost`, confirm detection picks it up first.
- [ ] Windows with no Boost: confirm the new error message guides users to `vcpkg install boost` / `BOOST_ROOT`.