### PR TITLE
Support custom agentLabel in chat header (iOS + Android)

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
@@ -17,36 +17,23 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
-import com.salesforce.android.reactagentforce.models.AgentMode
 
 /**
  * Manages the Agentforce conversation UI as an overlay on the current Activity.
@@ -179,58 +166,25 @@ private fun ConversationOverlayContent(onClose: () -> Unit) {
         val client = AgentforceClientHolder.agentforceClient
         val conversation = AgentforceClientHolder.currentConversation
 
-        val title = when (AgentforceClientHolder.currentMode) {
-            is AgentMode.Employee -> AgentforceClientHolder.agentLabel ?: "Employee Agent"
-            is AgentMode.Service -> "Service Agent"
-            null -> "Agentforce"
-        }
-
         if (conversation != null && client != null) {
+            // Render the SDK container directly — no bridge-owned top bar. The SDK
+            // draws its own header (showTopBar defaults to true), and the agent label
+            // override is applied via BridgeTopAppBarBuilder wired into the SDK config
+            // in AgentforceModule.configureEmployeeAgent. Wrapping it in our own
+            // Scaffold/TopAppBar previously produced a duplicate, redundant header.
             MaterialTheme {
-                Scaffold(
-                    modifier = Modifier.fillMaxSize(),
-                    topBar = {
-                        TopAppBar(
-                            title = {
-                                Text(
-                                    title,
-                                    fontSize = 18.sp,
-                                    fontWeight = FontWeight.Bold,
-                                    color = Color.White
-                                )
-                            },
-                            navigationIcon = {
-                                IconButton(onClick = onClose) {
-                                    Icon(
-                                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                        contentDescription = "Back",
-                                        tint = Color.White
-                                    )
-                                }
-                            },
-                            colors = TopAppBarDefaults.topAppBarColors(
-                                containerColor = Color(0xFF0176D3),
-                                titleContentColor = Color.White,
-                                navigationIconContentColor = Color.White
-                            ),
-                            windowInsets = WindowInsets(top = 50.dp, bottom = 0.dp),
-                            modifier = Modifier.heightIn(max = 95.dp)
-                        )
-                    },
-                    contentWindowInsets = WindowInsets(0.dp)
-                ) { paddingValues ->
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(paddingValues)
-                            .navigationBarsPadding()
-                            .imePadding()
-                    ) {
-                        client.AgentforceConversationContainer(
-                            conversation = conversation,
-                            onClose = onClose
-                        )
-                    }
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .statusBarsPadding()
+                        .padding(top = 12.dp)
+                        .navigationBarsPadding()
+                        .imePadding()
+                ) {
+                    client.AgentforceConversationContainer(
+                        conversation = conversation,
+                        onClose = onClose
+                    )
                 }
             }
         }

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -20,6 +20,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
+import com.salesforce.android.agentforcesdk.components.models.DefaultTopAppBarBuilder
 import com.salesforce.android.agentforcesdkimpl.AgentforceClient
 import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceConfiguration
 import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceMode
@@ -312,6 +313,15 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                 // canHandle() returns false when the map is empty, matching no-provider behavior.
                 agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
                 agentforceConfigBuilder.setDelegate(bridgeUIDelegate)
+                // Override the header title with the client-supplied agentLabel when
+                // present (client wins); otherwise use the SDK default bar, which falls
+                // back to the server-provided agent label. Mirrors the iOS bridge.
+                val agentLabel = employeeConfig.agentLabel?.trim()
+                if (!agentLabel.isNullOrEmpty()) {
+                    agentforceConfigBuilder.setTopAppBarBuilder(BridgeTopAppBarBuilder(agentLabel))
+                } else {
+                    agentforceConfigBuilder.setTopAppBarBuilder(DefaultTopAppBarBuilder)
+                }
                 val agentforceConfig = agentforceConfigBuilder.build()
 
                 // Use FullConfig mode for Employee Agent

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeTopAppBarBuilder.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeTopAppBarBuilder.kt
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ */
+package com.salesforce.android.reactagentforce
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.salesforce.android.agentforcesdk.components.models.ScreenType
+import com.salesforce.android.agentforcesdk.components.models.TopAppBarBuilder
+import com.salesforce.android.agentforcesdk.components.models.TopAppBarState
+import com.salesforce.android.agentforcesdk.components.theme.LocalAgentforceTheme
+
+/**
+ * Custom [TopAppBarBuilder] that overrides the conversation header title with a
+ * client-supplied Employee Agent label.
+ *
+ * Background: the Android SDK resolves its default header title as
+ * `selectedAgent?.label ?: alternateTitle ?: default` — the server-provided agent
+ * label always wins, and there is no config field that lets a client value take
+ * precedence. The SDK's only top-bar customization hook is [TopAppBarBuilder], and
+ * it is all-or-nothing per screen: either call `defaultContent()` (server title) or
+ * render a fully custom bar. To honor "client label wins" while keeping the SDK's
+ * default look and controls, this builder renders a bar from [TopAppBarState] that
+ * is visually equivalent to the SDK default ([AgentforceTitleRow]) but titled with
+ * the client label.
+ *
+ * Mirrors the iOS bridge's `BridgeNavigationBarBuilder`.
+ *
+ * Behavior:
+ * - CHAT_FEED with a non-empty [agentLabel] -> custom bar titled with the label.
+ * - Otherwise -> `defaultContent()` so the SDK falls back to the server label.
+ *
+ * Note: this is only installed when a non-empty label is supplied (see
+ * [AgentforceModule.configureEmployeeAgent]); with no label the SDK's
+ * `DefaultTopAppBarBuilder` is used instead.
+ */
+class BridgeTopAppBarBuilder(private val agentLabel: String) : TopAppBarBuilder {
+
+    @Composable
+    override fun TopAppBar(state: TopAppBarState, defaultContent: @Composable () -> Unit) {
+        if (state.screenType == ScreenType.CHAT_FEED && agentLabel.isNotBlank()) {
+            ClientLabelTopBar(label = agentLabel, state = state)
+        } else {
+            // Forms, onboarding, loading, error — keep SDK defaults.
+            defaultContent()
+        }
+    }
+}
+
+/**
+ * Renders a top bar matching the SDK's default chat header (close icon, centered
+ * title with optional agent selector, overflow menu), but using the client label as
+ * the title. Built entirely from public component models + theme so it stays
+ * decoupled from SDK internals.
+ */
+@Composable
+private fun ClientLabelTopBar(label: String, state: TopAppBarState) {
+    val colors = LocalAgentforceTheme.current.colors()
+    val typography = LocalAgentforceTheme.current.typography()
+
+    var showAgentMenu by remember { mutableStateOf(false) }
+    var showActionMenu by remember { mutableStateOf(false) }
+
+    val showAgentSelector = state.agents.size > 1
+
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 56.dp)
+                .background(colors.chatHeaderBackground)
+                .padding(horizontal = 16.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            // Close button (matches SDK default; bridge previously used a back arrow).
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = "Close",
+                tint = colors.onSurface3,
+                modifier = Modifier
+                    .size(20.dp)
+                    .clickable(
+                        onClick = state.onClose,
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null
+                    )
+            )
+
+            // Title + optional agent selector.
+            Box(modifier = Modifier.weight(1f, fill = false)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .then(
+                            if (showAgentSelector) {
+                                Modifier.clickable(
+                                    onClick = { showAgentMenu = true },
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null
+                                )
+                            } else {
+                                Modifier
+                            }
+                        )
+                        .semantics(mergeDescendants = true) { heading() }
+                ) {
+                    Text(
+                        text = label,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        style = typography.titlesFontScale3Regular.copy(color = colors.onSurface1),
+                        modifier = Modifier.weight(1f, fill = false)
+                    )
+                    if (showAgentSelector) {
+                        Icon(
+                            imageVector = Icons.Filled.KeyboardArrowDown,
+                            contentDescription = "Select agent",
+                            tint = colors.onSurface3,
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+                }
+
+                DropdownMenu(
+                    expanded = showAgentMenu,
+                    onDismissRequest = { showAgentMenu = false }
+                ) {
+                    state.agents.forEach { agent ->
+                        DropdownMenuItem(
+                            onClick = {
+                                state.onAgentSelect(agent.id)
+                                showAgentMenu = false
+                            },
+                            leadingIcon = if (agent.id == state.selectedAgentId) {
+                                {
+                                    Icon(
+                                        imageVector = Icons.Filled.Check,
+                                        contentDescription = null,
+                                        tint = colors.accent1,
+                                        modifier = Modifier.size(16.dp)
+                                    )
+                                }
+                            } else {
+                                null
+                            },
+                            text = {
+                                Text(
+                                    text = agent.displayName,
+                                    style = typography.bodyFontScale1Regular.copy(color = colors.onSurface1)
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+
+            // Overflow / more-menu — delegates to the SDK's own bottom sheet.
+            Box {
+                IconButton(
+                    onClick = {
+                        // Surface server-provided dynamic options inline; otherwise open
+                        // the SDK more menu directly.
+                        if (state.dynamicMenuOptions.isNotEmpty()) {
+                            showActionMenu = true
+                        } else {
+                            state.onShowMoreMenu()
+                        }
+                    },
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.MoreVert,
+                        contentDescription = "More options",
+                        tint = colors.onSurface3,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+
+                DropdownMenu(
+                    expanded = showActionMenu,
+                    onDismissRequest = { showActionMenu = false }
+                ) {
+                    state.dynamicMenuOptions.forEach { option ->
+                        DropdownMenuItem(
+                            onClick = {
+                                showActionMenu = false
+                                state.onDynamicMenuOptionClick(option)
+                            },
+                            text = {
+                                Text(
+                                    text = option.title,
+                                    style = typography.bodyFontScale1Regular.copy(color = colors.onSurface1)
+                                )
+                            }
+                        )
+                    }
+                    if (state.dynamicMenuOptions.isNotEmpty()) {
+                        HorizontalDivider(color = colors.border1)
+                    }
+                    DropdownMenuItem(
+                        onClick = {
+                            showActionMenu = false
+                            state.onShowMoreMenu()
+                        },
+                        text = {
+                            Text(
+                                text = "More Options",
+                                style = typography.bodyFontScale1Regular.copy(color = colors.onSurface1)
+                            )
+                        }
+                    )
+                }
+            }
+        }
+
+        HorizontalDivider(color = colors.border1)
+    }
+}

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -44,6 +44,12 @@ class AgentforceModule: RCTEventEmitter {
     /// Current mode configuration
     private var currentMode: AgentMode?
 
+    /// Navigation bar builder used to override the conversation header title with a
+    /// client-supplied Employee Agent label. Strongly retained here because
+    /// `NavigationBarManager` holds it as a weak reference. `nil` when no label is
+    /// supplied, so the SDK falls back to the server-provided agent label.
+    private var navigationBarBuilder: BridgeNavigationBarBuilder?
+
 
     private let listenerLock = NSLock()
     private var _hasListeners = false
@@ -173,6 +179,10 @@ class AgentforceModule: RCTEventEmitter {
         credentialProvider.configure(serviceAgent: config)
         currentMode = .service(config: config)
 
+        // Service Agent has no client-supplied label override; clear any builder
+        // left over from a prior Employee Agent session.
+        navigationBarBuilder = nil
+
         // Persist trimmed values to UserDefaults for cross-session recall
         let trimmedSiteUrl = config.serviceApiURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedOrgId = config.organizationId.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -258,6 +268,15 @@ class AgentforceModule: RCTEventEmitter {
         // UnifiedCredentialProvider will fetch fresh tokens from Mobile SDK automatically
         credentialProvider.configure(employeeAgent: config)
         currentMode = .employee(config: config)
+
+        // Install a navigation bar builder to override the header title when the
+        // client supplies a non-empty agentLabel. When absent, leave it nil so the
+        // SDK falls back to the server-provided agent label / default.
+        if let label = config.agentLabel?.trimmingCharacters(in: .whitespacesAndNewlines), !label.isEmpty {
+            navigationBarBuilder = BridgeNavigationBarBuilder(agentLabel: label)
+        } else {
+            navigationBarBuilder = nil
+        }
 
         // Persist employee agentId (editable in Settings tab)
         UserDefaults.standard.set(config.agentId ?? "", forKey: "EmployeeAgentId")
@@ -418,7 +437,8 @@ class AgentforceModule: RCTEventEmitter {
                         Task { @MainActor in
                             self?.dismissConversation()
                         }
-                    }
+                    },
+                    navigationBarBuilder: navigationBarBuilder
                 )
 
                 presentConversationView(chatView)
@@ -458,7 +478,8 @@ class AgentforceModule: RCTEventEmitter {
                         Task { @MainActor in
                             self?.dismissConversation()
                         }
-                    }
+                    },
+                    navigationBarBuilder: navigationBarBuilder
                 )
 
                 presentConversationView(chatView)

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeNavigationBarBuilder.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeNavigationBarBuilder.swift
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
+ *
+ * React Native bridge navigation bar builder for Agentforce SDK
+ */
+
+import Foundation
+import AgentforceSDK
+
+/// Navigation bar builder that overrides the conversation header title with a
+/// client-supplied agent label.
+///
+/// The Employee Agent `agentLabel` from the JS config has no first-class field on
+/// `AgentforceConfiguration`, and `createAgentforceChatView` exposes no title
+/// parameter. The only public hook for the header title is `NavigationBarBuilder`,
+/// which lets the host set `toolbarItems.title` per screen.
+///
+/// Behavior: when a non-empty label is provided, it is applied to the main
+/// conversation screen's title (client wins). When the label is empty/nil, no
+/// builder is installed at all (see `AgentforceModule`), so the SDK falls back to
+/// the server-provided agent label / default. `showDefaults` is left at its
+/// default (`true`) so the close button and overflow menu are preserved.
+final class BridgeNavigationBarBuilder: NavigationBarBuilder {
+
+    var handleNavigation: HandleNavigationClosure?
+    weak var refreshHandler: NavigationRefreshable?
+
+    /// - Parameter agentLabel: Non-empty client-supplied label to display as the
+    ///   conversation header title.
+    init(agentLabel: String) {
+        handleNavigation = { screenType, toolbarItems, _ in
+            // Only override the main conversation feed title. Form / pre-chat /
+            // onboarding screens keep their own SDK-provided titles.
+            if screenType == .conversation {
+                toolbarItems.title = agentLabel
+            }
+        }
+    }
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -229,11 +229,12 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
             organizationId: creds.organizationId,
             userId: creds.userId,
             agentId: agentId, // undefined triggers multi-agent mode
-            agentLabel: '', // TEMP: hardcoded to test agentLabel override
+            agentLabel: '', // optional: set a custom name to display in the chat header (overrides the server agent label)
             accessToken: creds.accessToken,
             featureFlags,
           }
-        : { ...EMPLOYEE_AGENT_CONFIG, agentId: agentId, agentLabel: '', featureFlags };
+        : // optional: set agentLabel to a custom name to display in the chat header (overrides the server agent label)
+          { ...EMPLOYEE_AGENT_CONFIG, agentId: agentId, agentLabel: '', featureFlags };
       await AgentforceService.configure(config);
 
       await AgentforceService.launchConversation();

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -229,10 +229,11 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
             organizationId: creds.organizationId,
             userId: creds.userId,
             agentId: agentId, // undefined triggers multi-agent mode
+            agentLabel: '', // TEMP: hardcoded to test agentLabel override
             accessToken: creds.accessToken,
             featureFlags,
           }
-        : { ...EMPLOYEE_AGENT_CONFIG, agentId: agentId, featureFlags };
+        : { ...EMPLOYEE_AGENT_CONFIG, agentId: agentId, agentLabel: '', featureFlags };
       await AgentforceService.configure(config);
 
       await AgentforceService.launchConversation();


### PR DESCRIPTION
## Summary

Lets RN SDK customers set a custom agent name in the chat header for Employee Agent via `agentLabel`. The client-supplied label overrides the header title when provided; otherwise the SDK falls back to the server-provided agent label.

## Changes

**iOS** (previously committed on this branch)
- `BridgeNavigationBarBuilder` sets the header title to `agentLabel` via the SDK's `NavigationBarBuilder` hook, wired into `configureEmployeeAgent`.

**Android**
- New `BridgeTopAppBarBuilder` (the SDK's `TopAppBarBuilder` hook) renders an SDK-default-styled header titled with `agentLabel`; falls back to `DefaultTopAppBarBuilder` (server label) when no label is supplied. Wired into `configureEmployeeAgent`.
- Removed the bridge's own `Scaffold`/`TopAppBar` wrapper in `AgentforceConversationOverlay`, which produced a duplicate header stacked on top of the SDK's own bar. The SDK container now renders directly, inset below the system bars.

**Shared**
- `HomeScreen.tsx`: documented the optional `agentLabel` config field for the employee agent.

## Behavior contract
- Non-empty `agentLabel` → shown as the header title (client wins).
- Empty/absent → server-provided agent label / SDK default.

## Known limitation (multi-agent)
In multi-agent mode the header doubles as an agent selector. On Android the custom title is rendered with a re-created selector; on iOS the SDK's `NavigationBarBuilder` makes title and selector mutually exclusive (no public API to expose the agent list / switch callback), so a custom label hides the selector. Recommend treating `agentLabel` as a single-agent feature for now, or following up with an iOS SDK change to reach full parity.

## Testing
- iOS: verified on simulator — header shows the custom label.
- Android: verified on emulator — single header showing the custom label; bridge module compiles against AgentforceSDK 15.20.3.