### PR TITLE
Fix Android employee-agent bootstrap 404 (set network + user, pass headers into RestRequest)

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -38,6 +38,8 @@ import com.salesforce.android.reactagentforce.providers.BridgeViewProvider
 import com.salesforce.android.reactagentforce.providers.UnifiedCredentialProvider
 import com.salesforce.android.agentforcesdkimpl.data.AgentforceDataProviderImpl
 import com.salesforce.android.agentforcesdkimpl.network.AgentforceNetworkImpl
+import com.salesforce.android.mobile.interfaces.user.Org
+import com.salesforce.android.mobile.interfaces.user.User
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -306,7 +308,25 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setCameraUriProvider(cameraUriProvider)
                     .setLogger(bridgeLogger)
                     .setNavigation(bridgeNavigation)
+                    // Route bootstrap (BotsAPI connect calls) through the authenticated
+                    // RestClient-backed network, matching the iOS bridge (which passes
+                    // salesforceNetwork). Without this, the SDK falls back to a default
+                    // AgentforceNetworkImpl() with no salesforceDomain, so the bootstrap
+                    // connect call 404s and the client never gets connectionInfo.
+                    .setNetwork(network)
                     .setDataProvider(dataProvider)
+                    // Set the User/Org so the SDK knows the orgId. The SDK derives the
+                    // runtime connection info from user.org.id when the internal-core
+                    // discovery endpoints are unavailable (the external-app case), via
+                    // AgentforceConnectionInfo(orgId=...). The iOS bridge sets this too;
+                    // without it, orgId is null and that fallback can't resolve a host.
+                    .setUser(
+                        User(
+                            org = Org(id = employeeConfig.organizationId, community = null),
+                            userName = employeeConfig.userId,
+                            displayName = employeeConfig.userId
+                        )
+                    )
                 agentforceConfigBuilder.setPermission(permissions)
                 agentforceConfigBuilder.setAgentforceVoiceModule(AgentforceVoiceProviderFactory(), AgentforceVoiceUIProvider())
                 // Always attach bridgeViewProvider so late registrations take effect.

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNetwork.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNetwork.kt
@@ -65,9 +65,12 @@ class BridgeNetwork(private val restClient: RestClient) : Network {
         // Append query params to the path as a query string.
         // RestRequest(RestMethod, String, Map) treats the Map as additionalHttpHeaders,
         // NOT query parameters, so we must encode them into the URL path ourselves.
-        val fullPath = if (queryParams.isNotEmpty()) {
+        // queryParams is a platform type and may be null on some requests (e.g. the
+        // session-create/send path), so guard against null — matching AgentforceNetworkImpl.
+        val safeQueryParams = queryParams ?: emptyMap()
+        val fullPath = if (safeQueryParams.isNotEmpty()) {
             val separator = if (path.contains("?")) "&" else "?"
-            val queryString = queryParams.entries.joinToString("&") { (k, v) ->
+            val queryString = safeQueryParams.entries.joinToString("&") { (k, v) ->
                 "${java.net.URLEncoder.encode(k, "UTF-8")}=${java.net.URLEncoder.encode(v.toString(), "UTF-8")}"
             }
             "$path$separator$queryString"
@@ -75,18 +78,21 @@ class BridgeNetwork(private val restClient: RestClient) : Network {
             path
         }
 
+        // Custom headers must be passed into the RestRequest constructor: RestRequest's
+        // additionalHttpHeaders field is `private final` and is left null by the
+        // method/path and method/path/body constructors, so mutating it post-construction
+        // throws NPE ("getAdditionalHttpHeaders(...) must not be null"). Pass the map in
+        // instead. additionalHttpHeaders is a platform type that may be null (e.g. the
+        // session-create/send path), so coerce to an empty map.
+        val headers = additionalHttpHeaders ?: emptyMap()
+
         // Create RestRequest - use body constructor if body exists, else path-only constructor
         val restRequest = if (body != null && body!!.isNotEmpty()) {
             val mediaType = contentType?.toMediaType()
             val requestBody = body!!.toRequestBody(mediaType)
-            RestRequest(restMethod, fullPath, requestBody)
+            RestRequest(restMethod, fullPath, requestBody, headers)
         } else {
-            RestRequest(restMethod, fullPath)
-        }
-
-        // Add custom headers
-        additionalHttpHeaders.forEach { (key, value) ->
-            restRequest.additionalHttpHeaders[key] = value
+            RestRequest(restMethod, fullPath, headers)
         }
 
         return restRequest


### PR DESCRIPTION
## Problem
Android employee-agent conversations failed to initialize on external (OAuth connected-app) integrations: bootstrap returned 404 / `BotsAPIError$NoData` ("No data returned from core service"), while iOS worked on the same org via the same bridge.

## Root cause
The SDK's `connect/agentforce-agent-info` and `connect/conversation-runtime-proxy` discovery endpoints are internal-core only and 404 for external apps **by design** — the app is expected to let the SDK derive runtime connection info from the orgId. The Android bridge was missing wiring the iOS bridge already had:

1. **No `User`/`Org` on the config** → the SDK's `orgId` (`config.user.org.id`) was null, so its `AgentforceConnectionInfo(orgId=...)` fallback couldn't resolve a host.
2. **No `setNetwork(...)`** → bootstrap ran on a default `AgentforceNetworkImpl()` with no host instead of the authenticated `RestClient`-backed `BridgeNetwork`.

## Changes (`AgentforceSDK-ReactNative-Bridge/android`)
- `AgentforceModule.kt`: add `.setUser(User(Org(id = organizationId, …)))` and `.setNetwork(network)` on the employee-agent config (mirrors the iOS bridge).
- `BridgeNetwork.kt`: pass `additionalHttpHeaders` into the `RestRequest` constructor instead of mutating the `private final` map post-construction (which threw `getAdditionalHttpHeaders(...) must not be null` once authenticated traffic flowed through it); null-guard `queryParams`/`additionalHttpHeaders`.

## Testing
Verified end-to-end on the sample employee-agent app against a sandbox org: bootstrap now succeeds and conversations initialize where they previously 404'd. iOS unaffected.