### PR TITLE
Add UIDelegate bridge for SDK UI event forwarding

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -92,6 +92,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     // Bridge hidden prechat fields (Service Agent only)
     private val bridgeHiddenPreChat = BridgeHiddenPreChat()
 
+    // Bridge UI delegate for forwarding SDK UI events to JS
+    private val bridgeUIDelegate = BridgeUIDelegate(reactContext)
+
     // Coroutine scope for async operations
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
@@ -194,6 +197,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                 // Always attach bridgeViewProvider so late registrations take effect.
                 // canHandle() returns false when the map is empty, matching no-provider behavior.
                 agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
+                agentforceConfigBuilder.setDelegate(bridgeUIDelegate)
                 val agentforceConfig = agentforceConfigBuilder.build()
 
                 val sdkMode = AgentforceMode.ServiceAgent(
@@ -296,6 +300,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                 // Always attach bridgeViewProvider so late registrations take effect.
                 // canHandle() returns false when the map is empty, matching no-provider behavior.
                 agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
+                agentforceConfigBuilder.setDelegate(bridgeUIDelegate)
                 val agentforceConfig = agentforceConfigBuilder.build()
 
                 // Use FullConfig mode for Employee Agent
@@ -622,6 +627,23 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         bridgeNavigation.forwardingEnabled = enabled
         Log.d(TAG, "Navigation forwarding ${if (enabled) "enabled" else "disabled"}")
         promise.resolve(true)
+    }
+
+    // endregion
+
+    // region UI Delegate Forwarding
+
+    @ReactMethod
+    fun enableUIDelegateForwarding(enabled: Boolean, promise: Promise) {
+        bridgeUIDelegate.forwardingEnabled = enabled
+        Log.d(TAG, "UI delegate forwarding ${if (enabled) "enabled" else "disabled"}")
+        promise.resolve(true)
+    }
+
+    @ReactMethod
+    fun provideModifiedUtterance(requestId: String, utterance: String, promise: Promise) {
+        val completed = bridgeUIDelegate.completeModification(requestId, utterance)
+        promise.resolve(completed)
     }
 
     // endregion

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeUIDelegate.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeUIDelegate.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Bridge UIDelegate that forwards Agentforce SDK UI events to React Native JS via events.
+ */
+package com.salesforce.android.reactagentforce
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.salesforce.android.agentforcesdkimpl.AgentConversation
+import com.salesforce.android.agentforcesdkimpl.AgentforceConversation
+import com.salesforce.android.agentforcesdkimpl.AgentforceUIDelegate
+import com.salesforce.android.agentforceservice.AgentforceUtterance
+import com.salesforce.android.agentforceservice.conversationservice.data.AgentforceMessage
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeout
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Implements the Agentforce SDK AgentforceUIDelegate interface and forwards UI events
+ * to JavaScript via NativeEventEmitter events.
+ *
+ * UI event forwarding is disabled by default and enabled when JS registers a UIDelegate.
+ */
+class BridgeUIDelegate(private val reactContext: ReactContext) : AgentforceUIDelegate {
+
+    /** Controls whether UI events are forwarded to JS. */
+    @Volatile
+    var forwardingEnabled: Boolean = false
+
+    /** Pending modify-utterance requests awaiting JS responses. */
+    private val pendingModifications = ConcurrentHashMap<String, CompletableDeferred<String>>()
+
+    /** ISO 8601 date formatter. */
+    private val iso8601Formatter: SimpleDateFormat
+        get() = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+
+    /** Returns a conversation ID string from an AgentConversation. */
+    private fun getConversationId(conversation: AgentConversation): String {
+        return if (conversation is AgentforceConversation) {
+            conversation.id
+        } else {
+            conversation.hashCode().toString()
+        }
+    }
+
+    override suspend fun modifyUtteranceBeforeSending(
+        agentforceUtterance: AgentforceUtterance
+    ): AgentforceUtterance {
+        if (!forwardingEnabled) return agentforceUtterance
+
+        val requestId = UUID.randomUUID().toString()
+        val deferred = CompletableDeferred<String>()
+        pendingModifications[requestId] = deferred
+
+        try {
+            val params = Arguments.createMap().apply {
+                putString("requestId", requestId)
+                putString("utterance", agentforceUtterance.utterance)
+            }
+
+            reactContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+                .emit("onModifyUtteranceRequest", params)
+
+            val modifiedText = withTimeout(5000) { deferred.await() }
+
+            return AgentforceUtterance(
+                utterance = modifiedText,
+                agentforceAttachment = agentforceUtterance.agentforceAttachment
+            )
+        } catch (e: Exception) {
+            return agentforceUtterance
+        } finally {
+            pendingModifications.remove(requestId)
+        }
+    }
+
+    /**
+     * Called by AgentforceModule when JS responds to a modify-utterance request.
+     *
+     * @return true if the request was found and completed, false otherwise.
+     */
+    fun completeModification(requestId: String, modifiedUtterance: String): Boolean {
+        val deferred = pendingModifications[requestId] ?: return false
+        return deferred.complete(modifiedUtterance)
+    }
+
+    override fun didSendUtterance(agentforceUtterance: AgentforceUtterance) {
+        if (!forwardingEnabled) return
+
+        val params = Arguments.createMap().apply {
+            putString("utterance", agentforceUtterance.utterance)
+            putBoolean("hasAttachment", agentforceUtterance.agentforceAttachment != null)
+            putString("timestamp", iso8601Formatter.format(Date()))
+        }
+
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit("onUtteranceSent", params)
+    }
+
+    override fun userDidSwitchAgents(newConversation: AgentConversation) {
+        if (!forwardingEnabled) return
+
+        val params = Arguments.createMap().apply {
+            putString("conversationId", getConversationId(newConversation))
+            putString("timestamp", iso8601Formatter.format(Date()))
+        }
+
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit("onAgentSwitch", params)
+    }
+
+    override fun didReceiveResponse(
+        agentforceMessage: AgentforceMessage,
+        conversation: AgentConversation
+    ) {
+        if (!forwardingEnabled) return
+
+        val params = Arguments.createMap().apply {
+            putString("responseId", agentforceMessage.id)
+            putString("message", agentforceMessage.message ?: agentforceMessage.text)
+            putString("type", agentforceMessage.type ?: "agent")
+            putString("conversationId", getConversationId(conversation))
+            putString("timestamp", iso8601Formatter.format(Date(agentforceMessage.timeStamp)))
+        }
+
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit("onAgentResponse", params)
+    }
+}

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeUIDelegate.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeUIDelegate.kt
@@ -6,6 +6,7 @@
  */
 package com.salesforce.android.reactagentforce
 
+import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.core.DeviceEventManagerModule
@@ -15,6 +16,7 @@ import com.salesforce.android.agentforcesdkimpl.AgentforceUIDelegate
 import com.salesforce.android.agentforceservice.AgentforceUtterance
 import com.salesforce.android.agentforceservice.conversationservice.data.AgentforceMessage
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -38,11 +40,13 @@ class BridgeUIDelegate(private val reactContext: ReactContext) : AgentforceUIDel
     /** Pending modify-utterance requests awaiting JS responses. */
     private val pendingModifications = ConcurrentHashMap<String, CompletableDeferred<String>>()
 
-    /** ISO 8601 date formatter. */
-    private val iso8601Formatter: SimpleDateFormat
-        get() = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+    /** Timeout for awaiting a modified utterance from JavaScript (milliseconds). */
+    private val modifyUtteranceTimeoutMs: Long = 10_000
+
+    private fun isoTimestamp(): String =
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
             timeZone = TimeZone.getTimeZone("UTC")
-        }
+        }.format(Date())
 
     /** Returns a conversation ID string from an AgentConversation. */
     private fun getConversationId(conversation: AgentConversation): String {
@@ -72,13 +76,17 @@ class BridgeUIDelegate(private val reactContext: ReactContext) : AgentforceUIDel
                 .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
                 .emit("onModifyUtteranceRequest", params)
 
-            val modifiedText = withTimeout(5000) { deferred.await() }
+            val modifiedText = withTimeout(modifyUtteranceTimeoutMs) { deferred.await() }
 
             return AgentforceUtterance(
                 utterance = modifiedText,
                 agentforceAttachment = agentforceUtterance.agentforceAttachment
             )
+        } catch (e: TimeoutCancellationException) {
+            Log.d(TAG, "modifyUtterance timed out for request $requestId, using original")
+            return agentforceUtterance
         } catch (e: Exception) {
+            Log.w(TAG, "modifyUtterance failed for request $requestId", e)
             return agentforceUtterance
         } finally {
             pendingModifications.remove(requestId)
@@ -101,7 +109,7 @@ class BridgeUIDelegate(private val reactContext: ReactContext) : AgentforceUIDel
         val params = Arguments.createMap().apply {
             putString("utterance", agentforceUtterance.utterance)
             putBoolean("hasAttachment", agentforceUtterance.agentforceAttachment != null)
-            putString("timestamp", iso8601Formatter.format(Date()))
+            putString("timestamp", isoTimestamp())
         }
 
         reactContext
@@ -114,7 +122,7 @@ class BridgeUIDelegate(private val reactContext: ReactContext) : AgentforceUIDel
 
         val params = Arguments.createMap().apply {
             putString("conversationId", getConversationId(newConversation))
-            putString("timestamp", iso8601Formatter.format(Date()))
+            putString("timestamp", isoTimestamp())
         }
 
         reactContext
@@ -133,11 +141,20 @@ class BridgeUIDelegate(private val reactContext: ReactContext) : AgentforceUIDel
             putString("message", agentforceMessage.message ?: agentforceMessage.text)
             putString("type", agentforceMessage.type ?: "agent")
             putString("conversationId", getConversationId(conversation))
-            putString("timestamp", iso8601Formatter.format(Date(agentforceMessage.timeStamp)))
+            putString("timestamp", formatTimestamp(agentforceMessage.timeStamp))
         }
 
         reactContext
             .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
             .emit("onAgentResponse", params)
+    }
+
+    private fun formatTimestamp(epochMillis: Long): String =
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }.format(Date(epochMillis))
+
+    companion object {
+        private const val TAG = "BridgeUIDelegate"
     }
 }

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
@@ -118,4 +118,15 @@ RCT_EXTERN_METHOD(registerViewProvider:(NSDictionary *)config
 RCT_EXTERN_METHOD(clearViewProvider:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+// MARK: - UI Delegate
+
+RCT_EXTERN_METHOD(enableUIDelegateForwarding:(BOOL)enabled
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(provideModifiedUtterance:(NSString *)requestId
+                  utterance:(NSString *)utterance
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -753,7 +753,24 @@ class AgentforceModule: RCTEventEmitter {
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) {
         bridgeUIDelegate.forwardingEnabled = enabled
+
+        if !enabled {
+            drainPendingContinuations()
+        }
+
         resolve(true)
+    }
+
+    /// Resume all pending modify-utterance continuations with nil to prevent leaks.
+    private func drainPendingContinuations() {
+        modifyContinuationsLock.lock()
+        let pending = modifyContinuations
+        modifyContinuations.removeAll()
+        modifyContinuationsLock.unlock()
+
+        for (_, continuation) in pending {
+            continuation.resume(returning: nil)
+        }
     }
 
     @objc
@@ -780,15 +797,15 @@ class AgentforceModule: RCTEventEmitter {
     func awaitModifiedUtterance(requestId: String, utteranceText: String, timeout: TimeInterval) async -> String? {
         guard listenerLock.withLock({ _hasListeners }) else { return nil }
 
-        sendEvent(withName: "onModifyUtteranceRequest", body: [
-            "requestId": requestId,
-            "utterance": utteranceText,
-        ])
-
         return await withCheckedContinuation { continuation in
             modifyContinuationsLock.lock()
             modifyContinuations[requestId] = continuation
             modifyContinuationsLock.unlock()
+
+            sendEvent(withName: "onModifyUtteranceRequest", body: [
+                "requestId": requestId,
+                "utterance": utteranceText,
+            ])
 
             Task {
                 try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -73,6 +73,17 @@ class AgentforceModule: RCTEventEmitter {
         return BridgeViewProvider(bridge: self.bridge)
     }()
 
+    // MARK: - UI Delegate
+
+    /// Bridge UI delegate for forwarding SDK UI events to JavaScript.
+    private lazy var bridgeUIDelegate: BridgeUIDelegate = {
+        return BridgeUIDelegate(module: self)
+    }()
+
+    /// Pending modify-utterance continuations keyed by requestId.
+    private var modifyContinuations: [String: CheckedContinuation<String?, Never>] = [:]
+    private let modifyContinuationsLock = NSLock()
+
     // MARK: - Module Setup
 
     override static func requiresMainQueueSetup() -> Bool {
@@ -80,7 +91,13 @@ class AgentforceModule: RCTEventEmitter {
     }
 
     override func supportedEvents() -> [String]! {
-        return ["onLogMessage", "onNavigationRequest"]
+        return [
+            "onLogMessage",
+            "onNavigationRequest",
+            "onUtteranceSent",
+            "onAgentSwitch",
+            "onModifyUtteranceRequest",
+        ]
     }
 
     override func startObserving() {
@@ -369,7 +386,7 @@ class AgentforceModule: RCTEventEmitter {
 
                 let chatView = try client.createAgentforceChatView(
                     conversation: conversation,
-                    delegate: nil,
+                    delegate: bridgeUIDelegate,
                     showTopBar: true,
                     onContainerClose: { [weak self] in
                         Task { @MainActor in
@@ -409,7 +426,7 @@ class AgentforceModule: RCTEventEmitter {
 
                 let chatView = try client.createAgentforceChatView(
                     conversation: conversation,
-                    delegate: nil,
+                    delegate: bridgeUIDelegate,
                     showTopBar: true,
                     onContainerClose: { [weak self] in
                         Task { @MainActor in
@@ -725,6 +742,72 @@ class AgentforceModule: RCTEventEmitter {
     func emitNavigationEvent(_ payload: [String: Any]) {
         guard listenerLock.withLock({ _hasListeners }) else { return }
         sendEvent(withName: "onNavigationRequest", body: payload)
+    }
+
+    // MARK: - UI Delegate Forwarding
+
+    @objc
+    func enableUIDelegateForwarding(
+        _ enabled: Bool,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        bridgeUIDelegate.forwardingEnabled = enabled
+        resolve(true)
+    }
+
+    @objc
+    func provideModifiedUtterance(
+        _ requestId: String,
+        utterance: String,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        modifyContinuationsLock.lock()
+        let continuation = modifyContinuations.removeValue(forKey: requestId)
+        modifyContinuationsLock.unlock()
+
+        if let continuation = continuation {
+            continuation.resume(returning: utterance)
+            resolve(true)
+        } else {
+            resolve(false)
+        }
+    }
+
+    /// Called by BridgeUIDelegate to emit a modify-utterance request to JS
+    /// and await the response (or timeout).
+    func awaitModifiedUtterance(requestId: String, utteranceText: String, timeout: TimeInterval) async -> String? {
+        guard listenerLock.withLock({ _hasListeners }) else { return nil }
+
+        sendEvent(withName: "onModifyUtteranceRequest", body: [
+            "requestId": requestId,
+            "utterance": utteranceText,
+        ])
+
+        return await withCheckedContinuation { continuation in
+            modifyContinuationsLock.lock()
+            modifyContinuations[requestId] = continuation
+            modifyContinuationsLock.unlock()
+
+            Task {
+                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                self.modifyContinuationsLock.lock()
+                let pending = self.modifyContinuations.removeValue(forKey: requestId)
+                self.modifyContinuationsLock.unlock()
+                pending?.resume(returning: nil)
+            }
+        }
+    }
+
+    func emitUtteranceSentEvent(_ payload: [String: Any]) {
+        guard listenerLock.withLock({ _hasListeners }) else { return }
+        sendEvent(withName: "onUtteranceSent", body: payload)
+    }
+
+    func emitAgentSwitchEvent(_ payload: [String: Any]) {
+        guard listenerLock.withLock({ _hasListeners }) else { return }
+        sendEvent(withName: "onAgentSwitch", body: payload)
     }
 
     // MARK: - View Provider

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeUIDelegate.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeUIDelegate.swift
@@ -69,14 +69,11 @@ class BridgeUIDelegate: AgentforceUIDelegate {
     func didSendUtterance(_ utterance: AgentforceUtterance) {
         guard forwardingEnabled else { return }
 
-        var payload: [String: Any] = [
-            "utterance": utterance.utterance
+        let payload: [String: Any] = [
+            "utterance": utterance.utterance,
+            "hasAttachment": utterance.attachment != nil,
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
         ]
-
-        if let attachment = utterance.attachment {
-            payload["hasAttachment"] = true
-            payload["attachment"] = String(describing: attachment)
-        }
 
         module?.emitUtteranceSentEvent(payload)
     }
@@ -85,7 +82,8 @@ class BridgeUIDelegate: AgentforceUIDelegate {
         guard forwardingEnabled else { return }
 
         let payload: [String: Any] = [
-            "conversationId": newConversation.conversationId.uuidString
+            "conversationId": newConversation.conversationId.uuidString,
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
         ]
 
         module?.emitAgentSwitchEvent(payload)

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeUIDelegate.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeUIDelegate.swift
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
+ *
+ * React Native bridge UI delegate for Agentforce SDK
+ */
+
+import Foundation
+import AgentforceSDK
+import AgentforceService
+
+/// Bridge UI delegate that forwards Agentforce SDK UI events to React Native JavaScript
+///
+/// Implements the iOS Agentforce SDK's AgentforceUIDelegate protocol and emits events
+/// to the React Native event emitter. Forwarding can be enabled/disabled
+/// to avoid bridge overhead when no JS delegate is registered.
+///
+/// The `modifyUtteranceBeforeSending` method emits a request to JS and waits
+/// (with a timeout) for JS to respond via `awaitModifiedUtterance` on the module.
+class BridgeUIDelegate: AgentforceUIDelegate {
+
+    // MARK: - Properties
+
+    /// Weak reference to the module to avoid retain cycles
+    weak var module: AgentforceModule?
+
+    private let lock = NSLock()
+    private var _forwardingEnabled: Bool = false
+
+    /// Controls whether UI delegate events should be forwarded to JavaScript.
+    /// Thread-safe: written on the JS thread, read on SDK callback threads.
+    var forwardingEnabled: Bool {
+        get { lock.withLock { _forwardingEnabled } }
+        set { lock.withLock { _forwardingEnabled = newValue } }
+    }
+
+    /// Timeout for awaiting a modified utterance from JavaScript (seconds).
+    /// If JS does not respond within this window, the original utterance is returned.
+    var modifyUtteranceTimeout: TimeInterval = 10.0
+
+    // MARK: - Initialization
+
+    init(module: AgentforceModule) {
+        self.module = module
+    }
+
+    // MARK: - AgentforceUIDelegate Protocol Implementation
+
+    func modifyUtteranceBeforeSending(_ utterance: AgentforceUtterance) async -> AgentforceUtterance {
+        guard forwardingEnabled, let module = module else {
+            return utterance
+        }
+
+        let requestId = UUID().uuidString
+
+        // Ask JS to modify the utterance; the module handles the continuation/timeout internally.
+        let modifiedText = await module.awaitModifiedUtterance(
+            requestId: requestId,
+            utteranceText: utterance.utterance,
+            timeout: modifyUtteranceTimeout
+        )
+
+        if let modifiedText = modifiedText {
+            return AgentforceUtterance(utterance: modifiedText, attachment: utterance.attachment)
+        }
+
+        return utterance
+    }
+
+    func didSendUtterance(_ utterance: AgentforceUtterance) {
+        guard forwardingEnabled else { return }
+
+        var payload: [String: Any] = [
+            "utterance": utterance.utterance
+        ]
+
+        if let attachment = utterance.attachment {
+            payload["hasAttachment"] = true
+            payload["attachment"] = String(describing: attachment)
+        }
+
+        module?.emitUtteranceSentEvent(payload)
+    }
+
+    func userDidSwitchAgents(newConversation: any AgentConversation) {
+        guard forwardingEnabled else { return }
+
+        let payload: [String: Any] = [
+            "conversationId": newConversation.conversationId.uuidString
+        ]
+
+        module?.emitAgentSwitchEvent(payload)
+    }
+
+    func userInitiatedVoice(for conversation: any AgentConversation) {
+        // Voice is managed internally in 260.5 - no forwarding needed.
+    }
+
+    // didReceiveResponse is a no-op on iOS: AgentforceMessage properties are internal
+    // in SDK 260.5, so the bridge cannot extract message text, type, or timestamp.
+    // Android exposes these publicly via its data class. Re-evaluate when the iOS SDK
+    // makes AgentforceMessage fields public.
+    func didReceiveResponse(_ message: AgentforceMessage, from conversation: any AgentConversation) {}
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/index.ts
@@ -35,6 +35,11 @@ export type {
   ViewProviderDelegate,
   ViewProviderComponentData,
   HiddenPreChatFields,
+  UIDelegate,
+  AgentResponseEvent,
+  UtteranceSentEvent,
+  AgentSwitchEvent,
+  ModifyUtteranceRequest,
 } from './types';
 export { isServiceAgentConfig, isEmployeeAgentConfig, isLegacyConfig } from './types';
 

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -27,6 +27,13 @@ import type {
 } from '../types/AgentforceContext';
 import { ViewProviderDelegate } from '../types/ViewProviderDelegate';
 import type { HiddenPreChatFields } from '../types/HiddenPreChatFields';
+import type {
+  UIDelegate,
+  AgentResponseEvent,
+  UtteranceSentEvent,
+  AgentSwitchEvent,
+  ModifyUtteranceRequest,
+} from '../types/UIDelegate';
 
 const { AgentforceModule } = NativeModules;
 
@@ -37,6 +44,13 @@ export type { NavigationDelegate, NavigationRequest };
 export type { AgentforceAdditionalContext, AgentforceContextVariable };
 export type { ViewProviderDelegate };
 export type { HiddenPreChatFields };
+export type {
+  UIDelegate,
+  AgentResponseEvent,
+  UtteranceSentEvent,
+  AgentSwitchEvent,
+  ModifyUtteranceRequest,
+};
 
 /**
  * Native module event names
@@ -44,6 +58,10 @@ export type { HiddenPreChatFields };
 const EVENTS = {
   LOG_MESSAGE: 'onLogMessage',
   NAVIGATION_REQUEST: 'onNavigationRequest',
+  AGENT_RESPONSE: 'onAgentResponse',
+  UTTERANCE_SENT: 'onUtteranceSent',
+  AGENT_SWITCH: 'onAgentSwitch',
+  MODIFY_UTTERANCE_REQUEST: 'onModifyUtteranceRequest',
 } as const;
 
 /**
@@ -124,6 +142,16 @@ class AgentforceService {
    * View provider delegate configuration (registered component types + React component name)
    */
   private viewProviderDelegate: ViewProviderDelegate | null = null;
+
+  /**
+   * UI delegate for receiving agent response, utterance, and switch events
+   */
+  private uiDelegate: UIDelegate | null = null;
+
+  /**
+   * Subscriptions for UI delegate events
+   */
+  private uiDelegateSubscriptions: EmitterSubscription[] = [];
 
   /**
    * Track if service has been initialized
@@ -319,6 +347,102 @@ class AgentforceService {
     } catch (error) {
       console.warn('[AgentforceService] Failed to clear view provider:', error);
     }
+  }
+
+  /**
+   * Register a UI delegate to receive agent response, utterance sent,
+   * agent switch, and modify-utterance events from the native Agentforce SDK.
+   *
+   * Can be called before or after launching a conversation.
+   *
+   * @param delegate - UI delegate implementation
+   *
+   * @example
+   * ```typescript
+   * AgentforceService.setUIDelegate({
+   *   onAgentResponse(event) {
+   *     console.log(`Agent said: ${event.message}`);
+   *   },
+   *   onUtteranceSent(event) {
+   *     console.log(`User sent: ${event.utterance}`);
+   *   },
+   *   onAgentSwitch(event) {
+   *     console.log(`Switched to conversation: ${event.conversationId}`);
+   *   },
+   *   modifyUtterance(request) {
+   *     return request.utterance.toUpperCase();
+   *   },
+   * });
+   * ```
+   */
+  setUIDelegate(delegate: UIDelegate): void {
+    this.uiDelegate = delegate;
+    this.setupUIDelegateListeners();
+    AgentforceModule?.enableUIDelegateForwarding(true);
+    console.log('[AgentforceService] UI delegate registered');
+  }
+
+  /**
+   * Clear the registered UI delegate and stop receiving UI events.
+   */
+  clearUIDelegate(): void {
+    this.uiDelegate = null;
+    for (const sub of this.uiDelegateSubscriptions) {
+      sub.remove();
+    }
+    this.uiDelegateSubscriptions = [];
+    AgentforceModule?.enableUIDelegateForwarding(false);
+    console.log('[AgentforceService] UI delegate cleared');
+  }
+
+  /**
+   * Set up listeners for UI delegate events from native layer
+   */
+  private setupUIDelegateListeners(): void {
+    for (const sub of this.uiDelegateSubscriptions) {
+      sub.remove();
+    }
+    this.uiDelegateSubscriptions = [];
+
+    if (!this.eventEmitter) {
+      return;
+    }
+
+    this.uiDelegateSubscriptions.push(
+      this.eventEmitter.addListener(EVENTS.AGENT_RESPONSE, (event: AgentResponseEvent) => {
+        this.uiDelegate?.onAgentResponse(event);
+      }),
+    );
+
+    this.uiDelegateSubscriptions.push(
+      this.eventEmitter.addListener(EVENTS.UTTERANCE_SENT, (event: UtteranceSentEvent) => {
+        this.uiDelegate?.onUtteranceSent?.(event);
+      }),
+    );
+
+    this.uiDelegateSubscriptions.push(
+      this.eventEmitter.addListener(EVENTS.AGENT_SWITCH, (event: AgentSwitchEvent) => {
+        this.uiDelegate?.onAgentSwitch?.(event);
+      }),
+    );
+
+    this.uiDelegateSubscriptions.push(
+      this.eventEmitter.addListener(
+        EVENTS.MODIFY_UTTERANCE_REQUEST,
+        async (request: ModifyUtteranceRequest) => {
+          if (!this.uiDelegate?.modifyUtterance) {
+            AgentforceModule?.provideModifiedUtterance(request.requestId, request.utterance);
+            return;
+          }
+          try {
+            const modified = await this.uiDelegate.modifyUtterance(request);
+            AgentforceModule?.provideModifiedUtterance(request.requestId, modified);
+          } catch {
+            AgentforceModule?.provideModifiedUtterance(request.requestId, request.utterance);
+          }
+        },
+      ),
+    );
   }
 
   /**
@@ -927,6 +1051,12 @@ class AgentforceService {
     this.navigationSubscription?.remove();
     this.navigationSubscription = null;
     this.navigationDelegate = null;
+
+    for (const sub of this.uiDelegateSubscriptions) {
+      sub.remove();
+    }
+    this.uiDelegateSubscriptions = [];
+    this.uiDelegate = null;
 
     // Clear native view provider registration before nulling the JS reference
     if (this.viewProviderDelegate) {

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -410,7 +410,7 @@ class AgentforceService {
 
     this.uiDelegateSubscriptions.push(
       this.eventEmitter.addListener(EVENTS.AGENT_RESPONSE, (event: AgentResponseEvent) => {
-        this.uiDelegate?.onAgentResponse(event);
+        this.uiDelegate?.onAgentResponse?.(event);
       }),
     );
 
@@ -436,7 +436,8 @@ class AgentforceService {
           }
           try {
             const modified = await this.uiDelegate.modifyUtterance(request);
-            AgentforceModule?.provideModifiedUtterance(request.requestId, modified);
+            const result = typeof modified === 'string' ? modified : request.utterance;
+            AgentforceModule?.provideModifiedUtterance(request.requestId, result);
           } catch {
             AgentforceModule?.provideModifiedUtterance(request.requestId, request.utterance);
           }

--- a/AgentforceSDK-ReactNative-Bridge/src/types/UIDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/UIDelegate.ts
@@ -1,0 +1,77 @@
+/**
+ * UI Delegate types for Agentforce SDK
+ *
+ * Allows JS to receive UI delegate events from the native Agentforce SDK:
+ * - Agent responses (complete, non-streaming)
+ * - Utterance sent notifications
+ * - Agent switch notifications
+ * - Utterance modification before sending (async request/response)
+ */
+
+export interface AgentResponseEvent {
+  /** Unique message identifier */
+  responseId: string;
+  /** The agent's response text (may be null for non-text responses) */
+  message: string | null;
+  /** Message type classification */
+  type: string;
+  /** Conversation that produced this response (UUID string) */
+  conversationId: string;
+  /** ISO 8601 timestamp */
+  timestamp?: string;
+}
+
+export interface UtteranceSentEvent {
+  /** The utterance text that was sent */
+  utterance: string;
+  /** Whether the utterance had an attachment */
+  hasAttachment: boolean;
+  /** ISO 8601 timestamp */
+  timestamp: string;
+}
+
+export interface AgentSwitchEvent {
+  /** Identifier of the new conversation after the switch */
+  conversationId: string;
+  /** ISO 8601 timestamp */
+  timestamp: string;
+}
+
+export interface ModifyUtteranceRequest {
+  /** Unique request ID — pass back in the return value */
+  requestId: string;
+  /** The original utterance text before modification */
+  utterance: string;
+}
+
+/**
+ * Delegate interface for receiving UI delegate events from the Agentforce SDK.
+ *
+ * Register using `AgentforceService.setUIDelegate()` before or after launching a conversation.
+ * All callbacks are optional except `onAgentResponse`.
+ *
+ * @example
+ * ```typescript
+ * AgentforceService.setUIDelegate({
+ *   onAgentResponse(event) {
+ *     console.log(`Agent said: ${event.message}`);
+ *   },
+ *   onUtteranceSent(event) {
+ *     console.log(`User sent: ${event.utterance}`);
+ *   },
+ *   onAgentSwitch(event) {
+ *     console.log(`Switched to conversation: ${event.conversationId}`);
+ *   },
+ *   modifyUtterance(request) {
+ *     return request.utterance.toUpperCase(); // modify the text
+ *   },
+ * });
+ * ```
+ */
+export interface UIDelegate {
+  onAgentResponse(event: AgentResponseEvent): void;
+  onUtteranceSent?(event: UtteranceSentEvent): void;
+  onAgentSwitch?(event: AgentSwitchEvent): void;
+  /** Return the modified utterance text, or the original to leave unchanged. */
+  modifyUtterance?(request: ModifyUtteranceRequest): string | Promise<string>;
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/types/UIDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/UIDelegate.ts
@@ -69,7 +69,8 @@ export interface ModifyUtteranceRequest {
  * ```
  */
 export interface UIDelegate {
-  onAgentResponse(event: AgentResponseEvent): void;
+  /** Called when the agent sends a response. Android only — iOS SDK does not expose message fields publicly. */
+  onAgentResponse?(event: AgentResponseEvent): void;
   onUtteranceSent?(event: UtteranceSentEvent): void;
   onAgentSwitch?(event: AgentSwitchEvent): void;
   /** Return the modified utterance text, or the original to leave unchanged. */

--- a/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
@@ -36,3 +36,12 @@ export { ViewProviderDelegate, ViewProviderComponentData } from './ViewProviderD
 
 // Hidden prechat field types
 export type { HiddenPreChatFields } from './HiddenPreChatFields';
+
+// UI delegate types
+export type {
+  UIDelegate,
+  AgentResponseEvent,
+  UtteranceSentEvent,
+  AgentSwitchEvent,
+  ModifyUtteranceRequest,
+} from './UIDelegate';


### PR DESCRIPTION
## Summary
- Implements `AgentforceUIDelegate` on iOS and Android native bridges to forward conversation lifecycle events to JavaScript
- Surfaces `didSendUtterance`, `userDidSwitchAgents`, and `modifyUtteranceBeforeSending` callbacks via a new `UIDelegate` interface in the TypeScript layer
- `didReceiveResponse` is active on Android only — iOS SDK 260.5 does not expose `AgentforceMessage` properties publicly (noted with comment for future enablement)
- Adds `setUIDelegate()` / `clearUIDelegate()` API to `AgentforceService`

## Test plan
- [x] iOS Service Agent: verified conversation launches correctly
- [ ] Android Service Agent: verify delegate events fire (onUtteranceSent, onAgentSwitch)
- [ ] Android: verify modifyUtterance round-trip (JS modifies text, agent receives modified version)
- [ ] iOS: verify modifyUtterance round-trip
- [ ] Verify clearUIDelegate stops forwarding
- [ ] Verify delegate can be set before or after launching conversation