### PR TITLE
Clear SDK session state before auth logout

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -310,6 +310,8 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
 
   const handleLogoutEmployeeAgent = async () => {
     try {
+      await AgentforceService.closeConversation();
+      await AgentforceService.resetSettings();
       await logoutEmployeeAgent();
       setEmployeeLoggedIn(false);
       Alert.alert('Signed Out', 'You have been signed out.');


### PR DESCRIPTION
## Summary
- Fix: previous session data was not cleared on logout — the container retained stale conversation state across login cycles
- Root cause: `handleLogoutEmployeeAgent()` only cleared auth tokens via the native bridge but never called `closeConversation()` or `resetSettings()` on the Agentforce SDK
- Adds `closeConversation()` + `resetSettings()` calls before the auth logout, ensuring the native SDK fully destroys its client and clears conversation data on both iOS and Android

## Work Items
- @W-22768466 — [iOS] Previous session data not cleared on logout
- @W-22767066 — [Android] Previous session data not cleared on logout

## Test plan
- [ ] Launch the sample app, sign in as Employee Agent, start a conversation
- [ ] Tap Settings → Sign Out
- [ ] Sign back in with the same or different user
- [ ] Verify the conversation view starts fresh (no previous messages, no stale agent data)
- [ ] Repeat on both iOS simulator and Android emulator
- [ ] Verify no crash during the logout sequence