### PR TITLE
Fix Android Employee Agent logout crash and toast handling

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNavigation.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNavigation.kt
@@ -6,6 +6,9 @@
  */
 package com.salesforce.android.reactagentforce
 
+import android.os.Handler
+import android.os.Looper
+import android.widget.Toast
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.core.DeviceEventManagerModule
@@ -17,6 +20,7 @@ import com.salesforce.android.mobile.interfaces.navigation.destination.ObjectHom
 import com.salesforce.android.mobile.interfaces.navigation.destination.PageReference
 import com.salesforce.android.mobile.interfaces.navigation.destination.QuickAction
 import com.salesforce.android.mobile.interfaces.navigation.destination.Record
+import org.json.JSONObject
 
 /**
  * Implements the Agentforce SDK Navigation interface and forwards navigation requests
@@ -56,6 +60,17 @@ class BridgeNavigation(private val reactContext: ReactContext) : Navigation {
     }
 
     private fun emitDestination(destination: Destination, replace: Boolean) {
+        // Handle toast PageReferences locally instead of forwarding to JS.
+        // The SDK uses navigation.goto(PageReference) with type "native__displayToast"
+        // for feedback confirmation and clipboard copy toasts.
+        if (destination is PageReference) {
+            val ref = destination.pageReference
+            if (ref != null && ref.contains("native__displayToast")) {
+                showNativeToast(ref)
+                return
+            }
+        }
+
         val params = Arguments.createMap()
 
         when (destination) {
@@ -100,5 +115,23 @@ class BridgeNavigation(private val reactContext: ReactContext) : Navigation {
         reactContext
             .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
             .emit("onNavigationRequest", params)
+    }
+
+    private fun showNativeToast(pageReferenceJson: String) {
+        try {
+            val json = JSONObject(pageReferenceJson)
+            val message = json.optString("message", "")
+            if (message.isNotEmpty()) {
+                Handler(Looper.getMainLooper()).post {
+                    Toast.makeText(
+                        reactContext.applicationContext,
+                        message,
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
+        } catch (_: Exception) {
+            // Malformed toast JSON — silently ignore
+        }
     }
 }

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/EmployeeAgentAuthBridge.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/EmployeeAgentAuthBridge.kt
@@ -17,6 +17,11 @@ import com.facebook.react.bridge.WritableNativeMap
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.rest.ClientManager
 import com.salesforce.androidsdk.rest.RestClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 class EmployeeAgentAuthBridge(reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext) {
@@ -26,6 +31,8 @@ class EmployeeAgentAuthBridge(reactContext: ReactApplicationContext) :
         // Default account type for Salesforce Mobile SDK (matches res/values/strings.xml in SDK)
         private const val DEFAULT_ACCOUNT_TYPE = "com.salesforce.androidsdk"
     }
+
+    private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
     override fun getName(): String = "EmployeeAgentAuthBridge"
 
@@ -144,12 +151,24 @@ class EmployeeAgentAuthBridge(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun logout(promise: Promise) {
-        try {
-            SalesforceSDKManager.getInstance()?.logout(currentActivity)
-            promise.resolve(null)
-        } catch (e: Exception) {
-            Log.e(TAG, "logout failed", e)
-            promise.reject("ERROR", e.message)
+        scope.launch {
+            try {
+                // Tear down Agentforce UI and client state before SDK logout to prevent
+                // ClassNotFoundException when the SDK's isDebugBuild() runs on a stale process.
+                AgentforceConversationOverlay.destroy()
+                AgentforceClientHolder.clear()
+
+                SalesforceSDKManager.getInstance()?.logout(currentActivity)
+                promise.resolve(null)
+            } catch (e: Exception) {
+                Log.e(TAG, "logout failed", e)
+                promise.reject("ERROR", e.message)
+            }
         }
+    }
+
+    override fun invalidate() {
+        super.invalidate()
+        scope.cancel()
     }
 }


### PR DESCRIPTION
## Summary
- **W-22767040 (P3)**: Fix intermittent crash/ANR during logout — destroy Agentforce conversation overlay and clear client state before SDK logout to prevent `ClassNotFoundException` when `isDebugBuild()` runs on a stale process
- **W-22764166 (P3)**: Fix navigation request panel appearing on Like/Dislike/Copy — intercept `native__displayToast` PageReferences and show Android Toast natively instead of forwarding to JS
- **W-22763623 (P3)**: Fix missing feedback confirmation message — same root cause as above; SDK sends toast via navigation which was being consumed by the JS navigation alert instead of showing to the user

## Not addressed in this PR
- **W-22762950 (P2)**: Record names showing as "Null" — root cause is in the pre-compiled SDK's `RecordField.displayValue()` rendering layer (fixed in SDK v15.61.0+ via commit 37b707c6). Cannot be fixed at the bridge level since the data is provided correctly but the SDK renders `null` displayValues as the literal string "null". Requires bumping `agentforce-sdk` dependency from 15.20.3 to 15.61.0+.

## Test plan
- [ ] Launch Employee Agent on Android, interact with agent, tap Like → native Toast appears ("Feedback submitted"), no navigation panel
- [ ] Tap Dislike → feedback modal appears, submit → native Toast appears, no navigation panel
- [ ] Tap Copy icon → content copied to clipboard, native Toast shows "Copied to clipboard", no navigation panel
- [ ] Sign out of Employee Agent → app returns to login screen without crash or ANR
- [ ] Repeat logout 5+ times to verify intermittent crash is resolved
- [ ] Verify record navigation (tap a record link) still triggers JS NavigationDelegate correctly