### PR TITLE
Fix copy icon and record selector for Employee Agent

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -18,6 +18,13 @@ import SalesforceNetwork
 import SalesforceSDKCore
 #endif
 
+/// Clipboard copier for the Agentforce SDK copy button.
+private struct BridgeCopier: AgentforceCopying {
+    func copyToClipboard(_ text: String) {
+        UIPasteboard.general.string = text
+    }
+}
+
 /// React Native bridge module for Agentforce SDK
 /// Supports both Service Agent (guest) and Employee Agent (authenticated) modes
 @objc(AgentforceModule)
@@ -295,6 +302,7 @@ class AgentforceModule: RCTEventEmitter {
 
         let fullConfiguration = AgentforceConfiguration(
             user: user,
+            agentforceCopier: BridgeCopier(),
             forceConfigEndpoint: config.instanceUrl,
             dataProvider: dataProvider,
             agentforceFeatureFlagSettings: featureFlagSettings,

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeDataProvider.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeDataProvider.swift
@@ -211,17 +211,19 @@ struct BridgeDataProvider: AgentforceDataProviding {
 
         // Extract fields from UI API format
         var parsedFields: [String: Any] = [:]
+        var displayFields: [AgentforceListDisplayColumn] = []
+
         if let fieldsData = json["fields"] as? [String: Any] {
             for (key, value) in fieldsData {
                 if let fieldValue = value as? [String: Any],
                    let actualValue = fieldValue["value"] {
                     parsedFields[key] = actualValue
+                    if actualValue is String, key != "Id" {
+                        displayFields.append(AgentforceListDisplayColumn(fieldApiName: key, label: key))
+                    }
                 }
             }
         }
-
-        // For now, use empty display fields - SDK may populate these internally
-        let displayFields: [AgentforceListDisplayColumn] = []
 
         return AgentforceRecordRepresentation(
             recordId: recordId,

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeDataProvider.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeDataProvider.swift
@@ -210,7 +210,7 @@ struct BridgeDataProvider: AgentforceDataProviding {
         }
 
         // Extract fields from UI API format.
-        // Use displayValue (human-readable) when present; fall back to value.
+        // fields holds raw values (IDs, API values) so SDK lookups/navigation work correctly.
         var parsedFields: [String: Any] = [:]
         var displayFields: [AgentforceListDisplayColumn] = []
 
@@ -218,9 +218,8 @@ struct BridgeDataProvider: AgentforceDataProviding {
             for key in fieldsData.keys.sorted() {
                 guard let fieldValue = fieldsData[key] as? [String: Any],
                       let actualValue = fieldValue["value"] else { continue }
-                let displayValue = fieldValue["displayValue"] as? String
-                parsedFields[key] = displayValue ?? actualValue
-                if key != "Id", displayValue != nil || !(actualValue is NSNull) {
+                parsedFields[key] = actualValue
+                if key != "Id", !(actualValue is NSNull) {
                     displayFields.append(AgentforceListDisplayColumn(fieldApiName: key, label: key))
                 }
             }

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeDataProvider.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeDataProvider.swift
@@ -209,18 +209,19 @@ struct BridgeDataProvider: AgentforceDataProviding {
             throw DataProviderError.invalidResponse
         }
 
-        // Extract fields from UI API format
+        // Extract fields from UI API format.
+        // Use displayValue (human-readable) when present; fall back to value.
         var parsedFields: [String: Any] = [:]
         var displayFields: [AgentforceListDisplayColumn] = []
 
         if let fieldsData = json["fields"] as? [String: Any] {
-            for (key, value) in fieldsData {
-                if let fieldValue = value as? [String: Any],
-                   let actualValue = fieldValue["value"] {
-                    parsedFields[key] = actualValue
-                    if actualValue is String, key != "Id" {
-                        displayFields.append(AgentforceListDisplayColumn(fieldApiName: key, label: key))
-                    }
+            for key in fieldsData.keys.sorted() {
+                guard let fieldValue = fieldsData[key] as? [String: Any],
+                      let actualValue = fieldValue["value"] else { continue }
+                let displayValue = fieldValue["displayValue"] as? String
+                parsedFields[key] = displayValue ?? actualValue
+                if key != "Id", displayValue != nil || !(actualValue is NSNull) {
+                    displayFields.append(AgentforceListDisplayColumn(fieldApiName: key, label: key))
                 }
             }
         }


### PR DESCRIPTION
## Summary
- **W-22768667** (P3): Add `BridgeCopier` (AgentforceCopying) to the Employee Agent configuration so the native SDK renders the copy button under agent responses
- **W-22768348** (P2): Populate `displayFields` in `parseRecordRepresentation` from the UI API response so the SDK can render the selected record after disambiguation submission (previously returned empty array, causing all records to re-display)

## Test plan
- [x] Launch Employee Agent conversation, get a text response from the agent — verify copy icon appears below the response
- [x] Tap copy icon — verify text is copied to clipboard (paste into Notes app)
- [x] Trigger record disambiguation (e.g., "give me Acme"), select a record, tap Submit — verify only the selected record displays after submission
- [ ] Verify Service Agent mode still works (no regression from copier being Employee-only)