### PR TITLE
Fix keyboard viewport regression on employee agent builds

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
@@ -8,6 +8,7 @@ import android.app.Activity
 import android.util.Log
 import android.view.MotionEvent
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
@@ -41,6 +42,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
@@ -93,6 +95,10 @@ object AgentforceConversationOverlay {
      * require a fresh conversation. Must be called on the main thread.
      */
     fun destroy() {
+        attachedActivity?.let { activity ->
+            WindowCompat.setDecorFitsSystemWindows(activity.window, true)
+            activity.window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_UNSPECIFIED)
+        }
         overlayContainer?.let { container ->
             (container.parent as? ViewGroup)?.removeView(container)
         }
@@ -104,6 +110,10 @@ object AgentforceConversationOverlay {
 
     private fun attachToActivity(activity: ComponentActivity) {
         destroy()
+
+        WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+        @Suppress("DEPRECATION")
+        activity.window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
 
         val overlayState = isVisible
         val wrapper = object : FrameLayout(activity) {


### PR DESCRIPTION
## Summary
- The secure form fix (#84) moved the conversation UI from a dedicated Activity to an overlay on `MainActivity`, but removed the `windowSoftInputMode="adjustResize"` and `enableEdgeToEdge()` setup that made Compose's `.imePadding()` work correctly
- On employee agent builds, the Mobile SDK login flow leaves `MainActivity` in a state where the system pans the entire window up instead of reporting IME insets — causing the whole chat panel to shift when the keyboard opens
- Fix: programmatically configure the host activity window (`setDecorFitsSystemWindows(false)` + `SOFT_INPUT_ADJUST_RESIZE`) when the overlay attaches, and restore defaults on destroy

## Test plan
- [x] Employee agent: open chat, tap input — only the input area pads up, chat panel stays in place
- [x] Employee agent: close chat and reopen — secure forms do not reappear (no regression on #84)
- [x] Service agent: keyboard behavior unchanged