### PR TITLE
Add integrate-agentforce-react-native skill for agentic SDK integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/refs/heads/main/marketplace/marketplace.schema.json",
+  "name": "agentforce-mobile-sdk-react-native",
+  "version": "0.1.0",
+  "owner": {
+    "name": "Salesforce",
+    "url": "https://github.com/salesforce/AgentforceMobileSDK-ReactNative"
+  },
+  "metadata": {
+    "description": "Tooling for integrating the Agentforce Mobile SDK into React Native apps via the react-native-agentforce bridge."
+  },
+  "plugins": [
+    {
+      "name": "agentforce-mobile-sdk-react-native",
+      "description": "Scaffolds AgentforceSDK integration into an existing React Native app: use-case-driven configuration mode selection (Service Agent vs Employee Agent), bridge package install + native iOS/Android wiring, AgentforceService configuration, logger/navigation/view-provider delegates, and a launch button.",
+      "repository": "https://github.com/salesforce/AgentforceMobileSDK-ReactNative",
+      "version": "0.1.0",
+      "author": {
+        "name": "Salesforce",
+        "url": "https://github.com/salesforce/AgentforceMobileSDK-ReactNative"
+      },
+      "license": "BSD-3-Clause",
+      "category": "development",
+      "keywords": [
+        "salesforce",
+        "agentforce",
+        "react-native",
+        "typescript",
+        "ios",
+        "android",
+        "ai",
+        "agent",
+        "integration"
+      ],
+      "tags": [
+        "salesforce",
+        "agentforce",
+        "react-native",
+        "typescript",
+        "scaffold"
+      ],
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,13 +32,7 @@
         "agent",
         "integration"
       ],
-      "tags": [
-        "salesforce",
-        "agentforce",
-        "react-native",
-        "typescript",
-        "scaffold"
-      ],
+      "tags": ["salesforce", "agentforce", "react-native", "typescript", "scaffold"],
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -20,7 +20,5 @@
     "integration",
     "scaffold"
   ],
-  "skills": [
-    "./skills/integrate-agentforce-react-native"
-  ]
+  "skills": ["./skills/integrate-agentforce-react-native"]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "agentforce-mobile-sdk-react-native",
+  "version": "0.1.0",
+  "description": "Integrate the Agentforce Mobile SDK into a React Native app via the react-native-agentforce bridge. Walks consumers through use-case discovery, picks the right configuration mode (Service Agent for public/customer-facing, Employee Agent for signed-in workforce), wires the bridge package and native iOS/Android dependencies, and scaffolds TypeScript files for AgentforceService configuration, logger/navigation/view-provider delegates, and a launch button.",
+  "author": {
+    "name": "Salesforce",
+    "url": "https://github.com/salesforce/AgentforceMobileSDK-ReactNative"
+  },
+  "repository": "https://github.com/salesforce/AgentforceMobileSDK-ReactNative",
+  "license": "BSD-3-Clause",
+  "keywords": [
+    "salesforce",
+    "agentforce",
+    "react-native",
+    "typescript",
+    "ios",
+    "android",
+    "ai",
+    "agent",
+    "integration",
+    "scaffold"
+  ],
+  "skills": [
+    "./skills/integrate-agentforce-react-native"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -83,6 +83,34 @@ This app uses the **AgentforceSDK-ReactNative-Bridge** (in-repo under `Agentforc
 - **Screens**: Home, Settings, About
 - **No app-specific code**: Same JavaScript for both apps
 
+## Integrate with Claude Code (`integrate-agentforce-react-native` skill)
+
+If you're using [Claude Code](https://www.anthropic.com/claude-code) (or other agentic tooling that supports the skill format), this repo ships an `integrate-agentforce-react-native` skill that walks you through SDK integration end-to-end:
+
+- **Use-case-driven configuration** — answer "what kind of agent?" and the skill picks the right `AgentforceService.configure(...)` mode (Service Agent vs Employee Agent) instead of asking you to choose between configuration shapes upfront.
+- **Bridge + native wiring** — adds the `react-native-agentforce` bridge package, runs the iOS/Android install scripts (Boost, XcodeGen, CocoaPods, Gradle), and surfaces the Mobile SDK requirements for Employee Agent.
+- **Scaffolds the integration files** — generates `agentforceConfig.ts`, `agentforceLogger.ts`, `agentforceNavigation.ts`, optional `employeeAuth.ts`, and a launch button (prominent home button, header icon, or auto-launch wrapper).
+- **MIAW deployment guidance** — for Service Agent, points you at the [Messaging for In-App and Web mobile deployment docs](https://help.salesforce.com/s/articleView?id=service.miaw_deployment_mobile.htm&type=5) before you try to build.
+
+### Install the skill
+
+The skill is shipped as a Claude Code plugin in this repository. From your consuming React Native project:
+
+```
+/plugin marketplace add salesforce/AgentforceMobileSDK-ReactNative
+/plugin install agentforce-mobile-sdk-react-native@agentforce-mobile-sdk-react-native
+```
+
+Then run the skill:
+
+```
+/integrate-agentforce-react-native
+```
+
+The skill is self-contained at `skills/integrate-agentforce-react-native/` (with reference docs and TypeScript snippet templates under `references/`), and the plugin/marketplace metadata lives at `.claude-plugin/`. The skill is also installable via the standard skills.sh-style `npx skills add` workflow since it lives at the root `skills/` directory. You can also clone this repo and reference the skill directory directly from your project's Claude Code configuration if you prefer not to use the marketplace.
+
+If you'd rather integrate manually, the steps below cover the same ground.
+
 ## 📋 Prerequisites
 
 ### General

--- a/skills/integrate-agentforce-react-native/SKILL.md
+++ b/skills/integrate-agentforce-react-native/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: integrate-agentforce-react-native
+description: Integrate the Agentforce Mobile SDK into an existing React Native app. Walks the consumer through use-case discovery, picks the right configuration (Service Agent for public/customer-facing, Employee Agent for signed-in workforce), wires the `react-native-agentforce` bridge package + native iOS/Android dependencies, and scaffolds TypeScript files for the AgentforceService configuration, logger/navigation/view-provider delegates, and a launch button. Use when a developer asks to "add Agentforce", "integrate the Agentforce SDK", "set up Agentforce chat", or wire a React Native app up to a Salesforce agent.
+---
+
+# integrate-agentforce-react-native
+
+This skill walks a consumer through wiring the **Agentforce Mobile SDK** (via the `react-native-agentforce` bridge) into their React Native app. It is **interactive** — ask the user the questions in each phase before generating code. Don't assume; the wrong configuration mode is the most common integration mistake.
+
+## Operating rules
+
+- **Run inside the consumer's React Native project, not inside the SDK repo.** If the working directory contains `AgentforceSDK-ReactNative-Bridge/` as a sibling of `package.json`, refuse and tell the user to `cd` into their consuming app.
+- **Discover before deciding.** Always run Phase 1 (use-case discovery) before recommending a config mode. Don't ask "Service Agent or Employee Agent?" — most consumers don't know what those map to.
+- **Employee Agent requires the host app to bring its own Salesforce Mobile SDK** for OAuth. The bridge does **not** bundle it. Surface this *before* scaffolding so the user can confirm they have it (or are willing to add it).
+- **Use `AskUserQuestion` for branching choices.** Don't free-text prompts — give 2–4 explicit options.
+- **Substitute placeholders, don't leave `{{TOKENS}}` in the final files.** Collect values up front; if the user can't provide a value, leave a clearly-marked `// TODO:` comment instead.
+- **Configuration must precede `launchConversation()`.** Document this in scaffolded files; it's a common cause of runtime failures.
+
+## Phase 0 — Detect the target project
+
+Look in the current working directory for:
+
+- `package.json` with `react-native` in `dependencies` or `peerDependencies`
+- `ios/` and `android/` folders (bare React Native; required — the bridge is iOS/Android only)
+- `app.json` or `metro.config.js` to confirm
+
+If none is present, ask the user where the React Native project root is and `cd` there. If the directory contains `AgentforceSDK-ReactNative-Bridge/` at the root and the package name is `react-native-agentforce-sample` or similar, refuse — that's this SDK's own repo.
+
+**Expo managed workflow is not supported** — the bridge requires native code. If you detect `expo` in `package.json` *without* `ios/` and `android/` folders, tell the user they need to `expo prebuild` (or migrate to a bare workflow) first.
+
+See `references/dep-detection.md` for the full setup checklist.
+
+## Phase 1 — Discover the use case (this drives configuration mode)
+
+Ask **first** what they're building, then map to a configuration mode:
+
+```
+AskUserQuestion: "What kind of agent are you integrating?"
+  - Public service agent (customer-facing, no sign-in)        → ServiceAgentConfig (type: 'service')
+  - Employee agent (signed-in workforce users)                → EmployeeAgentConfig (type: 'employee')
+  - Other / not sure                                           → see references/auth-flows.md
+```
+
+### Branch A — Public service agent
+
+This is the **simplest** path:
+
+- Use `AgentforceService.configure({ type: 'service', serviceApiURL, organizationId, esDeveloperName })`.
+- The bridge handles guest/anonymous auth automatically — no OAuth, no Mobile SDK, **no token plumbing required**.
+- Tell the user they'll need a **Messaging-for-In-App-Web (MIAW) mobile deployment** in their Salesforce org first, and link the docs:
+  - https://help.salesforce.com/s/articleView?id=service.miaw_deployment_mobile.htm&type=5
+- If they don't have one yet, pause here. The skill can't proceed without `serviceApiURL`, `organizationId`, and `esDeveloperName` from the deployment.
+
+### Branch B — Employee agent
+
+Employee Agent requires **OAuth credentials**. The host app must:
+
+1. Add the **Salesforce Mobile SDK** to the native iOS/Android sides (the bridge does not bundle it).
+2. Configure **bootconfig** and initialize the Mobile SDK at app start.
+3. Either pass `accessToken` directly to `AgentforceService.configure(...)`, **or** rely on the in-bridge `EmployeeAgentAuthBridge` which fetches credentials from the running Mobile SDK.
+
+Ask the follow-up:
+
+```
+AskUserQuestion: "Does this app already use the Salesforce Mobile SDK for login?"
+  - Yes (Mobile SDK is already wired up)   → use EmployeeAgentAuthBridge (login/logout/credentials)
+  - No (we'll add it)                      → link Mobile SDK setup docs, pause for confirmation
+  - We have our own OAuth flow             → pass accessToken directly to configure()
+```
+
+Mobile SDK setup docs to link when they need them:
+- iOS: https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/ios_introduction.htm
+- Android: https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/android_introduction.htm
+- Connected App / OAuth setup: https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/oauth_configure_connected_app.htm
+
+For employee scaffolding, use `references/snippets/configure-employee.ts`. For Mobile-SDK-driven auth, also include `references/snippets/employee-auth.ts` (calls `loginForEmployeeAgent()` / `getEmployeeAgentCredentials()`).
+
+### Branch C — Other / not sure
+
+Walk them through `references/auth-flows.md`. The two extra notes to surface here:
+
+- The bridge currently exposes **two** modes: `service` and `employee`. There's no third "guest with explicit URL" mode like the native SDKs have — Service Agent already handles unauthenticated/public chat.
+- If the consumer wants a public agent that doesn't go through MIAW (e.g. Agent API behind an Experience Cloud site without a service deployment), the bridge doesn't support it directly — surface this and ask whether they want to build a thin wrapper or wait for first-class support.
+
+## Phase 2 — Pick where to launch the conversation
+
+The bridge launches a **native** conversation UI (the iOS/Android SDK's pre-built chat surface) — there is no React Native chat component to embed inline. So the choice is just *where in your RN app the launch trigger lives*:
+
+```
+AskUserQuestion: "Where should the launch trigger live?"
+  - A prominent button on a Home screen (recommended)        → ChatLaunchButton.tsx
+  - In a navigation bar or header (icon button)              → HeaderLaunchButton.tsx
+  - Auto-launch on first app open (after configuration)      → AutoLaunchOnMount.tsx
+  - Custom — I'll wire it up myself                          → just provide configure() snippet
+```
+
+Each option corresponds to one snippet in `references/snippets/`. The launch trigger calls `AgentforceService.launchConversation()` — the native SDK takes over UI from there until the user closes the conversation.
+
+## Phase 3 — Collect config values
+
+Based on the chosen branch:
+
+| Branch | Required values |
+|---|---|
+| Service Agent | `serviceApiURL`, `organizationId`, `esDeveloperName` |
+| Employee + Mobile SDK | `instanceUrl`, `organizationId`, `userId`, `agentId` (or omit for multi-agent), Connected App Consumer Key + Callback URL |
+| Employee + direct token | All of the above plus `accessToken` (and a refresh strategy) |
+
+Ask one question per missing value. If the user gives "I don't know" for a Service Agent value, point them back at the MIAW deployment link and stop.
+
+For Employee Agent without an existing Mobile SDK setup, also collect:
+- **Consumer Key** (from the Connected App)
+- **Callback URL** (from the Connected App, e.g. `myapp://oauth/callback`)
+
+These get written into the iOS `bootconfig.plist` / Android `bootconfig.xml` during Mobile SDK setup. The skill does **not** automate Mobile SDK installation — surface the install commands and pause:
+
+```bash
+# iOS — Salesforce Mobile SDK pods (in your Podfile)
+pod 'SalesforceSDKCommon'
+pod 'SalesforceAnalytics'
+pod 'SalesforceSDKCore'
+pod 'SmartStore'
+pod 'MobileSync'
+pod 'SalesforceReact'
+```
+
+```kotlin
+// Android — in app/build.gradle.kts (Kotlin DSL) or app/build.gradle (Groovy)
+implementation("com.salesforce.mobilesdk:SalesforceReact:13.1.1")
+```
+
+## Phase 4 — Add the bridge dependency
+
+The bridge ships as a local package `react-native-agentforce`. Two install paths:
+
+### Path 1: Install from this repo (recommended for now)
+
+```bash
+# Add the bridge package as a tarball or git dependency
+npm install salesforce/AgentforceMobileSDK-ReactNative#dev --save
+# or, if the bridge is published to a registry your org uses:
+npm install react-native-agentforce
+```
+
+Then run the platform install scripts shipped with the bridge (these patch CocoaPods / Gradle, install Boost, etc.):
+
+```bash
+node node_modules/react-native-agentforce/installios.js service   # or 'employee' / 'all'
+node node_modules/react-native-agentforce/installandroid.js service
+```
+
+### Path 2: In-repo bridge (for forks / patches)
+
+If the consumer is forking or contributing back, vendor `AgentforceSDK-ReactNative-Bridge/` into their repo and reference it via npm:
+
+```json
+{
+  "dependencies": {
+    "react-native-agentforce": "file:./AgentforceSDK-ReactNative-Bridge"
+  }
+}
+```
+
+See `references/dep-detection.md` for the full Podfile / Gradle / Boost / XcodeGen setup.
+
+## Phase 5 — Scaffold TypeScript files
+
+Create the directory `src/agentforce/` (or `agentforce/` at the project root if the consumer doesn't use `src/`) and write:
+
+| File | When | Source snippet |
+|---|---|---|
+| `agentforceConfig.ts` | Always | `snippets/configure-service.ts` or `configure-employee.ts` based on Phase 1 |
+| `agentforceLogger.ts` | Always | `snippets/agentforceLogger.ts` |
+| `agentforceNavigation.ts` | Always | `snippets/agentforceNavigation.ts` |
+| `employeeAuth.ts` | Employee + Mobile SDK only | `snippets/employee-auth.ts` |
+| `ChatLaunchButton.tsx` | Always | one of `snippets/ChatLaunchButton.tsx`, `HeaderLaunchButton.tsx`, `AutoLaunchOnMount.tsx` based on Phase 2 |
+
+The configuration helper exposes a single `configureAgentforce()` function that calls `setLoggerDelegate(...)` and `setNavigationDelegate(...)` first, then `configure(...)`. Order matters — register delegates **before** configuring so the logger captures init-time SDK output.
+
+## Phase 6 — Wire it into App startup
+
+Patch the consumer's `App.tsx` (or root component) to call `configureAgentforce()` once at mount, with a loading state until it resolves:
+
+```tsx
+const [ready, setReady] = useState(false);
+
+useEffect(() => {
+  configureAgentforce().then(() => setReady(true));
+  return () => AgentforceService.destroy();
+}, []);
+
+if (!ready) return <LoadingScreen />;
+```
+
+If the user has an existing app with state management (Redux, Zustand, React Query, etc.), surface that instead — fold the configure call into their bootstrap action rather than `useEffect` in `App.tsx`.
+
+## Phase 7 — Verify
+
+Tell the user:
+
+1. **Install native deps**:
+   - iOS: `cd ios && pod install` (the bridge install script will have run `xcodegen` and patched `boost.podspec` if Boost is installed via Homebrew).
+   - Android: `cd android && ./gradlew :app:dependencies` to confirm `AgentforceSDK-ReactNative-Bridge` resolved.
+2. **Build**:
+   - iOS: `npm run ios` (or `npx react-native run-ios`).
+   - Android: `npm run android` (or `npx react-native run-android`).
+3. **Logs**:
+   - JavaScript: Metro bundler output, plus your `LoggerDelegate` console line.
+   - iOS native: Xcode console.
+   - Android native: `npx react-native log-android` or Android Studio Logcat (filter `AgentforceSDK`).
+4. **Service Agent**: tap the launch button, verify the native conversation UI opens, send a test utterance, see the response.
+5. **Employee Agent**: confirm `isEmployeeAgentAuthSupported()` returns `true` (Mobile SDK is wired up), then `loginForEmployeeAgent()` opens the OAuth screen, then launch.
+
+If the build fails, common causes:
+
+- **iOS** — missing `xcodegen` (`brew install xcodegen`) or missing Boost (`brew install boost`).
+- **iOS** — `pod install` fails with version conflicts on `SalesforceReact` if Mobile SDK and bridge versions don't agree. Check `ios/Podfile.lock`.
+- **Android** — wrong JDK (need 17), or Boost not exported via `REACT_NATIVE_BOOST_PATH`.
+- **Both** — `AgentforceModule native module not found` at runtime usually means autolinking didn't run; restart Metro with `npm start -- --reset-cache`.
+- **Employee Agent** — `Employee Agent auth is not available` from `loginForEmployeeAgent()` means the Mobile SDK isn't initialized. Check bootconfig and SDK init.
+
+## References
+
+- `references/auth-flows.md` — Service vs Employee Agent decision tree, Mobile SDK requirements, how `EmployeeAgentAuthBridge` interacts with the native Mobile SDK.
+- `references/api-reference.md` — `AgentforceService` method walkthrough: `configure`, `launchConversation`, `setAdditionalContext`, `setLoggerDelegate`, `setNavigationDelegate`, `setViewProviderDelegate`, `registerHiddenPreChatFields`.
+- `references/dep-detection.md` — Podfile, Gradle, Boost, XcodeGen, install scripts.
+- `references/chat-presentation.md` — Where to put the launch trigger in your RN navigation hierarchy. The chat UI itself is native; you can't embed it inside an RN view.
+- `references/snippets/*.ts(x)` — File templates with `{{PLACEHOLDERS}}` to substitute.

--- a/skills/integrate-agentforce-react-native/SKILL.md
+++ b/skills/integrate-agentforce-react-native/SKILL.md
@@ -11,7 +11,7 @@ This skill walks a consumer through wiring the **Agentforce Mobile SDK** (via th
 
 - **Run inside the consumer's React Native project, not inside the SDK repo.** If the working directory contains `AgentforceSDK-ReactNative-Bridge/` as a sibling of `package.json`, refuse and tell the user to `cd` into their consuming app.
 - **Discover before deciding.** Always run Phase 1 (use-case discovery) before recommending a config mode. Don't ask "Service Agent or Employee Agent?" — most consumers don't know what those map to.
-- **Employee Agent requires the host app to bring its own Salesforce Mobile SDK** for OAuth. The bridge does **not** bundle it. Surface this *before* scaffolding so the user can confirm they have it (or are willing to add it).
+- **Employee Agent requires the host app to bring its own Salesforce Mobile SDK** for OAuth. The bridge does **not** bundle it. Surface this _before_ scaffolding so the user can confirm they have it (or are willing to add it).
 - **Use `AskUserQuestion` for branching choices.** Don't free-text prompts — give 2–4 explicit options.
 - **Substitute placeholders, don't leave `{{TOKENS}}` in the final files.** Collect values up front; if the user can't provide a value, leave a clearly-marked `// TODO:` comment instead.
 - **Configuration must precede `launchConversation()`.** Document this in scaffolded files; it's a common cause of runtime failures.
@@ -26,7 +26,7 @@ Look in the current working directory for:
 
 If none is present, ask the user where the React Native project root is and `cd` there. If the directory contains `AgentforceSDK-ReactNative-Bridge/` at the root and the package name is `react-native-agentforce-sample` or similar, refuse — that's this SDK's own repo.
 
-**Expo managed workflow is not supported** — the bridge requires native code. If you detect `expo` in `package.json` *without* `ios/` and `android/` folders, tell the user they need to `expo prebuild` (or migrate to a bare workflow) first.
+**Expo managed workflow is not supported** — the bridge requires native code. If you detect `expo` in `package.json` _without_ `ios/` and `android/` folders, tell the user they need to `expo prebuild` (or migrate to a bare workflow) first.
 
 See `references/dep-detection.md` for the full setup checklist.
 
@@ -69,6 +69,7 @@ AskUserQuestion: "Does this app already use the Salesforce Mobile SDK for login?
 ```
 
 Mobile SDK setup docs to link when they need them:
+
 - iOS: https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/ios_introduction.htm
 - Android: https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/android_introduction.htm
 - Connected App / OAuth setup: https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/oauth_configure_connected_app.htm
@@ -84,7 +85,7 @@ Walk them through `references/auth-flows.md`. The two extra notes to surface her
 
 ## Phase 2 — Pick where to launch the conversation
 
-The bridge launches a **native** conversation UI (the iOS/Android SDK's pre-built chat surface) — there is no React Native chat component to embed inline. So the choice is just *where in your RN app the launch trigger lives*:
+The bridge launches a **native** conversation UI (the iOS/Android SDK's pre-built chat surface) — there is no React Native chat component to embed inline. So the choice is just _where in your RN app the launch trigger lives_:
 
 ```
 AskUserQuestion: "Where should the launch trigger live?"
@@ -100,15 +101,16 @@ Each option corresponds to one snippet in `references/snippets/`. The launch tri
 
 Based on the chosen branch:
 
-| Branch | Required values |
-|---|---|
-| Service Agent | `serviceApiURL`, `organizationId`, `esDeveloperName` |
-| Employee + Mobile SDK | `instanceUrl`, `organizationId`, `userId`, `agentId` (or omit for multi-agent), Connected App Consumer Key + Callback URL |
-| Employee + direct token | All of the above plus `accessToken` (and a refresh strategy) |
+| Branch                  | Required values                                                                                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Service Agent           | `serviceApiURL`, `organizationId`, `esDeveloperName`                                                                      |
+| Employee + Mobile SDK   | `instanceUrl`, `organizationId`, `userId`, `agentId` (or omit for multi-agent), Connected App Consumer Key + Callback URL |
+| Employee + direct token | All of the above plus `accessToken` (and a refresh strategy)                                                              |
 
 Ask one question per missing value. If the user gives "I don't know" for a Service Agent value, point them back at the MIAW deployment link and stop.
 
 For Employee Agent without an existing Mobile SDK setup, also collect:
+
 - **Consumer Key** (from the Connected App)
 - **Callback URL** (from the Connected App, e.g. `myapp://oauth/callback`)
 
@@ -167,13 +169,13 @@ See `references/dep-detection.md` for the full Podfile / Gradle / Boost / XcodeG
 
 Create the directory `src/agentforce/` (or `agentforce/` at the project root if the consumer doesn't use `src/`) and write:
 
-| File | When | Source snippet |
-|---|---|---|
-| `agentforceConfig.ts` | Always | `snippets/configure-service.ts` or `configure-employee.ts` based on Phase 1 |
-| `agentforceLogger.ts` | Always | `snippets/agentforceLogger.ts` |
-| `agentforceNavigation.ts` | Always | `snippets/agentforceNavigation.ts` |
-| `employeeAuth.ts` | Employee + Mobile SDK only | `snippets/employee-auth.ts` |
-| `ChatLaunchButton.tsx` | Always | one of `snippets/ChatLaunchButton.tsx`, `HeaderLaunchButton.tsx`, `AutoLaunchOnMount.tsx` based on Phase 2 |
+| File                      | When                       | Source snippet                                                                                             |
+| ------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `agentforceConfig.ts`     | Always                     | `snippets/configure-service.ts` or `configure-employee.ts` based on Phase 1                                |
+| `agentforceLogger.ts`     | Always                     | `snippets/agentforceLogger.ts`                                                                             |
+| `agentforceNavigation.ts` | Always                     | `snippets/agentforceNavigation.ts`                                                                         |
+| `employeeAuth.ts`         | Employee + Mobile SDK only | `snippets/employee-auth.ts`                                                                                |
+| `ChatLaunchButton.tsx`    | Always                     | one of `snippets/ChatLaunchButton.tsx`, `HeaderLaunchButton.tsx`, `AutoLaunchOnMount.tsx` based on Phase 2 |
 
 The configuration helper exposes a single `configureAgentforce()` function that calls `setLoggerDelegate(...)` and `setNavigationDelegate(...)` first, then `configure(...)`. Order matters — register delegates **before** configuring so the logger captures init-time SDK output.
 

--- a/skills/integrate-agentforce-react-native/references/api-reference.md
+++ b/skills/integrate-agentforce-react-native/references/api-reference.md
@@ -1,0 +1,177 @@
+# `AgentforceService` API reference
+
+The bridge exports a singleton `AgentforceService` from `react-native-agentforce`. All methods return Promises and are no-ops on web/desktop (return `false` or empty values).
+
+## Lifecycle
+
+```ts
+import { AgentforceService } from 'react-native-agentforce';
+
+// 1. Register delegates first (so they catch init-time SDK output)
+AgentforceService.setLoggerDelegate(myLogger);
+AgentforceService.setNavigationDelegate(myNavigation);
+
+// 2. Configure
+await AgentforceService.configure({ type: 'service', ... });
+
+// 3. Launch the native conversation UI
+await AgentforceService.launchConversation();
+
+// 4. (Optional) attach context to the live conversation
+await AgentforceService.setAdditionalContext({ variables: [...] });
+
+// 5. On app shutdown — clean up event listeners
+AgentforceService.destroy();
+```
+
+## Methods
+
+### `configure(config)`
+
+Initialize the SDK with a `ServiceAgentConfig` or `EmployeeAgentConfig`. Idempotent — re-call to switch modes or update tokens.
+
+```ts
+await AgentforceService.configure({
+  type: 'service',
+  serviceApiURL: 'https://service.salesforce.com',
+  organizationId: '00Dxx0000001234',
+  esDeveloperName: 'MyServiceAgent',
+});
+```
+
+### `launchConversation()`
+
+Open the native chat UI. **Preserves** any existing conversation — users continue where they left off. Throws if `configure()` hasn't been called.
+
+### `startNewConversation()`
+
+Like `launchConversation()` but discards any existing conversation first.
+
+### `closeConversation()`
+
+Programmatically close the chat UI. Usually unnecessary — the SDK's built-in close button handles this.
+
+### `isConfigured()` / `getConfigurationInfo()`
+
+Check current state. `getConfigurationInfo()` returns `{ configured, mode, description? }` — use it to gate UI on whether `configure()` has run.
+
+### `setAdditionalContext({ variables })`
+
+Attach contextual data to the **current** conversation. Must be called **after** `launchConversation()`.
+
+```ts
+await AgentforceService.setAdditionalContext({
+  variables: [
+    { name: 'userId', type: 'Text', value: '005xx0000001234' },
+    { name: 'accountId', type: 'Text', value: '001xx0000001234' },
+    { name: 'score', type: 'Number', value: 95.5 },
+    { name: 'isVIP', type: 'Boolean', value: true },
+    { name: 'createdDate', type: 'DateTime', value: '2026-03-06T10:00:00Z' },
+  ],
+});
+```
+
+Supported variable types: `Text`, `Number`, `Boolean`, `Date`, `DateTime`, `Json`, `List`, `Money`, `Object`, `Ref`, `Variable`.
+
+### `registerHiddenPreChatFields(fields)`
+
+Service Agent only. Pre-populate hidden prechat field values **before** `launchConversation()`:
+
+```ts
+await AgentforceService.registerHiddenPreChatFields({
+  ContactId: '003xx0000001234',
+  AccountId: '001xx0000005678',
+});
+await AgentforceService.launchConversation();
+```
+
+### `setLoggerDelegate(delegate)` / `clearLoggerDelegate()`
+
+Forward SDK logs to JS:
+
+```ts
+AgentforceService.setLoggerDelegate({
+  onLog(level, message, error) {
+    console.log(`[Agentforce ${level.toUpperCase()}] ${message}`, error);
+  },
+});
+```
+
+Levels: `'error' | 'warn' | 'info' | 'debug'` (debug is iOS-only).
+
+### `setNavigationDelegate(delegate)` / `clearNavigationDelegate()`
+
+Handle SDK navigation requests (record opens, link taps, quick actions) in JS rather than letting the SDK handle them natively:
+
+```ts
+import { Linking } from 'react-native';
+
+AgentforceService.setNavigationDelegate({
+  onNavigate(request) {
+    switch (request.type) {
+      case 'link':
+        if (request.uri) Linking.openURL(request.uri as string);
+        break;
+      case 'record':
+        navigation.navigate('RecordDetail', {
+          recordId: request.recordId,
+          objectType: request.objectType,
+        });
+        break;
+      // ...
+    }
+  },
+});
+```
+
+### `setViewProviderDelegate(delegate)` / `clearViewProviderDelegate()`
+
+Replace native rendering for specific component types with React Native components:
+
+```ts
+await AgentforceService.setViewProviderDelegate({
+  componentMap: {
+    'copilot/richText': 'CustomRichTextView',
+    'copilot/markdown': 'CustomMarkdownView',
+  },
+});
+```
+
+The component name on the right must be registered with React Native's component registry. This is an advanced feature — most consumers don't need it.
+
+### `getFeatureFlags()` / `setFeatureFlags(flags)`
+
+Read or persist feature flags. Flags take effect on the next `configure()`:
+
+```ts
+type FeatureFlags = {
+  enableMultiAgent: boolean;
+  enableMultiModalInput: boolean;
+  enablePDFUpload: boolean;
+  enableVoice: boolean;
+  enableCustomViewProvider: boolean;
+};
+```
+
+If the consumer doesn't pass `featureFlags` to `configure()`, the bridge merges the persisted ones in.
+
+### `destroy()`
+
+Clear all event listeners and delegate references. Call on app shutdown.
+
+## Employee Agent auth helpers
+
+Separate from `AgentforceService`, the bridge exports auth helpers tied to the Mobile SDK:
+
+```ts
+import {
+  isEmployeeAgentAuthSupported,
+  hasEmployeeAgentSession,
+  loginForEmployeeAgent,
+  logoutEmployeeAgent,
+  getEmployeeAgentCredentials,
+  refreshEmployeeAgentCredentials,
+} from 'react-native-agentforce';
+```
+
+See `auth-flows.md` for the full flow.

--- a/skills/integrate-agentforce-react-native/references/auth-flows.md
+++ b/skills/integrate-agentforce-react-native/references/auth-flows.md
@@ -1,0 +1,148 @@
+# Auth flow reference (React Native)
+
+The bridge exposes **two** configuration modes via the `type` discriminator on `AgentConfig`:
+
+```ts
+type AgentConfig = ServiceAgentConfig | EmployeeAgentConfig;
+
+interface ServiceAgentConfig {
+  type: 'service';
+  serviceApiURL: string;
+  organizationId: string;
+  esDeveloperName: string;
+  featureFlags?: FeatureFlags;
+}
+
+interface EmployeeAgentConfig {
+  type: 'employee';
+  instanceUrl: string;
+  organizationId: string;
+  userId: string;
+  agentId?: string;        // omit for multi-agent
+  agentLabel?: string;
+  accessToken?: string;    // optional; native SDK can refresh from Mobile SDK
+  featureFlags?: FeatureFlags;
+}
+```
+
+A legacy fallback (`LegacyServiceAgentConfig` — no `type` field) is also accepted for backward compatibility, but new integrations should always set `type`.
+
+## Decision tree
+
+```
+Is the agent customer-facing (anyone can chat without signing in)?
+├── Yes → ServiceAgentConfig (type: 'service') + MIAW deployment
+│         No Mobile SDK needed.
+│         Prerequisites: serviceApiURL, organizationId, esDeveloperName.
+│         Setup: https://help.salesforce.com/s/articleView?id=service.miaw_deployment_mobile.htm&type=5
+│
+└── No (signed-in employees / workforce users)
+     │
+     └── EmployeeAgentConfig (type: 'employee')
+         │
+         └── How are credentials supplied?
+             │
+             ├── Salesforce Mobile SDK already in the host app
+             │   → Use EmployeeAgentAuthBridge from the bridge:
+             │     loginForEmployeeAgent() / getEmployeeAgentCredentials() / logoutEmployeeAgent()
+             │   → configure() with type: 'employee' and omit accessToken;
+             │     the native SDK fetches fresh tokens from the Mobile SDK on demand.
+             │
+             ├── Custom OAuth flow (no Mobile SDK)
+             │   → Pass accessToken directly to configure().
+             │   → Caller is responsible for token refresh — re-call configure() with
+             │     a fresh accessToken when the existing one expires.
+             │
+             └── No auth at all
+                 → Don't use Employee Agent. Use Service Agent instead.
+```
+
+## Service Agent — what's actually happening under the hood
+
+When you `configure({ type: 'service', ... })`:
+- The bridge sets up an unauthenticated session against the MIAW deployment identified by `esDeveloperName`.
+- Internally the SDKs use empty OAuth credentials (Guest mode).
+- The conversation UI doesn't show any sign-in affordance.
+
+You don't need to write any auth provider — the bridge handles it.
+
+## Employee Agent — Mobile SDK flow
+
+The bridge exposes `EmployeeAgentAuthBridge` (only present in builds that include the Mobile SDK). Surfaced via these JS helpers from `react-native-agentforce`:
+
+```ts
+import {
+  isEmployeeAgentAuthSupported,
+  isEmployeeAgentAuthReady,
+  hasEmployeeAgentSession,
+  loginForEmployeeAgent,
+  logoutEmployeeAgent,
+  getEmployeeAgentCredentials,
+  refreshEmployeeAgentCredentials,
+} from 'react-native-agentforce';
+```
+
+Typical flow:
+
+```ts
+// On app start
+if (await isEmployeeAgentAuthSupported()) {
+  if (!(await hasEmployeeAgentSession())) {
+    await loginForEmployeeAgent();   // shows native OAuth screen
+  }
+  const creds = await getEmployeeAgentCredentials();
+  await AgentforceService.configure({
+    type: 'employee',
+    instanceUrl: creds!.instanceUrl,
+    organizationId: creds!.organizationId,
+    userId: creds!.userId,
+    agentId: '0Xxxx0000001234',       // or omit for multi-agent
+    accessToken: creds!.accessToken,  // optional but recommended
+  });
+}
+```
+
+`isEmployeeAgentAuthSupported()` returns `false` if:
+- The host app didn't include the Mobile SDK (e.g. iOS pod `SalesforceReact` not in Podfile).
+- The bridge's `EmployeeAgentAuthBridge` native module isn't registered.
+
+If `false`, hide the Employee Agent UI in the consuming app — the user has no way to sign in.
+
+## Employee Agent — direct token flow (no Mobile SDK)
+
+If the consumer has their own OAuth implementation:
+
+```ts
+const accessToken = await myCustomOAuthFlow.getAccessToken();
+await AgentforceService.configure({
+  type: 'employee',
+  instanceUrl: 'https://myorg.my.salesforce.com',
+  organizationId: '00Dxx0000001234',
+  userId: '005xx0000001234',
+  agentId: '0Xxxx0000001234',
+  accessToken,
+});
+```
+
+In this case the consumer is fully responsible for token refresh. If the token expires mid-conversation, the SDK will surface auth errors via the logger delegate; re-`configure()` with a fresh token to recover.
+
+## Why there's no `Guest(url)` or `OrgJWT` mode in the bridge
+
+The native iOS/Android SDKs expose four credential cases (`OAuth`, `OrgJWT`, `Guest`, `PassThroughAuth`). The RN bridge consolidates these into the two modes above for simplicity:
+
+- `service` → maps to `Guest(url)` natively.
+- `employee` with `accessToken` → maps to `OAuth(authToken, orgId, userId)`.
+- `employee` without `accessToken` (Mobile SDK present) → bridge fetches `OAuth` credentials on demand.
+- `OrgJWT` and `PassThroughAuth` are not currently exposed via the JS bridge.
+
+If the consumer needs `OrgJWT` or `PassThroughAuth`, they currently have to fork the bridge and add the case manually — surface this as a known limitation.
+
+## Prerequisites checklist
+
+Before scaffolding, confirm the user has:
+
+| Branch | Prerequisites |
+|---|---|
+| Service Agent | MIAW mobile deployment configured; `serviceApiURL`, `organizationId`, `esDeveloperName` |
+| Employee + Mobile SDK | Mobile SDK in iOS Podfile and Android `app/build.gradle`; bootconfig.plist / bootconfig.xml configured; `instanceUrl`, `organizationId`, `userId`, `agentId` (optional) |
+| Employee + direct token | Existing OAuth flow that returns Salesforce access tokens; same instanceUrl/orgId/userId values; refresh strategy |

--- a/skills/integrate-agentforce-react-native/references/auth-flows.md
+++ b/skills/integrate-agentforce-react-native/references/auth-flows.md
@@ -18,9 +18,9 @@ interface EmployeeAgentConfig {
   instanceUrl: string;
   organizationId: string;
   userId: string;
-  agentId?: string;        // omit for multi-agent
+  agentId?: string; // omit for multi-agent
   agentLabel?: string;
-  accessToken?: string;    // optional; native SDK can refresh from Mobile SDK
+  accessToken?: string; // optional; native SDK can refresh from Mobile SDK
   featureFlags?: FeatureFlags;
 }
 ```
@@ -60,6 +60,7 @@ Is the agent customer-facing (anyone can chat without signing in)?
 ## Service Agent — what's actually happening under the hood
 
 When you `configure({ type: 'service', ... })`:
+
 - The bridge sets up an unauthenticated session against the MIAW deployment identified by `esDeveloperName`.
 - Internally the SDKs use empty OAuth credentials (Guest mode).
 - The conversation UI doesn't show any sign-in affordance.
@@ -88,7 +89,7 @@ Typical flow:
 // On app start
 if (await isEmployeeAgentAuthSupported()) {
   if (!(await hasEmployeeAgentSession())) {
-    await loginForEmployeeAgent();   // shows native OAuth screen
+    await loginForEmployeeAgent(); // shows native OAuth screen
   }
   const creds = await getEmployeeAgentCredentials();
   await AgentforceService.configure({
@@ -96,13 +97,14 @@ if (await isEmployeeAgentAuthSupported()) {
     instanceUrl: creds!.instanceUrl,
     organizationId: creds!.organizationId,
     userId: creds!.userId,
-    agentId: '0Xxxx0000001234',       // or omit for multi-agent
-    accessToken: creds!.accessToken,  // optional but recommended
+    agentId: '0Xxxx0000001234', // or omit for multi-agent
+    accessToken: creds!.accessToken, // optional but recommended
   });
 }
 ```
 
 `isEmployeeAgentAuthSupported()` returns `false` if:
+
 - The host app didn't include the Mobile SDK (e.g. iOS pod `SalesforceReact` not in Podfile).
 - The bridge's `EmployeeAgentAuthBridge` native module isn't registered.
 
@@ -141,8 +143,8 @@ If the consumer needs `OrgJWT` or `PassThroughAuth`, they currently have to fork
 
 Before scaffolding, confirm the user has:
 
-| Branch | Prerequisites |
-|---|---|
-| Service Agent | MIAW mobile deployment configured; `serviceApiURL`, `organizationId`, `esDeveloperName` |
-| Employee + Mobile SDK | Mobile SDK in iOS Podfile and Android `app/build.gradle`; bootconfig.plist / bootconfig.xml configured; `instanceUrl`, `organizationId`, `userId`, `agentId` (optional) |
-| Employee + direct token | Existing OAuth flow that returns Salesforce access tokens; same instanceUrl/orgId/userId values; refresh strategy |
+| Branch                  | Prerequisites                                                                                                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Service Agent           | MIAW mobile deployment configured; `serviceApiURL`, `organizationId`, `esDeveloperName`                                                                                 |
+| Employee + Mobile SDK   | Mobile SDK in iOS Podfile and Android `app/build.gradle`; bootconfig.plist / bootconfig.xml configured; `instanceUrl`, `organizationId`, `userId`, `agentId` (optional) |
+| Employee + direct token | Existing OAuth flow that returns Salesforce access tokens; same instanceUrl/orgId/userId values; refresh strategy                                                       |

--- a/skills/integrate-agentforce-react-native/references/chat-presentation.md
+++ b/skills/integrate-agentforce-react-native/references/chat-presentation.md
@@ -1,0 +1,126 @@
+# Chat presentation reference (React Native)
+
+**The chat UI is native, not a React Native component.** When you call `AgentforceService.launchConversation()`, the iOS/Android SDK presents its own chat surface (modally on iOS, as a fragment/activity on Android). You **cannot** embed `AgentforceConversationContainer` (iOS SwiftUI) or its Android Compose equivalent inside a React Native view tree.
+
+That means presentation choices on RN are limited to **where the launch trigger lives** in your app.
+
+## Patterns
+
+### Prominent button on the Home screen (recommended default)
+
+Best for "open the assistant" CTAs. Visible, discoverable, easy to gate on configuration state.
+
+```tsx
+import { AgentforceService } from 'react-native-agentforce';
+
+function HomeScreen() {
+  const onLaunch = async () => {
+    if (!(await AgentforceService.isConfigured())) {
+      Alert.alert('Configure Agentforce in Settings first');
+      return;
+    }
+    await AgentforceService.launchConversation();
+  };
+
+  return (
+    <View>
+      {/* ...your home content */}
+      <TouchableOpacity onPress={onLaunch}>
+        <Text>Ask the agent</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+```
+
+### Header / nav bar icon button
+
+Tucked into a `headerRight` so the chat is always one tap away regardless of which screen the user is on.
+
+```tsx
+<Stack.Screen
+  name="Home"
+  component={HomeScreen}
+  options={({ navigation }) => ({
+    headerRight: () => (
+      <TouchableOpacity onPress={() => AgentforceService.launchConversation()}>
+        <Icon name="chat" />
+      </TouchableOpacity>
+    ),
+  })}
+/>
+```
+
+### Auto-launch on first app open
+
+Useful for assistant-first apps where the chat IS the product. Launch immediately after `configure()` resolves.
+
+```tsx
+useEffect(() => {
+  configureAgentforce().then(() => AgentforceService.launchConversation());
+}, []);
+```
+
+Avoid this pattern in apps that have other primary content — auto-launch is a heavy interruption if the user opened the app for something else.
+
+### Programmatic launch from a deep link
+
+If the consumer has deep linking via `react-native-deep-linking` or React Navigation's `linking` config:
+
+```tsx
+const linking = {
+  prefixes: ['myapp://'],
+  config: { screens: { Home: 'home' } },
+  subscribe(listener) {
+    return Linking.addEventListener('url', async ({ url }) => {
+      if (url.endsWith('/agent')) {
+        await AgentforceService.launchConversation();
+      }
+      listener(url);
+    });
+  },
+};
+```
+
+## What about embedding the chat inline?
+
+Not supported by the current bridge. If you need the chat to live inside a tab or panel within your RN UI:
+
+- iOS: would require exposing the SwiftUI `AgentforceChatView` via a `RCTViewManager` and bridging Compose views on Android. Neither is currently in the bridge.
+- Workaround: launch the conversation modally via `launchConversation()` and use `closeConversation()` to dismiss it programmatically. Not as smooth as inline embedding.
+
+If the consumer specifically asks for inline embedding, surface this as a known limitation and ask whether they want to:
+
+1. Use the modal launch trigger instead.
+2. Build their own custom view manager (out of scope for this skill).
+3. File a feature request in the SDK repo.
+
+## Gating the launch on configuration state
+
+Always check `isConfigured()` before launching. The first launch will fail otherwise:
+
+```tsx
+const [configured, setConfigured] = useState(false);
+
+useEffect(() => {
+  AgentforceService.isConfigured().then(setConfigured);
+}, []);
+
+return (
+  <Button
+    title="Ask the agent"
+    disabled={!configured}
+    onPress={() => AgentforceService.launchConversation()}
+  />
+);
+```
+
+## Closing programmatically
+
+Rare, but if you need to dismiss the chat from JS (e.g. on logout):
+
+```ts
+await AgentforceService.closeConversation();
+```
+
+The SDK's built-in close button is the normal user-initiated path; `closeConversation()` is for cleanup scenarios.

--- a/skills/integrate-agentforce-react-native/references/dep-detection.md
+++ b/skills/integrate-agentforce-react-native/references/dep-detection.md
@@ -9,6 +9,7 @@ Look for these in the working directory:
 3. `app.json` with `"expo"` key + no `ios/` or `android/` → **Expo managed workflow**. Refuse and tell the user to `expo prebuild` first or migrate to a bare workflow. The bridge cannot autolink into a managed Expo app.
 
 Common false positives:
+
 - A monorepo where `package.json` is at the root but the RN app is in `apps/mobile/`. Walk into the RN app dir before continuing.
 
 ## Refusing to run inside the SDK repo
@@ -33,6 +34,7 @@ node node_modules/react-native-agentforce/installandroid.js service
 ```
 
 These scripts:
+
 - Install Boost via Homebrew (or surface a clear error if it's missing).
 - Patch `boost.podspec` (iOS) or set `REACT_NATIVE_BOOST_PATH` (Android) so React Native uses the local Homebrew install instead of downloading ~100MB during builds.
 - Run `xcodegen generate` (iOS) to (re)build `*.xcodeproj` from `project.yml`.

--- a/skills/integrate-agentforce-react-native/references/dep-detection.md
+++ b/skills/integrate-agentforce-react-native/references/dep-detection.md
@@ -1,0 +1,156 @@
+# Dependency setup (React Native)
+
+## Project type detection
+
+Look for these in the working directory:
+
+1. `package.json` with `react-native` in `dependencies` or `peerDependencies` → React Native project.
+2. `ios/` and `android/` folders → bare React Native (required — the bridge needs native code).
+3. `app.json` with `"expo"` key + no `ios/` or `android/` → **Expo managed workflow**. Refuse and tell the user to `expo prebuild` first or migrate to a bare workflow. The bridge cannot autolink into a managed Expo app.
+
+Common false positives:
+- A monorepo where `package.json` is at the root but the RN app is in `apps/mobile/`. Walk into the RN app dir before continuing.
+
+## Refusing to run inside the SDK repo
+
+If the working directory contains `AgentforceSDK-ReactNative-Bridge/` as a sibling of the root `package.json` and the package name is `react-native-agentforce-sample` (or similar), this is the SDK's own repo. Refuse and tell the user to `cd` into their consuming app.
+
+## Install the bridge package
+
+### Option 1: From this repo (current state)
+
+The bridge isn't published to npm yet. Install from GitHub:
+
+```bash
+npm install salesforce/AgentforceMobileSDK-ReactNative#dev --save
+```
+
+…or pin to a specific commit/tag. Then run the platform install scripts that ship with the bridge:
+
+```bash
+node node_modules/react-native-agentforce/installios.js service     # or 'employee' / 'all'
+node node_modules/react-native-agentforce/installandroid.js service
+```
+
+These scripts:
+- Install Boost via Homebrew (or surface a clear error if it's missing).
+- Patch `boost.podspec` (iOS) or set `REACT_NATIVE_BOOST_PATH` (Android) so React Native uses the local Homebrew install instead of downloading ~100MB during builds.
+- Run `xcodegen generate` (iOS) to (re)build `*.xcodeproj` from `project.yml`.
+- Run `pod install` (iOS) and Gradle sync (Android).
+
+### Option 2: Local file dependency (forks/patches)
+
+Clone or vendor `AgentforceSDK-ReactNative-Bridge/` into the consumer's repo, then:
+
+```json
+{
+  "dependencies": {
+    "react-native-agentforce": "file:./AgentforceSDK-ReactNative-Bridge"
+  }
+}
+```
+
+Then `npm install` and run the install scripts as above.
+
+## iOS native setup
+
+### Prerequisites
+
+- macOS, Xcode 15+, iOS 17+ deployment target.
+- CocoaPods (`brew install cocoapods` or `gem install cocoapods`).
+- **XcodeGen** (`brew install xcodegen`) — the bridge generates `*.xcodeproj` from `ios/project.yml`.
+- **Boost** (`brew install boost`) — avoids React Native downloading Boost during builds.
+
+### Podfile
+
+For Service Agent only:
+
+```ruby
+target 'YourApp' do
+  pod 'ReactNativeAgentforce', :path => '../node_modules/react-native-agentforce/ios'
+  # ...rest of your Podfile
+end
+```
+
+For Employee Agent (host app must include Mobile SDK pods):
+
+```ruby
+target 'YourApp' do
+  pod 'ReactNativeAgentforce', :path => '../node_modules/react-native-agentforce/ios'
+  pod 'SalesforceReact'
+  pod 'SalesforceSDKCore'
+  pod 'SmartStore'
+  pod 'MobileSync'
+  # ...rest of your Podfile
+end
+```
+
+After editing the Podfile, run:
+
+```bash
+cd ios
+pod install --repo-update
+```
+
+If `pod install` fails with version conflicts, check that your `Podfile.lock` versions of `SalesforceReact` and `ReactNativeAgentforce` are compatible.
+
+## Android native setup
+
+### Prerequisites
+
+- Android Studio, JDK 17 (higher versions cause build failures).
+- Gradle 8.0+, AGP that matches your RN version.
+- Min SDK 24+ (the bridge supports Android 7+; the underlying Agentforce SDK requires 29+ on its own — but the bridge itself loads later).
+
+### `android/build.gradle` (project-level)
+
+Verify the React Native gradle plugin and Boost path are wired up. The install script does this automatically; if you're doing it by hand:
+
+```gradle
+ext {
+    REACT_NATIVE_BOOST_PATH = "/opt/homebrew/Cellar/boost/<version>"  // or wherever brew installed it
+}
+```
+
+### `android/app/build.gradle` (or `.kts`)
+
+For Employee Agent, add:
+
+```gradle
+implementation "com.salesforce.mobilesdk:SalesforceReact:13.1.1"
+```
+
+Autolinking handles `react-native-agentforce` itself — no manual `implementation` line needed for the bridge.
+
+### Sync
+
+```bash
+cd android
+./gradlew :app:dependencies
+```
+
+…or just rebuild from Android Studio.
+
+## Boost — why everyone hits this
+
+React Native 0.71+ pulls Boost during builds from `archives.boost.io`. CI environments and corporate networks often block this. The bridge's install scripts work around it:
+
+- **Install Homebrew Boost first**: `brew install boost`
+- **Run the install script**: it patches `boost.podspec` and exports `REACT_NATIVE_BOOST_PATH` so both platforms use the local copy.
+
+If the user is on Linux or Windows (no Homebrew), point them at `docs/ci-guide.md` in the SDK repo for alternative Boost setups.
+
+## Verifying the install
+
+```bash
+# JS side
+npm ls react-native-agentforce
+
+# iOS — pod is linked
+grep -i ReactNativeAgentforce ios/Podfile.lock
+
+# Android — autolinking picked it up
+./gradlew :app:dependencies | grep -i agentforce
+```
+
+If any of these come up empty, the install didn't take — re-run the install script and watch for errors.

--- a/skills/integrate-agentforce-react-native/references/snippets/AutoLaunchOnMount.tsx
+++ b/skills/integrate-agentforce-react-native/references/snippets/AutoLaunchOnMount.tsx
@@ -1,0 +1,35 @@
+// Auto-launch on first app open. Use only if the chat IS the product —
+// otherwise it's a heavy interruption.
+//
+// Wraps your root component so the chat opens automatically once
+// configuration resolves. Remove the auto-launch effect if you only
+// want the configure() call.
+
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import { AgentforceService } from 'react-native-agentforce';
+import { configureAgentforce } from './agentforceConfig';
+
+export function AutoLaunchOnMount({ children }: { children: React.ReactNode }) {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    configureAgentforce()
+      .then(() => AgentforceService.launchConversation())
+      .finally(() => setReady(true));
+
+    return () => {
+      AgentforceService.destroy();
+    };
+  }, []);
+
+  if (!ready) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/skills/integrate-agentforce-react-native/references/snippets/ChatLaunchButton.tsx
+++ b/skills/integrate-agentforce-react-native/references/snippets/ChatLaunchButton.tsx
@@ -1,0 +1,49 @@
+// Prominent launch button for a Home screen.
+//
+// Disables itself until configureAgentforce() has resolved.
+
+import React, { useEffect, useState } from 'react';
+import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { AgentforceService } from 'react-native-agentforce';
+
+export function ChatLaunchButton() {
+  const [configured, setConfigured] = useState(false);
+
+  useEffect(() => {
+    AgentforceService.isConfigured().then(setConfigured);
+  }, []);
+
+  const onPress = async () => {
+    try {
+      await AgentforceService.launchConversation();
+    } catch (e) {
+      Alert.alert('Failed to launch Agentforce', String(e));
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={[styles.button, !configured && styles.buttonDisabled]}
+        onPress={onPress}
+        disabled={!configured}>
+        <Text style={styles.buttonText}>
+          {configured ? 'Ask the agent' : 'Configuring…'}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 16 },
+  button: {
+    backgroundColor: '#0176D3',
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  buttonDisabled: { backgroundColor: '#A8B7C7' },
+  buttonText: { color: '#FFFFFF', fontSize: 16, fontWeight: '600' },
+});

--- a/skills/integrate-agentforce-react-native/references/snippets/ChatLaunchButton.tsx
+++ b/skills/integrate-agentforce-react-native/references/snippets/ChatLaunchButton.tsx
@@ -27,9 +27,7 @@ export function ChatLaunchButton() {
         style={[styles.button, !configured && styles.buttonDisabled]}
         onPress={onPress}
         disabled={!configured}>
-        <Text style={styles.buttonText}>
-          {configured ? 'Ask the agent' : 'Configuring…'}
-        </Text>
+        <Text style={styles.buttonText}>{configured ? 'Ask the agent' : 'Configuring…'}</Text>
       </TouchableOpacity>
     </View>
   );

--- a/skills/integrate-agentforce-react-native/references/snippets/HeaderLaunchButton.tsx
+++ b/skills/integrate-agentforce-react-native/references/snippets/HeaderLaunchButton.tsx
@@ -1,0 +1,24 @@
+// Nav-bar / header icon button. Drop into `headerRight` of a React
+// Navigation screen so the chat is always one tap away.
+//
+// Usage:
+//   <Stack.Screen
+//     name="Home"
+//     component={HomeScreen}
+//     options={{ headerRight: () => <HeaderLaunchButton /> }}
+//   />
+
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+import { AgentforceService } from 'react-native-agentforce';
+
+export function HeaderLaunchButton() {
+  return (
+    <TouchableOpacity
+      onPress={() => AgentforceService.launchConversation()}
+      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+      {/* Replace with your icon library (e.g. react-native-vector-icons) */}
+      <Text style={{ color: '#FFFFFF', fontSize: 18 }}>💬</Text>
+    </TouchableOpacity>
+  );
+}

--- a/skills/integrate-agentforce-react-native/references/snippets/agentforceLogger.ts
+++ b/skills/integrate-agentforce-react-native/references/snippets/agentforceLogger.ts
@@ -1,0 +1,20 @@
+// Logger delegate — forwards SDK logs to the JS console.
+//
+// If you have a logging service (Sentry, Datadog, etc.), wire it up here.
+
+import type { LoggerDelegate, LogLevel } from 'react-native-agentforce';
+
+export const agentforceLogger: LoggerDelegate = {
+  onLog(level: LogLevel, message: string, error?: string) {
+    const timestamp = new Date().toISOString();
+    const prefix = `[${timestamp}][Agentforce ${level.toUpperCase()}]`;
+    if (error) {
+      console.log(`${prefix} ${message} | ERROR: ${error}`);
+    } else {
+      console.log(`${prefix} ${message}`);
+    }
+
+    // TODO: forward to your analytics / error reporting service if needed.
+    // e.g. if (level === 'error') Sentry.captureMessage(message, { extra: { error } });
+  },
+};

--- a/skills/integrate-agentforce-react-native/references/snippets/agentforceNavigation.ts
+++ b/skills/integrate-agentforce-react-native/references/snippets/agentforceNavigation.ts
@@ -1,0 +1,39 @@
+// Navigation delegate — handles SDK navigation requests in JS instead of
+// letting the native SDK handle them.
+//
+// Use this to route record opens / link taps / quick actions through your
+// own React Navigation stack, deep linking, or in-app browser.
+
+import { Alert, Linking } from 'react-native';
+import type { NavigationDelegate, NavigationRequest } from 'react-native-agentforce';
+
+export const agentforceNavigation: NavigationDelegate = {
+  onNavigate(request: NavigationRequest) {
+    // Known request.type values: 'record', 'link', 'quickAction',
+    // 'pageReference', 'objectHome', 'app', 'unknown'
+    switch (request.type) {
+      case 'link': {
+        const uri = request.uri as string | undefined;
+        if (uri) Linking.openURL(uri);
+        break;
+      }
+      case 'record': {
+        // TODO: navigate to your record detail screen, e.g.
+        //   navigationRef.navigate('RecordDetail', {
+        //     recordId: request.recordId,
+        //     objectType: request.objectType,
+        //   });
+        console.log(`[Agentforce Nav] record: ${request.objectType} ${request.recordId}`);
+        break;
+      }
+      case 'quickAction': {
+        // TODO: invoke your in-app quick action handler
+        console.log(`[Agentforce Nav] quickAction: ${request.actionName}`);
+        break;
+      }
+      default:
+        // Useful while developing — replace with silent handling in production
+        Alert.alert('Navigation Request', JSON.stringify(request, null, 2));
+    }
+  },
+};

--- a/skills/integrate-agentforce-react-native/references/snippets/configure-employee.ts
+++ b/skills/integrate-agentforce-react-native/references/snippets/configure-employee.ts
@@ -1,0 +1,69 @@
+// Employee Agent configuration — signed-in workforce users.
+//
+// Two flavors below; the skill picks one based on Phase 1 follow-up:
+//   A) Mobile SDK in host app  — uses EmployeeAgentAuthBridge to fetch creds
+//   B) Direct token            — caller supplies accessToken from their own OAuth flow
+//
+// Skill writes the chosen flavor as `agentforceConfig.ts`.
+
+import {
+  AgentforceService,
+  isEmployeeAgentAuthSupported,
+  hasEmployeeAgentSession,
+  loginForEmployeeAgent,
+  getEmployeeAgentCredentials,
+} from 'react-native-agentforce';
+import { agentforceLogger } from './agentforceLogger';
+import { agentforceNavigation } from './agentforceNavigation';
+
+// ── A) Mobile SDK flow ──────────────────────────────────────────────────
+export async function configureAgentforce(): Promise<boolean> {
+  AgentforceService.setLoggerDelegate(agentforceLogger);
+  AgentforceService.setNavigationDelegate(agentforceNavigation);
+
+  if (!(await isEmployeeAgentAuthSupported())) {
+    throw new Error(
+      'Employee Agent auth is not available. ' +
+        'Add the Salesforce Mobile SDK to your iOS Podfile and Android build.gradle.',
+    );
+  }
+
+  if (!(await hasEmployeeAgentSession())) {
+    await loginForEmployeeAgent(); // opens native OAuth screen
+  }
+
+  const creds = await getEmployeeAgentCredentials();
+  if (!creds) {
+    throw new Error('Failed to fetch Employee Agent credentials after login');
+  }
+
+  return AgentforceService.configure({
+    type: 'employee',
+    instanceUrl: creds.instanceUrl,
+    organizationId: creds.organizationId,
+    userId: creds.userId,
+    agentId: '{{AGENT_ID}}', // or omit for multi-agent picker
+    accessToken: creds.accessToken,
+  });
+}
+
+// ── B) Direct-token flow (uncomment to use; delete A above) ─────────────
+//
+// export async function configureAgentforce(): Promise<boolean> {
+//   AgentforceService.setLoggerDelegate(agentforceLogger);
+//   AgentforceService.setNavigationDelegate(agentforceNavigation);
+//
+//   const accessToken = await myCustomOAuth.getAccessToken();
+//   // TODO: wire myCustomOAuth to your existing OAuth implementation.
+//   // Caller is responsible for refreshing the token; re-call configureAgentforce()
+//   // with a fresh accessToken when the existing one expires.
+//
+//   return AgentforceService.configure({
+//     type: 'employee',
+//     instanceUrl: '{{INSTANCE_URL}}',
+//     organizationId: '{{ORGANIZATION_ID}}',
+//     userId: '{{USER_ID}}',
+//     agentId: '{{AGENT_ID}}',
+//     accessToken,
+//   });
+// }

--- a/skills/integrate-agentforce-react-native/references/snippets/configure-service.ts
+++ b/skills/integrate-agentforce-react-native/references/snippets/configure-service.ts
@@ -1,0 +1,22 @@
+// Service Agent configuration — public, customer-facing, no auth.
+//
+// Skill writes this as `agentforceConfig.ts`. Call `configureAgentforce()`
+// once at app startup, then `AgentforceService.launchConversation()`
+// when the user opens the chat.
+
+import { AgentforceService } from 'react-native-agentforce';
+import { agentforceLogger } from './agentforceLogger';
+import { agentforceNavigation } from './agentforceNavigation';
+
+export async function configureAgentforce(): Promise<boolean> {
+  // Register delegates BEFORE configure() so init-time SDK output is captured
+  AgentforceService.setLoggerDelegate(agentforceLogger);
+  AgentforceService.setNavigationDelegate(agentforceNavigation);
+
+  return AgentforceService.configure({
+    type: 'service',
+    serviceApiURL: '{{SERVICE_API_URL}}',     // e.g. 'https://your-domain.my.salesforce-scrt.com'
+    organizationId: '{{ORGANIZATION_ID}}',     // 15 or 18 char Org ID
+    esDeveloperName: '{{ES_DEVELOPER_NAME}}',  // Einstein Service Agent dev name
+  });
+}

--- a/skills/integrate-agentforce-react-native/references/snippets/configure-service.ts
+++ b/skills/integrate-agentforce-react-native/references/snippets/configure-service.ts
@@ -15,8 +15,8 @@ export async function configureAgentforce(): Promise<boolean> {
 
   return AgentforceService.configure({
     type: 'service',
-    serviceApiURL: '{{SERVICE_API_URL}}',     // e.g. 'https://your-domain.my.salesforce-scrt.com'
-    organizationId: '{{ORGANIZATION_ID}}',     // 15 or 18 char Org ID
-    esDeveloperName: '{{ES_DEVELOPER_NAME}}',  // Einstein Service Agent dev name
+    serviceApiURL: '{{SERVICE_API_URL}}', // e.g. 'https://your-domain.my.salesforce-scrt.com'
+    organizationId: '{{ORGANIZATION_ID}}', // 15 or 18 char Org ID
+    esDeveloperName: '{{ES_DEVELOPER_NAME}}', // Einstein Service Agent dev name
   });
 }

--- a/skills/integrate-agentforce-react-native/references/snippets/employee-auth.ts
+++ b/skills/integrate-agentforce-react-native/references/snippets/employee-auth.ts
@@ -1,0 +1,45 @@
+// Employee Agent auth helpers — only needed when the host app uses the
+// Salesforce Mobile SDK for OAuth.
+//
+// These thin wrappers around the bridge's auth helpers are convenient for
+// gating UI on `isLoggedIn` state and recovering from token expiry.
+
+import {
+  AgentforceService,
+  isEmployeeAgentAuthSupported,
+  hasEmployeeAgentSession,
+  loginForEmployeeAgent,
+  logoutEmployeeAgent,
+  getEmployeeAgentCredentials,
+  refreshEmployeeAgentCredentials,
+} from 'react-native-agentforce';
+
+export async function ensureEmployeeAgentLogin(): Promise<void> {
+  if (!(await isEmployeeAgentAuthSupported())) {
+    throw new Error(
+      'Mobile SDK not present. Add SalesforceReact (iOS Podfile / Android build.gradle).',
+    );
+  }
+  if (await hasEmployeeAgentSession()) return;
+  await loginForEmployeeAgent();
+}
+
+export async function logoutAndResetAgentforce(): Promise<void> {
+  await AgentforceService.closeConversation();
+  await logoutEmployeeAgent();
+  await AgentforceService.resetSettings();
+}
+
+export async function refreshTokenAndReconfigure(agentId?: string): Promise<void> {
+  const fresh = await refreshEmployeeAgentCredentials();
+  await AgentforceService.configure({
+    type: 'employee',
+    instanceUrl: fresh.instanceUrl,
+    organizationId: fresh.organizationId,
+    userId: fresh.userId,
+    agentId,
+    accessToken: fresh.accessToken,
+  });
+}
+
+export { getEmployeeAgentCredentials };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -66,5 +66,6 @@
     /* Advanced Options */
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "exclude": ["node_modules", "skills"]
 }


### PR DESCRIPTION
## Summary

Ships a Claude Code skill plus marketplace plugin metadata that walks 3rd-party React Native consumers through Agentforce SDK integration via the `react-native-agentforce` bridge.

The skill:
- **Use-case-driven configuration** — picks the right `AgentforceService.configure(...)` mode (Service Agent for public/customer-facing, Employee Agent for signed-in workforce) based on what the consumer is building, instead of asking them to choose between configuration shapes upfront.
- **Bridge + native wiring** — surfaces the `react-native-agentforce` bridge install, the iOS/Android install scripts (Boost, XcodeGen, CocoaPods, Gradle), and the Mobile SDK requirements for Employee Agent.
- **Scaffolds the integration files** — generates `agentforceConfig.ts`, `agentforceLogger.ts`, `agentforceNavigation.ts`, optional `employeeAuth.ts`, and a launch button (prominent home button, header icon, or auto-launch wrapper).
- **MIAW deployment guidance** — for Service Agent, links to the Messaging for In-App and Web mobile deployment docs.

This is the third in a series of `integrate-agentforce-*` skills; companions for iOS and Android already shipped to their respective repos.

## Layout

- `skills/integrate-agentforce-react-native/SKILL.md` — main skill prompt (7-phase workflow)
- `skills/integrate-agentforce-react-native/references/` — auth-flows, api-reference, dep-detection, chat-presentation
- `skills/integrate-agentforce-react-native/references/snippets/` — TypeScript templates with placeholders
- `.claude-plugin/plugin.json` + `marketplace.json` — Claude Code marketplace metadata
- `README.md` — adds an "Integrate with Claude Code" section above Prerequisites

## Test plan

- [ ] Open this repo in Claude Code; confirm `/integrate-agentforce-react-native` appears in the available-skills list.
- [ ] In a fresh React Native test app, run `/plugin marketplace add salesforce/AgentforceMobileSDK-ReactNative` and `/plugin install agentforce-mobile-sdk-react-native@agentforce-mobile-sdk-react-native`, then run the skill end-to-end through both Service Agent and Employee Agent paths.
- [ ] After scaffold, verify the generated TypeScript compiles and the launch button opens the native conversation UI on both iOS and Android.
- [ ] Verify ``npx skills add`` (skills.sh-style installer) discovers the skill at ``skills/integrate-agentforce-react-native/``.