### PR TITLE
Expose serviceUISettings to JavaScript configuration

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -24,6 +24,7 @@ import com.salesforce.android.agentforcesdkimpl.AgentforceClient
 import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceConfiguration
 import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceMode
 import com.salesforce.android.agentforcesdkimpl.configuration.ServiceAgentConfiguration
+import com.salesforce.android.agentforcesdkimpl.configuration.ServiceUISettings
 import com.salesforce.android.agentforcesdkimpl.utils.AgentforceFeatureFlagSettings
 import com.salesforce.android.agentforcesdkvoice.AgentforceVoiceProviderFactory
 import com.salesforce.android.agentforcesdkvoice.AgentforceVoiceUIProvider
@@ -160,6 +161,15 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             AgentforceConversationOverlay.destroy()
             AgentforceClientHolder.clear()
             try {
+                // Build ServiceUISettings from JS config (use SDK defaults for omitted keys)
+                val uiSettings = serviceConfig.serviceUISettings?.let { raw ->
+                    ServiceUISettings(
+                        downloadTranscript = raw["downloadTranscript"] ?: true,
+                        endConversation = raw["endConversation"] ?: true,
+                        enableLightingType = raw["enableLightningType"] ?: false
+                    )
+                } ?: ServiceUISettings()
+
                 // Create SDK Service Agent configuration
                 val sdkServiceConfig = ServiceAgentConfiguration
                     .builder(
@@ -167,6 +177,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                         organizationId = serviceConfig.organizationId,
                         serviceApiURL = serviceConfig.serviceApiURL
                     )
+                    .setServiceUISettings(uiSettings)
                     .build()
                 val flags = getFeatureFlagsFromConfigOrPrefs(config)
                 val featureFlagSettings = AgentforceFeatureFlagSettings.builder()

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/models/AgentMode.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/models/AgentMode.kt
@@ -42,7 +42,9 @@ data class ServiceAgentModeConfig(
     /** Salesforce Organization ID */
     val organizationId: String,
     /** The Einstein Service Agent developer name */
-    val esDeveloperName: String
+    val esDeveloperName: String,
+    /** Optional UI settings parsed from JS config */
+    val serviceUISettings: Map<String, Boolean>? = null
 ) {
     companion object {
         /**
@@ -54,11 +56,26 @@ data class ServiceAgentModeConfig(
             val serviceApiURL = map.getString("serviceApiURL") ?: return null
             val organizationId = map.getString("organizationId") ?: return null
             val esDeveloperName = map.getString("esDeveloperName") ?: return null
-            
+
+            val uiSettings: Map<String, Boolean>? = if (map.hasKey("serviceUISettings")) {
+                map.getMap("serviceUISettings")?.let { settingsMap ->
+                    val result = mutableMapOf<String, Boolean>()
+                    val iterator = settingsMap.keySetIterator()
+                    while (iterator.hasNextKey()) {
+                        val key = iterator.nextKey()
+                        result[key] = settingsMap.getBoolean(key)
+                    }
+                    result.ifEmpty { null }
+                }
+            } else {
+                null
+            }
+
             return ServiceAgentModeConfig(
                 serviceApiURL = serviceApiURL,
                 organizationId = organizationId,
-                esDeveloperName = esDeveloperName
+                esDeveloperName = esDeveloperName,
+                serviceUISettings = uiSettings
             )
         }
     }

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -157,15 +157,33 @@ class AgentforceModule: RCTEventEmitter {
         UserDefaults.standard.set(trimmedOrgId, forKey: "ServiceAgentOrgUrl")
         UserDefaults.standard.set(trimmedDevName, forKey: "ServiceAgentDevName")
 
+        // Build ServiceUISettings from JS config (use SDK defaults for omitted keys)
+        let uiSettings: ServiceUISettings
+        if let raw = config.serviceUISettings {
+            uiSettings = ServiceUISettings(
+                downloadTranscript: raw["downloadTranscript"] ?? true,
+                endConversation: raw["endConversation"] ?? true,
+                validationFailureChunkEnabled: raw["validationFailureChunkEnabled"] ?? true,
+                useWelcomeUtterances: raw["useWelcomeUtterances"] ?? false,
+                showQueueStatus: raw["showQueueStatus"] ?? true,
+                enableVideoUpload: raw["enableVideoUpload"] ?? false,
+                enableLightningType: raw["enableLightningType"] ?? false,
+                secureForms: raw["secureForms"] ?? true,
+                enableAudioUpload: raw["enableAudioUpload"] ?? false
+            )
+        } else {
+            uiSettings = ServiceUISettings(
+                showQueueStatus: true,
+                secureForms: true
+            )
+        }
+
         // Use .serviceAgent() mode with overrides for logger and navigation.
         let serviceConfig = ServiceAgentConfiguration(
             esDeveloperName: config.esDeveloperName,
             organizationId: config.organizationId,
             serviceApiURL: config.serviceApiURL,
-            serviceUISettings: ServiceUISettings(
-                showQueueStatus: true,
-                secureForms: true
-            ),
+            serviceUISettings: uiSettings,
             forceConfigEndPoint: config.serviceApiURL
         )
         .withLogger(bridgeLogger)

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Models/AgentMode.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Models/AgentMode.swift
@@ -33,13 +33,16 @@ enum AgentMode {
 struct ServiceAgentModeConfig {
     /// The Service API URL endpoint
     let serviceApiURL: String
-    
+
     /// Salesforce Organization ID
     let organizationId: String
-    
+
     /// The Einstein Service Agent developer name
     let esDeveloperName: String
-    
+
+    /// Optional UI settings parsed from JS config
+    let serviceUISettings: [String: Bool]?
+
     /// Creates a ServiceAgentModeConfig from a dictionary
     /// - Parameter dict: Dictionary containing configuration values
     /// - Returns: ServiceAgentModeConfig if all required fields are present, nil otherwise
@@ -49,11 +52,12 @@ struct ServiceAgentModeConfig {
               let esDeveloperName = dict["esDeveloperName"] as? String else {
             return nil
         }
-        
+
         return ServiceAgentModeConfig(
             serviceApiURL: serviceApiURL,
             organizationId: organizationId,
-            esDeveloperName: esDeveloperName
+            esDeveloperName: esDeveloperName,
+            serviceUISettings: dict["serviceUISettings"] as? [String: Bool]
         )
     }
 }

--- a/AgentforceSDK-ReactNative-Bridge/src/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/index.ts
@@ -19,6 +19,7 @@ export type { AuthCredentials } from './services/EmployeeAgentAuth';
 
 export type {
   ServiceAgentConfig,
+  ServiceUISettings,
   EmployeeAgentConfig,
   AgentConfig,
   FeatureFlags,

--- a/AgentforceSDK-ReactNative-Bridge/src/types/AgentConfig.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/AgentConfig.ts
@@ -28,6 +28,33 @@ interface BaseAgentConfig {
 }
 
 /**
+ * UI-specific settings for Service Agent conversations.
+ *
+ * Controls visibility and behavior of conversation UI features.
+ * All fields are optional — omitted fields use SDK defaults.
+ */
+export interface ServiceUISettings {
+  /** Show the download transcript option (default: true) */
+  downloadTranscript?: boolean;
+  /** Show the end conversation option (default: true) */
+  endConversation?: boolean;
+  /** Enable validation failure chunk display (default: true, iOS only) */
+  validationFailureChunkEnabled?: boolean;
+  /** Use welcome utterances instead of a static welcome message (default: false, iOS only) */
+  useWelcomeUtterances?: boolean;
+  /** Show queue status indicator (default: false, iOS only) */
+  showQueueStatus?: boolean;
+  /** Enable video upload in conversations (default: false, iOS only) */
+  enableVideoUpload?: boolean;
+  /** Enable Lightning Type mapping for experience model types (default: false) */
+  enableLightningType?: boolean;
+  /** Enable secure forms during conversations (default: false, iOS only) */
+  secureForms?: boolean;
+  /** Enable audio upload in conversations (default: false, iOS only) */
+  enableAudioUpload?: boolean;
+}
+
+/**
  * Service Agent configuration (anonymous/guest access)
  *
  * Used for customer-facing support scenarios where no authentication is required.
@@ -40,6 +67,10 @@ interface BaseAgentConfig {
  *   serviceApiURL: 'https://service.salesforce.com',
  *   organizationId: '00Dxx0000001234',
  *   esDeveloperName: 'MyServiceAgent',
+ *   serviceUISettings: {
+ *     downloadTranscript: false,
+ *     enableLightningType: true,
+ *   },
  * };
  * ```
  */
@@ -52,6 +83,9 @@ export interface ServiceAgentConfig extends BaseAgentConfig {
 
   /** The Einstein Service Agent developer name */
   esDeveloperName: string;
+
+  /** Optional UI settings for the service agent conversation */
+  serviceUISettings?: ServiceUISettings;
 }
 
 /**

--- a/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
@@ -7,6 +7,7 @@
 // Agent configuration types
 export {
   ServiceAgentConfig,
+  ServiceUISettings,
   EmployeeAgentConfig,
   AgentConfig,
   FeatureFlags,


### PR DESCRIPTION
## Summary
- Adds `ServiceUISettings` interface to TypeScript types, allowing JS to pass UI settings when configuring a Service Agent
- iOS bridge parses the settings and passes them to `ServiceAgentConfiguration` (defaults: `showQueueStatus: true`, `secureForms: true` when omitted)
- Android bridge parses the settings and passes them via `.setServiceUISettings()` on the builder (`downloadTranscript`, `endConversation`, `enableLightningType`)
- All fields are optional — omitted fields use SDK defaults

## Test plan
- [ ] iOS: verify service agent launches with default settings (no `serviceUISettings` passed)
- [ ] iOS: verify passing `serviceUISettings: { downloadTranscript: false }` disables transcript download
- [ ] Android: verify service agent launches with default settings
- [ ] Android: verify passing `serviceUISettings: { enableLightningType: true }` enables lightning type
- [ ] Verify omitting `serviceUISettings` entirely preserves existing behavior