### PR TITLE
Fix Android Employee Agent re-initialization (dismiss + re-launch) 404

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
@@ -158,23 +158,10 @@ private fun ConversationOverlayContent(onClose: () -> Unit) {
 
     if (conversation == null || client == null) return
 
-    // IMPORTANT: do NOT wrap the SDK container in AnimatedVisibility (or any other
-    // composable that removes it from the composition when hidden). The SDK's
-    // AgentforceConversationContainer runs bootstrap in a one-shot LaunchedEffect(Unit);
-    // disposing it on hide and recomposing it on the next show re-fires that bootstrap.
-    // For external OAuth apps the discovery endpoints (connect/agentforce-agent-info,
-    // conversation-runtime-proxy) 404 by design, so isGlobalBootstrapComplete never flips
-    // true and every re-show re-bootstraps. On a fresh conversation the SDK recovers from
-    // that 404 (forcedBootstrap -> INITIALIZE -> session create), but on a REUSED
-    // conversation that already has a session the re-fired bootstrap can't recover and the
-    // chat is stuck on "Network error: 404". iOS never re-bootstraps on re-launch (its
-    // container goes straight to containerState=ready) because the conversation stays alive.
-    // We mirror that by keeping the container permanently composed and animating visibility
-    // via a vertical translation only (it slides off-screen when hidden, never leaves the
-    // composition), so the SDK's ViewModel and bootstrap state survive hide/show exactly like
-    // iOS. Touches while hidden are already gated by the wrapper's dispatchTouchEvent, and
-    // destroy() (agentId change / mode switch) still tears the whole container down for the
-    // fresh-conversation path. See [[project_rn_android_bootstrap_fix]].
+    // Keep the container permanently composed and animate visibility via translationY only.
+    // AnimatedVisibility would remove it from the composition on hide and re-run the SDK's
+    // one-shot bootstrap on the next show, which 404s on a reused conversation. See
+    // [[project_rn_android_bootstrap_fix]].
     if (visible) {
         BackHandler { onClose() }
     }

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
@@ -12,10 +12,8 @@ import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
@@ -26,8 +24,13 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
@@ -150,43 +153,60 @@ object AgentforceConversationOverlay {
 private fun ConversationOverlayContent(onClose: () -> Unit) {
     val visible by AgentforceConversationOverlay.isVisible
 
-    AnimatedVisibility(
-        visible = visible,
-        enter = slideInVertically(
-            initialOffsetY = { fullHeight -> fullHeight },
-            animationSpec = tween(durationMillis = 250)
-        ),
-        exit = slideOutVertically(
-            targetOffsetY = { fullHeight -> fullHeight },
-            animationSpec = tween(durationMillis = 250)
-        )
-    ) {
+    val client = AgentforceClientHolder.agentforceClient
+    val conversation = AgentforceClientHolder.currentConversation
+
+    if (conversation == null || client == null) return
+
+    // IMPORTANT: do NOT wrap the SDK container in AnimatedVisibility (or any other
+    // composable that removes it from the composition when hidden). The SDK's
+    // AgentforceConversationContainer runs bootstrap in a one-shot LaunchedEffect(Unit);
+    // disposing it on hide and recomposing it on the next show re-fires that bootstrap.
+    // For external OAuth apps the discovery endpoints (connect/agentforce-agent-info,
+    // conversation-runtime-proxy) 404 by design, so isGlobalBootstrapComplete never flips
+    // true and every re-show re-bootstraps. On a fresh conversation the SDK recovers from
+    // that 404 (forcedBootstrap -> INITIALIZE -> session create), but on a REUSED
+    // conversation that already has a session the re-fired bootstrap can't recover and the
+    // chat is stuck on "Network error: 404". iOS never re-bootstraps on re-launch (its
+    // container goes straight to containerState=ready) because the conversation stays alive.
+    // We mirror that by keeping the container permanently composed and animating visibility
+    // via a vertical translation only (it slides off-screen when hidden, never leaves the
+    // composition), so the SDK's ViewModel and bootstrap state survive hide/show exactly like
+    // iOS. Touches while hidden are already gated by the wrapper's dispatchTouchEvent, and
+    // destroy() (agentId change / mode switch) still tears the whole container down for the
+    // fresh-conversation path. See [[project_rn_android_bootstrap_fix]].
+    if (visible) {
         BackHandler { onClose() }
+    }
 
-        val client = AgentforceClientHolder.agentforceClient
-        val conversation = AgentforceClientHolder.currentConversation
+    var heightPx by remember { mutableIntStateOf(0) }
+    // Slide fully off-screen (downward) when hidden; rest at 0 (fully shown) when visible.
+    val translationY by animateFloatAsState(
+        targetValue = if (visible) 0f else heightPx.toFloat(),
+        animationSpec = tween(durationMillis = 250),
+        label = "overlaySlide"
+    )
 
-        if (conversation != null && client != null) {
-            // Render the SDK container directly — no bridge-owned top bar. The SDK
-            // draws its own header (showTopBar defaults to true), and the agent label
-            // override is applied via BridgeTopAppBarBuilder wired into the SDK config
-            // in AgentforceModule.configureEmployeeAgent. Wrapping it in our own
-            // Scaffold/TopAppBar previously produced a duplicate, redundant header.
-            MaterialTheme {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .statusBarsPadding()
-                        .padding(top = 12.dp)
-                        .navigationBarsPadding()
-                        .imePadding()
-                ) {
-                    client.AgentforceConversationContainer(
-                        conversation = conversation,
-                        onClose = onClose
-                    )
-                }
-            }
+    // Render the SDK container directly — no bridge-owned top bar. The SDK
+    // draws its own header (showTopBar defaults to true), and the agent label
+    // override is applied via BridgeTopAppBarBuilder wired into the SDK config
+    // in AgentforceModule.configureEmployeeAgent. Wrapping it in our own
+    // Scaffold/TopAppBar previously produced a duplicate, redundant header.
+    MaterialTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .onSizeChanged { heightPx = it.height }
+                .graphicsLayer { this.translationY = translationY }
+                .statusBarsPadding()
+                .padding(top = 12.dp)
+                .navigationBarsPadding()
+                .imePadding()
+        ) {
+            client.AgentforceConversationContainer(
+                conversation = conversation,
+                onClose = onClose
+            )
         }
     }
 }

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -254,9 +254,25 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
 
         Log.d(TAG, "Configuring Employee Agent - Org: ${employeeConfig.organizationId}, User: ${employeeConfig.userId}")
 
-        // Check if agentId changed - only clear if it did
+        // Decide whether we need to build a fresh AgentforceClient, mirroring the iOS bridge
+        // (configureEmployeeAgent -> needsNewClient). A new client is required only when we are
+        // switching from Service mode, when the agentId changed, or when no client exists yet.
+        //
+        // This guard is what makes agent dismiss + re-launch (same agentId) work. The internal-core
+        // discovery endpoints (connect/agentforce-agent-info etc.) 404 for external OAuth apps by
+        // design; the SDK only recovers from that 404 (forcedBootstrap -> INITIALIZE -> session
+        // create) for a conversation that lives on the SAME client that bootstrapped it. If we
+        // always rebuilt the client (the old Android behavior) while preserving the previous
+        // conversation, the new client's ConversationProvider would start with an empty map and the
+        // preserved conversation would be orphaned on the OLD client — launchConversation() then
+        // skips createConversation() (currentConversation != null), no fresh conversation is
+        // registered on the new client, and re-launch dies on "Network error: 404". Reusing the
+        // existing client keeps the conversation (and its history) paired with its bootstrapping
+        // client, exactly like iOS. See [[project_rn_android_bootstrap_fix]].
         val currentEmployeeMode = currentMode as? LocalAgentMode.Employee
+        val switchingModes = AgentforceClientHolder.isServiceAgent
         val agentIdChanged = currentEmployeeMode?.config?.agentId != employeeConfig.agentId
+        val needsNewClient = switchingModes || agentIdChanged || AgentforceClientHolder.agentforceClient == null
 
         // Configure unified credential provider for Employee Agent mode
         // UnifiedCredentialProvider will fetch fresh tokens from Mobile SDK automatically
@@ -266,17 +282,24 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         // Persist employee agentId (editable in Settings tab)
         employeePrefs.edit().putString(KEY_EMPLOYEE_AGENT_ID, employeeConfig.agentId ?: "").apply()
 
-        val shouldClear = AgentforceClientHolder.isServiceAgent || agentIdChanged
-
         scope.launch(Dispatchers.Main) {
-            // Destroy overlay and clear on main thread to avoid Compose observer errors
-            if (shouldClear) {
-                Log.d(TAG, "AgentId changed or switching modes - clearing client and conversation")
-                AgentforceConversationOverlay.destroy()
-                AgentforceClientHolder.clear()
-            } else {
-                Log.d(TAG, "AgentId unchanged - preserving conversation")
+            if (!needsNewClient) {
+                // Reuse the existing client and its conversation (credentials refresh automatically
+                // via UnifiedCredentialProvider). Preserves conversation history across re-launch.
+                Log.d(TAG, "AgentId unchanged - reusing existing client and conversation")
+                AgentforceClientHolder.setMode(LocalAgentMode.Employee(employeeConfig))
+                promise.resolve(Arguments.createMap().apply {
+                    putBoolean("success", true)
+                    putString("mode", "employee")
+                })
+                return@launch
             }
+
+            // Tear down the previous overlay/client/conversation before building a fresh one, so
+            // launchConversation() recreates a conversation paired with the new client.
+            Log.d(TAG, "Switching modes or agentId changed - clearing client and conversation")
+            AgentforceConversationOverlay.destroy()
+            AgentforceClientHolder.clear()
             try {
                 // Create AgentforceConfiguration for FullConfig mode
                 val flags = getFeatureFlagsFromConfigOrPrefs(config)

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -254,21 +254,10 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
 
         Log.d(TAG, "Configuring Employee Agent - Org: ${employeeConfig.organizationId}, User: ${employeeConfig.userId}")
 
-        // Decide whether we need to build a fresh AgentforceClient, mirroring the iOS bridge
-        // (configureEmployeeAgent -> needsNewClient). A new client is required only when we are
-        // switching from Service mode, when the agentId changed, or when no client exists yet.
-        //
-        // This guard is what makes agent dismiss + re-launch (same agentId) work. The internal-core
-        // discovery endpoints (connect/agentforce-agent-info etc.) 404 for external OAuth apps by
-        // design; the SDK only recovers from that 404 (forcedBootstrap -> INITIALIZE -> session
-        // create) for a conversation that lives on the SAME client that bootstrapped it. If we
-        // always rebuilt the client (the old Android behavior) while preserving the previous
-        // conversation, the new client's ConversationProvider would start with an empty map and the
-        // preserved conversation would be orphaned on the OLD client — launchConversation() then
-        // skips createConversation() (currentConversation != null), no fresh conversation is
-        // registered on the new client, and re-launch dies on "Network error: 404". Reusing the
-        // existing client keeps the conversation (and its history) paired with its bootstrapping
-        // client, exactly like iOS. See [[project_rn_android_bootstrap_fix]].
+        // Rebuild the client only when switching from Service mode, the agentId changed, or no
+        // client exists yet (mirrors iOS's needsNewClient). Otherwise reuse it: rebuilding while
+        // preserving the conversation orphans that conversation on the old client and breaks
+        // re-launch with a 404. See [[project_rn_android_bootstrap_fix]].
         val currentEmployeeMode = currentMode as? LocalAgentMode.Employee
         val switchingModes = AgentforceClientHolder.isServiceAgent
         val agentIdChanged = currentEmployeeMode?.config?.agentId != employeeConfig.agentId


### PR DESCRIPTION
## Problem

On Android (React Native), an Employee Agent conversation initializes fine on first launch, but **re-initialization** (dismiss the agent UI, then re-launch with the same `agentId`) fails with `Network error: 404` — the chat never reaches a ready state. iOS works correctly on the same org with the same RN bridge.

## Root cause

Two issues combined; both had to be fixed:

1. **Android always rebuilt the `AgentforceClient` on every `configure()`.** When the `agentId` was unchanged the conversation was preserved, but it stayed bound to the *old* client's `ConversationProvider` while a fresh (empty) client took its place. iOS instead reuses the existing client+conversation when nothing material changed (`needsNewClient`).

2. **The overlay wrapped the SDK container in `AnimatedVisibility`.** That removes `AgentforceConversationContainer` from the composition on hide and recomposes it on the next show. The SDK runs bootstrap in a one-shot `LaunchedEffect(Unit)`, so every re-show re-fired bootstrap. For external OAuth apps the discovery endpoints (`connect/agentforce-agent-info`, `conversation-runtime-proxy`) 404 by design, so `isGlobalBootstrapComplete` never flips true. On a *fresh* conversation the SDK recovers from that 404 (forcedBootstrap → INITIALIZE → session create), but on a *reused* conversation that already has a session the re-fired bootstrap cannot recover → stuck on 404.

Captured iOS re-launch logs confirmed the target behavior: iOS makes **zero network calls** on re-launch (`containerState` goes straight to `ready`) because the conversation stays alive and is never re-bootstrapped.

## Fix

- **`AgentforceModule.kt`** — mirror iOS's `needsNewClient = switchingModes || agentIdChanged || client == null`; when false, reuse the existing client and conversation instead of rebuilding (preserves conversation history across re-launch).
- **`AgentforceConversationOverlay.kt`** — keep the SDK container permanently composed; animate show/hide via a vertical `graphicsLayer { translationY }` translation only, so the container never leaves the composition and the SDK's ViewModel + bootstrap state survive hide/show — matching iOS.

Together these make Android re-launch behave like iOS: conversation preserved, no re-bootstrap, no 404.

## Testing

- Verified on the customer's org (Syngenta UAT sandbox): first launch + dismiss/re-launch with the same agent now both succeed, with no `agent-info` 404 on re-launch.
- `:react-native-agentforce:compileDebugKotlin` builds clean.

## Notes

- Builds on the earlier fix (`setNetwork`/`setUser`/header-constructor, already merged to `dev`).
- Known edge: if the host Activity *instance* changes between dismiss and re-launch, `show()` re-attaches a fresh `ComposeView` and would re-bootstrap. The normal dismiss/relaunch cycle on a stable Activity is covered; cross-activity relaunch would be a separate follow-up.