### PR TITLE
Add unit-test coverage across the bridge (JS, Android, iOS) + CI

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -188,11 +188,22 @@ jobs:
 
       - name: Run bridge unit tests
         run: |
+          # Pick an available iPhone simulator by UDID. The `test` action requires a
+          # concrete device (generic/by-name destinations are brittle across runner
+          # image updates — model availability changes), so discover one at runtime.
+          DEVICE_ID=$(xcrun simctl list devices available --json \
+            | python3 -c "import json,sys; d=json.load(sys.stdin)['devices']; ids=[dev['udid'] for rt in sorted(d) for dev in d[rt] if dev.get('isAvailable') and dev['name'].startswith('iPhone')]; print(ids[-1] if ids else '')")
+          if [ -z "$DEVICE_ID" ]; then
+            echo "::error::No available iPhone simulator found on the runner"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "Using simulator UDID: $DEVICE_ID"
           xcodebuild test \
             -workspace ios/ReactAgentforce.xcworkspace \
             -scheme BridgeUnitTests \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16'
+            -destination "platform=iOS Simulator,id=$DEVICE_ID"
 
   # Job 4: Build validation matrix (parallel builds)
   build-validation:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -77,7 +77,124 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  # Job 3: Build validation matrix (parallel builds)
+  # Job 3a: Android native unit tests (bridge library module, JVM — no emulator)
+  android-unit-tests:
+    name: Android Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: lint-and-typecheck
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install Boost
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-all-dev
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            android/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps --ignore-scripts
+
+      - name: Generate app config
+        run: node scripts/generate-app-config.js employee
+
+      - name: Run Android setup
+        run: node installandroid.js employee
+
+      - name: Run bridge unit tests
+        run: cd android && ./gradlew :react-native-agentforce:testDebugUnitTest --console=plain
+
+      - name: Upload test report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-unit-test-report
+          path: AgentforceSDK-ReactNative-Bridge/android/build/reports/tests/**
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # Job 3b: iOS native unit tests (bridge AgentMode logic — standalone XCTest bundle)
+  ios-unit-tests:
+    name: iOS Unit Tests
+    runs-on: macos-26
+    timeout-minutes: 30
+    needs: lint-and-typecheck
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: false
+
+      - name: Install CocoaPods
+        run: gem install cocoapods -v 1.15.2
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Install Boost
+        run: brew install boost
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.*.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps --ignore-scripts
+
+      - name: Generate app config
+        run: node scripts/generate-app-config.js employee
+
+      - name: Run iOS setup (xcodegen + pod install)
+        run: node installios.js employee
+
+      - name: Run bridge unit tests
+        run: |
+          xcodebuild test \
+            -workspace ios/ReactAgentforce.xcworkspace \
+            -scheme BridgeUnitTests \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16'
+
+  # Job 4: Build validation matrix (parallel builds)
   build-validation:
     name: Build ${{ matrix.platform }} - ${{ matrix.variant }}
     runs-on: ${{ matrix.os }}
@@ -230,7 +347,7 @@ jobs:
   all-checks-passed:
     name: All Checks Passed ✓
     runs-on: ubuntu-latest
-    needs: [lint-and-typecheck, unit-tests, build-validation]
+    needs: [lint-and-typecheck, unit-tests, android-unit-tests, ios-unit-tests, build-validation]
     if: always()
 
     steps:
@@ -238,6 +355,8 @@ jobs:
         run: |
           if [[ "${{ needs.lint-and-typecheck.result }}" != "success" ]] || \
              [[ "${{ needs.unit-tests.result }}" != "success" ]] || \
+             [[ "${{ needs.android-unit-tests.result }}" != "success" ]] || \
+             [[ "${{ needs.ios-unit-tests.result }}" != "success" ]] || \
              [[ "${{ needs.build-validation.result }}" != "success" ]]; then
             echo "❌ One or more checks failed"
             exit 1

--- a/AgentforceSDK-ReactNative-Bridge/android/build.gradle
+++ b/AgentforceSDK-ReactNative-Bridge/android/build.gradle
@@ -35,6 +35,12 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+
+    testOptions {
+        // Let JVM unit tests run without an emulator: android.* stubs (e.g. android.util.Log
+        // used by BridgeDiagnostics) return default values instead of throwing "not mocked".
+        unitTests.returnDefaultValues = true
+    }
 }
 
 repositories {
@@ -66,4 +72,13 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:2.2.0"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0"
+
+    // JVM unit tests (no emulator). MockK mocks RN ReadableMap and the Mobile SDK
+    // SalesforceSDKManager singleton; coroutines-test for suspend logic if needed.
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "io.mockk:mockk:1.13.11"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3"
+    // SalesforceSDKManager is compileOnly in main (host provides it); tests that mock it
+    // need it on the test classpath.
+    testImplementation "com.salesforce.mobilesdk:SalesforceReact:13.1.1"
 }

--- a/AgentforceSDK-ReactNative-Bridge/android/src/test/java/com/salesforce/android/reactagentforce/models/AgentModeTest.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/test/java/com/salesforce/android/reactagentforce/models/AgentModeTest.kt
@@ -1,0 +1,162 @@
+package com.salesforce.android.reactagentforce.models
+
+import com.facebook.react.bridge.ReadableMap
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AgentModeTest {
+
+    /** Builds a mock ReadableMap backed by a string map; getString/hasKey honor it. */
+    private fun mapOf(strings: Map<String, String?>): ReadableMap {
+        val map = mockk<ReadableMap>(relaxed = true)
+        every { map.hasKey(any()) } answers { strings.containsKey(firstArg()) }
+        every { map.getString(any()) } answers { strings[firstArg<String>()] }
+        return map
+    }
+
+    // --- typeString ---
+
+    @Test
+    fun `typeString reflects the variant`() {
+        val service = AgentMode.Service(
+            ServiceAgentModeConfig("https://x", "00D", "Agent")
+        )
+        val employee = AgentMode.Employee(
+            EmployeeAgentModeConfig("https://x", "00D", "005", accessToken = "tok")
+        )
+        assertEquals("service", service.typeString)
+        assertEquals("employee", employee.typeString)
+    }
+
+    // --- ServiceAgentModeConfig.fromReadableMap ---
+
+    @Test
+    fun `service config parses all required fields`() {
+        val map = mapOf(
+            mapOf(
+                "serviceApiURL" to "https://service",
+                "organizationId" to "00D",
+                "esDeveloperName" to "MyAgent",
+            )
+        )
+        val config = ServiceAgentModeConfig.fromReadableMap(map)
+        assertEquals("https://service", config?.serviceApiURL)
+        assertEquals("00D", config?.organizationId)
+        assertEquals("MyAgent", config?.esDeveloperName)
+        assertNull(config?.serviceUISettings)
+    }
+
+    @Test
+    fun `service config is null when a required field is missing`() {
+        val map = mapOf(
+            mapOf(
+                "serviceApiURL" to "https://service",
+                "organizationId" to "00D",
+                // esDeveloperName missing
+            )
+        )
+        assertNull(ServiceAgentModeConfig.fromReadableMap(map))
+    }
+
+    @Test
+    fun `service config parses serviceUISettings when present`() {
+        val settings = mockk<ReadableMap>(relaxed = true)
+        val iterator = mockk<com.facebook.react.bridge.ReadableMapKeySetIterator>()
+        every { iterator.hasNextKey() } returnsMany listOf(true, true, false)
+        every { iterator.nextKey() } returnsMany listOf("downloadTranscript", "endConversation")
+        every { settings.keySetIterator() } returns iterator
+        every { settings.getBoolean("downloadTranscript") } returns false
+        every { settings.getBoolean("endConversation") } returns true
+
+        val map = mockk<ReadableMap>(relaxed = true)
+        every { map.getString("serviceApiURL") } returns "https://service"
+        every { map.getString("organizationId") } returns "00D"
+        every { map.getString("esDeveloperName") } returns "MyAgent"
+        every { map.hasKey("serviceUISettings") } returns true
+        every { map.getMap("serviceUISettings") } returns settings
+
+        val config = ServiceAgentModeConfig.fromReadableMap(map)
+        assertEquals(mapOf("downloadTranscript" to false, "endConversation" to true), config?.serviceUISettings)
+    }
+
+    // --- EmployeeAgentModeConfig.fromReadableMap ---
+
+    @Test
+    fun `employee config parses required fields and optional agentId`() {
+        val map = mapOf(
+            mapOf(
+                "instanceUrl" to "https://myorg",
+                "organizationId" to "00D",
+                "userId" to "005",
+                "accessToken" to "tok",
+                "agentId" to "0Xa",
+            )
+        )
+        val config = EmployeeAgentModeConfig.fromReadableMap(map)
+        assertEquals("https://myorg", config?.instanceUrl)
+        assertEquals("005", config?.userId)
+        assertEquals("tok", config?.accessToken)
+        assertEquals("0Xa", config?.agentId)
+    }
+
+    @Test
+    fun `employee config treats blank agentId as null`() {
+        val map = mapOf(
+            mapOf(
+                "instanceUrl" to "https://myorg",
+                "organizationId" to "00D",
+                "userId" to "005",
+                "accessToken" to "tok",
+                "agentId" to "   ",
+            )
+        )
+        assertNull(EmployeeAgentModeConfig.fromReadableMap(map)?.agentId)
+    }
+
+    @Test
+    fun `employee config reads agentLabel only when the key is present`() {
+        val withLabel = mapOf(
+            mapOf(
+                "instanceUrl" to "https://myorg",
+                "organizationId" to "00D",
+                "userId" to "005",
+                "accessToken" to "tok",
+                "agentLabel" to "Support Bot",
+            )
+        )
+        assertEquals("Support Bot", EmployeeAgentModeConfig.fromReadableMap(withLabel)?.agentLabel)
+
+        val withoutLabel = mapOf(
+            mapOf(
+                "instanceUrl" to "https://myorg",
+                "organizationId" to "00D",
+                "userId" to "005",
+                "accessToken" to "tok",
+            )
+        )
+        assertNull(EmployeeAgentModeConfig.fromReadableMap(withoutLabel)?.agentLabel)
+    }
+
+    @Test
+    fun `employee config is null when accessToken is missing`() {
+        val map = mapOf(
+            mapOf(
+                "instanceUrl" to "https://myorg",
+                "organizationId" to "00D",
+                "userId" to "005",
+                // accessToken missing
+            )
+        )
+        assertNull(EmployeeAgentModeConfig.fromReadableMap(map))
+    }
+
+    @Test
+    fun `employee mode exposes its config`() {
+        val config = EmployeeAgentModeConfig("https://x", "00D", "005", accessToken = "tok")
+        val mode = AgentMode.Employee(config)
+        assertEquals("005", mode.config.userId)
+    }
+}

--- a/AgentforceSDK-ReactNative-Bridge/android/src/test/java/com/salesforce/android/reactagentforce/providers/UnifiedCredentialProviderTest.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/test/java/com/salesforce/android/reactagentforce/providers/UnifiedCredentialProviderTest.kt
@@ -1,0 +1,91 @@
+package com.salesforce.android.reactagentforce.providers
+
+import com.salesforce.android.agentforceservice.AgentforceAuthCredentials
+import com.salesforce.android.reactagentforce.models.EmployeeAgentModeConfig
+import com.salesforce.android.reactagentforce.models.ServiceAgentModeConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * In a JVM unit test the Mobile SDK is never initialized, so
+ * SalesforceSDKManager.getInstance() throws "must call init() first". The
+ * provider catches that and routes to its cached-token fallback — which is
+ * exactly the employee-mode branch these tests exercise (no mocking needed).
+ */
+class UnifiedCredentialProviderTest {
+
+    private val serviceConfig = ServiceAgentModeConfig("https://service", "00DService", "Agent")
+    private val employeeConfig =
+        EmployeeAgentModeConfig("https://myorg", "00DEmp", "005User", accessToken = "secret-token")
+
+    @Test
+    fun `unconfigured provider reports no mode`() {
+        val provider = UnifiedCredentialProvider()
+        assertFalse(provider.isConfigured)
+        assertFalse(provider.isServiceAgent)
+        assertFalse(provider.isEmployeeAgent)
+        assertEquals("Unconfigured", provider.currentConfiguration)
+    }
+
+    @Test
+    fun `service mode yields empty-token OAuth credentials`() {
+        val provider = UnifiedCredentialProvider()
+        provider.configure(serviceConfig)
+
+        assertTrue(provider.isServiceAgent)
+        assertFalse(provider.isEmployeeAgent)
+        assertTrue(provider.isConfigured)
+        assertEquals("Service Agent - Org: 00DService", provider.currentConfiguration)
+
+        val creds = provider.getAuthCredentials() as AgentforceAuthCredentials.OAuth
+        assertEquals("", creds.authToken)
+        assertEquals("00DService", creds.orgId)
+        assertEquals("", creds.userId)
+    }
+
+    @Test
+    fun `employee mode falls back to cached token when no Mobile SDK user`() {
+        val provider = UnifiedCredentialProvider()
+        provider.configure(employeeConfig)
+
+        assertTrue(provider.isEmployeeAgent)
+        assertEquals("Employee Agent - Org: 00DEmp, User: 005User", provider.currentConfiguration)
+
+        val creds = provider.getAuthCredentials() as AgentforceAuthCredentials.OAuth
+        assertEquals("secret-token", creds.authToken)
+        assertEquals("00DEmp", creds.orgId)
+        assertEquals("005User", creds.userId)
+    }
+
+    @Test
+    fun `updateToken replaces the cached employee token`() {
+        val provider = UnifiedCredentialProvider()
+        provider.configure(employeeConfig)
+        provider.updateToken("refreshed-token")
+
+        val creds = provider.getAuthCredentials() as AgentforceAuthCredentials.OAuth
+        assertEquals("refreshed-token", creds.authToken)
+    }
+
+    @Test
+    fun `updateToken is a no-op in service mode`() {
+        val provider = UnifiedCredentialProvider()
+        provider.configure(serviceConfig)
+        provider.updateToken("ignored")
+
+        val creds = provider.getAuthCredentials() as AgentforceAuthCredentials.OAuth
+        assertEquals("", creds.authToken)
+    }
+
+    @Test
+    fun `reset clears configuration`() {
+        val provider = UnifiedCredentialProvider()
+        provider.configure(serviceConfig)
+        provider.reset()
+
+        assertFalse(provider.isConfigured)
+        assertEquals("Unconfigured", provider.currentConfiguration)
+    }
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Tests for AgentforceService.
+ *
+ * react-native is mocked so the singleton can be exercised on the JVM-less
+ * jest environment. The mock captures event-emitter listeners in a registry
+ * (`__emit`) so tests can drive native events through the delegate plumbing,
+ * and exposes a mutable `Platform.OS` to exercise the platform guards.
+ */
+import type { AgentConfig, LegacyServiceAgentConfig } from '../../types/AgentConfig';
+import type { AgentforceAdditionalContext } from '../../types/AgentforceContext';
+
+jest.mock('react-native', () => {
+  const listeners: Record<string, Array<(payload: unknown) => void>> = {};
+
+  const AgentforceModule = {
+    enableLogForwarding: jest.fn(),
+    enableNavigationForwarding: jest.fn(),
+    enableUIDelegateForwarding: jest.fn(),
+    provideModifiedUtterance: jest.fn(),
+    registerViewProvider: jest.fn().mockResolvedValue(undefined),
+    clearViewProvider: jest.fn().mockResolvedValue(undefined),
+    configure: jest.fn().mockResolvedValue({ success: true, mode: 'service' }),
+    configureWithConfig: jest.fn().mockResolvedValue({ success: true, mode: 'service' }),
+    getFeatureFlags: jest.fn(),
+    setFeatureFlags: jest.fn().mockResolvedValue(undefined),
+    launchConversation: jest.fn().mockResolvedValue({ success: true }),
+    startNewConversation: jest.fn().mockResolvedValue({ success: true }),
+    closeConversation: jest.fn().mockResolvedValue({ success: true }),
+    isConfigured: jest.fn(),
+    getConfiguration: jest.fn(),
+    getConfigurationInfo: jest.fn(),
+    getEmployeeAgentId: jest.fn(),
+    setEmployeeAgentId: jest.fn().mockResolvedValue(undefined),
+    setAdditionalContext: jest.fn().mockResolvedValue({ success: true }),
+    registerHiddenPreChatFields: jest.fn().mockResolvedValue(undefined),
+    getHiddenPreChatFields: jest.fn(),
+    resetSettings: jest.fn().mockResolvedValue({ success: true }),
+  };
+
+  class NativeEventEmitter {
+    addListener(event: string, cb: (payload: unknown) => void) {
+      (listeners[event] = listeners[event] || []).push(cb);
+      return {
+        remove: () => {
+          listeners[event] = (listeners[event] || []).filter(c => c !== cb);
+        },
+      };
+    }
+  }
+
+  return {
+    NativeModules: { AgentforceModule },
+    NativeEventEmitter,
+    Platform: { OS: 'ios' },
+    __listeners: listeners,
+    __emit: (event: string, payload: unknown) =>
+      (listeners[event] || []).slice().forEach(c => c(payload)),
+  };
+});
+
+// Access the mocked module internals.
+const RN = require('react-native');
+const nativeModule = RN.NativeModules.AgentforceModule;
+const emit = (event: string, payload?: unknown) => RN.__emit(event, payload);
+
+// Import after the mock is registered.
+import AgentforceService from '../AgentforceService';
+
+const setPlatform = (os: string) => {
+  RN.Platform.OS = os;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setPlatform('ios');
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const serviceConfig: AgentConfig = {
+  type: 'service',
+  serviceApiURL: 'https://service.salesforce.com',
+  organizationId: '00Dxx0000001234',
+  esDeveloperName: 'MyServiceAgent',
+  featureFlags: {
+    enableMultiAgent: true,
+    enableMultiModalInput: false,
+    enablePDFUpload: false,
+    enableVoice: false,
+    enableCustomViewProvider: false,
+  },
+};
+
+describe('AgentforceService.configure', () => {
+  it('routes to configureWithConfig on iOS', async () => {
+    setPlatform('ios');
+    const result = await AgentforceService.configure(serviceConfig);
+    expect(nativeModule.configureWithConfig).toHaveBeenCalledTimes(1);
+    expect(nativeModule.configure).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it('routes to configure on Android', async () => {
+    setPlatform('android');
+    await AgentforceService.configure(serviceConfig);
+    expect(nativeModule.configure).toHaveBeenCalledTimes(1);
+    expect(nativeModule.configureWithConfig).not.toHaveBeenCalled();
+  });
+
+  it('returns false on unsupported platforms', async () => {
+    setPlatform('web');
+    const result = await AgentforceService.configure(serviceConfig);
+    expect(result).toBe(false);
+    expect(nativeModule.configure).not.toHaveBeenCalled();
+    expect(nativeModule.configureWithConfig).not.toHaveBeenCalled();
+  });
+
+  it('normalizes a legacy config (no type field) into a service config', async () => {
+    setPlatform('ios');
+    const legacy: LegacyServiceAgentConfig = {
+      serviceApiURL: 'https://service.salesforce.com',
+      organizationId: '00Dxx0000001234',
+      esDeveloperName: 'LegacyAgent',
+    };
+    await AgentforceService.configure(legacy);
+    const passed = nativeModule.configureWithConfig.mock.calls[0][0];
+    expect(passed.type).toBe('service');
+    expect(passed.esDeveloperName).toBe('LegacyAgent');
+  });
+
+  it('merges stored feature flags when the config omits them', async () => {
+    setPlatform('ios');
+    nativeModule.getFeatureFlags.mockResolvedValue({
+      enableMultiAgent: false,
+      enableVoice: true,
+    });
+    const withoutFlags = { ...(serviceConfig as any) };
+    delete withoutFlags.featureFlags;
+    await AgentforceService.configure(withoutFlags);
+    const passed = nativeModule.configureWithConfig.mock.calls[0][0];
+    expect(passed.featureFlags).toEqual({
+      enableMultiAgent: false,
+      enableMultiModalInput: false,
+      enablePDFUpload: false,
+      enableVoice: true,
+      enableCustomViewProvider: false,
+    });
+  });
+
+  it('keeps provided feature flags without consulting native storage', async () => {
+    setPlatform('ios');
+    await AgentforceService.configure(serviceConfig);
+    expect(nativeModule.getFeatureFlags).not.toHaveBeenCalled();
+  });
+
+  it('rethrows when the native module throws', async () => {
+    setPlatform('ios');
+    nativeModule.configureWithConfig.mockRejectedValueOnce(new Error('boom'));
+    await expect(AgentforceService.configure(serviceConfig)).rejects.toThrow('boom');
+  });
+});
+
+describe('AgentforceService.getFeatureFlags', () => {
+  const defaults = {
+    enableMultiAgent: true,
+    enableMultiModalInput: false,
+    enablePDFUpload: false,
+    enableVoice: false,
+    enableCustomViewProvider: false,
+  };
+
+  it('returns defaults on an unsupported platform', async () => {
+    setPlatform('web');
+    await expect(AgentforceService.getFeatureFlags()).resolves.toEqual(defaults);
+  });
+
+  it('returns defaults when the native call throws', async () => {
+    setPlatform('ios');
+    nativeModule.getFeatureFlags.mockRejectedValueOnce(new Error('nope'));
+    await expect(AgentforceService.getFeatureFlags()).resolves.toEqual(defaults);
+  });
+
+  it('fills missing fields with their defaults', async () => {
+    setPlatform('ios');
+    nativeModule.getFeatureFlags.mockResolvedValueOnce({ enableVoice: true });
+    await expect(AgentforceService.getFeatureFlags()).resolves.toEqual({
+      ...defaults,
+      enableVoice: true,
+    });
+  });
+});
+
+describe('AgentforceService logger delegate', () => {
+  it('registers, forwards events, then stops after clear', () => {
+    const onLog = jest.fn();
+    AgentforceService.setLoggerDelegate({ onLog });
+    expect(nativeModule.enableLogForwarding).toHaveBeenCalledWith(true);
+
+    emit('onLogMessage', { level: 'error', message: 'bad', error: 'stack' });
+    expect(onLog).toHaveBeenCalledWith('error', 'bad', 'stack');
+
+    AgentforceService.clearLoggerDelegate();
+    expect(nativeModule.enableLogForwarding).toHaveBeenLastCalledWith(false);
+
+    onLog.mockClear();
+    emit('onLogMessage', { level: 'info', message: 'after-clear' });
+    expect(onLog).not.toHaveBeenCalled();
+  });
+});
+
+describe('AgentforceService navigation delegate', () => {
+  it('forwards navigation requests to the delegate', () => {
+    const onNavigate = jest.fn();
+    AgentforceService.setNavigationDelegate({ onNavigate });
+    expect(nativeModule.enableNavigationForwarding).toHaveBeenCalledWith(true);
+
+    emit('onNavigationRequest', { type: 'link', uri: 'https://x.test' });
+    expect(onNavigate).toHaveBeenCalledWith({ type: 'link', uri: 'https://x.test' });
+
+    AgentforceService.clearNavigationDelegate();
+    expect(nativeModule.enableNavigationForwarding).toHaveBeenLastCalledWith(false);
+  });
+});
+
+describe('AgentforceService UI delegate', () => {
+  afterEach(() => {
+    AgentforceService.clearUIDelegate();
+  });
+
+  it('forwards agent response, utterance, and switch events', () => {
+    const onAgentResponse = jest.fn();
+    const onUtteranceSent = jest.fn();
+    const onAgentSwitch = jest.fn();
+    AgentforceService.setUIDelegate({ onAgentResponse, onUtteranceSent, onAgentSwitch });
+    expect(nativeModule.enableUIDelegateForwarding).toHaveBeenCalledWith(true);
+
+    emit('onAgentResponse', { responseId: '1', message: 'hi', type: 'text', conversationId: 'c' });
+    emit('onUtteranceSent', { utterance: 'hello', hasAttachment: false, timestamp: 't' });
+    emit('onAgentSwitch', { conversationId: 'c2', timestamp: 't' });
+
+    expect(onAgentResponse).toHaveBeenCalledTimes(1);
+    expect(onUtteranceSent).toHaveBeenCalledTimes(1);
+    expect(onAgentSwitch).toHaveBeenCalledTimes(1);
+  });
+
+  it('echoes the original utterance when no modifyUtterance handler is set', async () => {
+    AgentforceService.setUIDelegate({ onAgentResponse: jest.fn() });
+    emit('onModifyUtteranceRequest', { requestId: 'r1', utterance: 'orig' });
+    await Promise.resolve();
+    expect(nativeModule.provideModifiedUtterance).toHaveBeenCalledWith('r1', 'orig');
+  });
+
+  it('forwards the modified utterance from the handler', async () => {
+    AgentforceService.setUIDelegate({
+      onAgentResponse: jest.fn(),
+      modifyUtterance: req => req.utterance.toUpperCase(),
+    });
+    emit('onModifyUtteranceRequest', { requestId: 'r2', utterance: 'orig' });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(nativeModule.provideModifiedUtterance).toHaveBeenCalledWith('r2', 'ORIG');
+  });
+
+  it('falls back to the original utterance when the handler throws', async () => {
+    AgentforceService.setUIDelegate({
+      onAgentResponse: jest.fn(),
+      modifyUtterance: () => {
+        throw new Error('handler failed');
+      },
+    });
+    emit('onModifyUtteranceRequest', { requestId: 'r3', utterance: 'orig' });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(nativeModule.provideModifiedUtterance).toHaveBeenCalledWith('r3', 'orig');
+  });
+});
+
+describe('AgentforceService.setAdditionalContext validation', () => {
+  beforeEach(() => setPlatform('ios'));
+
+  it('throws when variables is not an array', async () => {
+    await expect(
+      AgentforceService.setAdditionalContext({} as AgentforceAdditionalContext),
+    ).rejects.toThrow(/variables/);
+  });
+
+  it('throws when a variable is missing a name', async () => {
+    await expect(
+      AgentforceService.setAdditionalContext({
+        variables: [{ type: 'Text', value: 'x' } as any],
+      }),
+    ).rejects.toThrow(/name/);
+  });
+
+  it('throws on an unknown variable type', async () => {
+    await expect(
+      AgentforceService.setAdditionalContext({
+        variables: [{ name: 'a', type: 'Bogus' as any, value: 'x' }],
+      }),
+    ).rejects.toThrow(/unknown type/);
+  });
+
+  it('forwards a valid context to the native module', async () => {
+    const context: AgentforceAdditionalContext = {
+      variables: [
+        { name: 'userId', type: 'Text', value: '005' },
+        { name: 'score', type: 'Number', value: 95.5 },
+      ],
+    };
+    await expect(AgentforceService.setAdditionalContext(context)).resolves.toBe(true);
+    expect(nativeModule.setAdditionalContext).toHaveBeenCalledWith(context);
+  });
+});
+
+describe('AgentforceService passthrough + normalization', () => {
+  beforeEach(() => setPlatform('ios'));
+
+  it('launchConversation resolves the native success flag', async () => {
+    await expect(AgentforceService.launchConversation()).resolves.toBe(true);
+    expect(nativeModule.launchConversation).toHaveBeenCalled();
+  });
+
+  it('isConfigured handles a raw boolean return', async () => {
+    nativeModule.isConfigured.mockResolvedValueOnce(true);
+    await expect(AgentforceService.isConfigured()).resolves.toBe(true);
+  });
+
+  it('isConfigured handles an object return', async () => {
+    nativeModule.isConfigured.mockResolvedValueOnce({ configured: true });
+    await expect(AgentforceService.isConfigured()).resolves.toBe(true);
+  });
+
+  it('getConfiguration returns null when all fields are empty', async () => {
+    nativeModule.getConfiguration.mockResolvedValueOnce({
+      serviceApiURL: '',
+      organizationId: '',
+      esDeveloperName: '',
+    });
+    await expect(AgentforceService.getConfiguration()).resolves.toBeNull();
+  });
+
+  it('getConfiguration returns a typed service config when populated', async () => {
+    nativeModule.getConfiguration.mockResolvedValueOnce({
+      serviceApiURL: 'https://x',
+      organizationId: '00D',
+      esDeveloperName: 'Agent',
+    });
+    const config = await AgentforceService.getConfiguration();
+    expect(config).toMatchObject({ type: 'service', esDeveloperName: 'Agent' });
+  });
+
+  it('getConfigurationInfo falls back to isConfigured when the new method is absent', async () => {
+    const original = nativeModule.getConfigurationInfo;
+    // Simulate an older native module without getConfigurationInfo.
+    (nativeModule as any).getConfigurationInfo = undefined;
+    nativeModule.isConfigured.mockResolvedValueOnce(true);
+    const info = await AgentforceService.getConfigurationInfo();
+    expect(info).toEqual({ configured: true, mode: 'service' });
+    (nativeModule as any).getConfigurationInfo = original;
+  });
+
+  it('getEmployeeAgentId returns empty string on a non-string result', async () => {
+    nativeModule.getEmployeeAgentId.mockResolvedValueOnce(undefined);
+    await expect(AgentforceService.getEmployeeAgentId()).resolves.toBe('');
+  });
+
+  it('clearHiddenPreChatFields registers an empty map', async () => {
+    await AgentforceService.clearHiddenPreChatFields();
+    expect(nativeModule.registerHiddenPreChatFields).toHaveBeenCalledWith({});
+  });
+});

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/EmployeeAgentAuth.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/EmployeeAgentAuth.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the EmployeeAgentAuth wrappers.
+ *
+ * The module captures `NativeModules.EmployeeAgentAuthBridge` at import time, so
+ * each scenario uses jest.isolateModules with a freshly-configured react-native
+ * mock to exercise both the "bridge present" and "bridge missing" branches.
+ */
+
+type Bridge = {
+  isAuthSupported?: jest.Mock;
+  getAuthCredentials?: jest.Mock;
+  refreshAuthCredentials?: jest.Mock;
+  login?: jest.Mock;
+  logout?: jest.Mock;
+};
+
+function loadWith(bridge: Bridge | undefined, os = 'ios') {
+  let mod: typeof import('../EmployeeAgentAuth');
+  jest.isolateModules(() => {
+    jest.doMock('react-native', () => ({
+      NativeModules: bridge ? { EmployeeAgentAuthBridge: bridge } : {},
+      Platform: { OS: os },
+    }));
+    mod = require('../EmployeeAgentAuth');
+  });
+  // @ts-expect-error assigned inside isolateModules
+  return mod;
+}
+
+const creds = {
+  instanceUrl: 'https://x.my.salesforce.com',
+  organizationId: '00D',
+  userId: '005',
+  accessToken: 'tok',
+};
+
+describe('isEmployeeAgentAuthSupported', () => {
+  it('is false on unsupported platforms', async () => {
+    const mod = loadWith({ isAuthSupported: jest.fn() }, 'web');
+    await expect(mod.isEmployeeAgentAuthSupported()).resolves.toBe(false);
+  });
+
+  it('is false when the bridge is missing', async () => {
+    const mod = loadWith(undefined);
+    await expect(mod.isEmployeeAgentAuthSupported()).resolves.toBe(false);
+  });
+
+  it('is true when the bridge reports support', async () => {
+    const mod = loadWith({ isAuthSupported: jest.fn().mockResolvedValue(true) });
+    await expect(mod.isEmployeeAgentAuthSupported()).resolves.toBe(true);
+  });
+
+  it('is false when the bridge throws', async () => {
+    const mod = loadWith({ isAuthSupported: jest.fn().mockRejectedValue(new Error('x')) });
+    await expect(mod.isEmployeeAgentAuthSupported()).resolves.toBe(false);
+  });
+});
+
+describe('isEmployeeAgentAuthReady / hasEmployeeAgentSession', () => {
+  it('is true with credentials that have an access token', async () => {
+    const mod = loadWith({ getAuthCredentials: jest.fn().mockResolvedValue(creds) });
+    await expect(mod.isEmployeeAgentAuthReady()).resolves.toBe(true);
+    await expect(mod.hasEmployeeAgentSession()).resolves.toBe(true);
+  });
+
+  it('is false when credentials lack an access token', async () => {
+    const mod = loadWith({
+      getAuthCredentials: jest.fn().mockResolvedValue({ ...creds, accessToken: '' }),
+    });
+    await expect(mod.isEmployeeAgentAuthReady()).resolves.toBe(false);
+  });
+
+  it('is false when credentials are null', async () => {
+    const mod = loadWith({ getAuthCredentials: jest.fn().mockResolvedValue(null) });
+    await expect(mod.isEmployeeAgentAuthReady()).resolves.toBe(false);
+  });
+
+  it('is false when the bridge throws', async () => {
+    const mod = loadWith({ getAuthCredentials: jest.fn().mockRejectedValue(new Error('x')) });
+    await expect(mod.isEmployeeAgentAuthReady()).resolves.toBe(false);
+  });
+});
+
+describe('getEmployeeAgentCredentials', () => {
+  it('returns credentials from the bridge', async () => {
+    const mod = loadWith({ getAuthCredentials: jest.fn().mockResolvedValue(creds) });
+    await expect(mod.getEmployeeAgentCredentials()).resolves.toEqual(creds);
+  });
+
+  it('returns null when the bridge throws', async () => {
+    const mod = loadWith({ getAuthCredentials: jest.fn().mockRejectedValue(new Error('x')) });
+    await expect(mod.getEmployeeAgentCredentials()).resolves.toBeNull();
+  });
+
+  it('returns null when the bridge is missing', async () => {
+    const mod = loadWith(undefined);
+    await expect(mod.getEmployeeAgentCredentials()).resolves.toBeNull();
+  });
+});
+
+describe('loginForEmployeeAgent', () => {
+  it('resolves credentials from the bridge', async () => {
+    const mod = loadWith({ login: jest.fn().mockResolvedValue(creds) });
+    await expect(mod.loginForEmployeeAgent()).resolves.toEqual(creds);
+  });
+
+  it('throws when the bridge is missing', async () => {
+    const mod = loadWith(undefined);
+    await expect(mod.loginForEmployeeAgent()).rejects.toThrow(/not available/);
+  });
+});
+
+describe('refreshEmployeeAgentCredentials', () => {
+  it('resolves refreshed credentials', async () => {
+    const mod = loadWith({ refreshAuthCredentials: jest.fn().mockResolvedValue(creds) });
+    await expect(mod.refreshEmployeeAgentCredentials()).resolves.toEqual(creds);
+  });
+
+  it('throws when refresh is unavailable', async () => {
+    const mod = loadWith(undefined);
+    await expect(mod.refreshEmployeeAgentCredentials()).rejects.toThrow(/not available/);
+  });
+});
+
+describe('logoutEmployeeAgent', () => {
+  it('calls the bridge logout', async () => {
+    const logout = jest.fn().mockResolvedValue(undefined);
+    const mod = loadWith({ logout });
+    await mod.logoutEmployeeAgent();
+    expect(logout).toHaveBeenCalled();
+  });
+
+  it('is a no-op when the bridge is missing', async () => {
+    const mod = loadWith(undefined);
+    await expect(mod.logoutEmployeeAgent()).resolves.toBeUndefined();
+  });
+});

--- a/AgentforceSDK-ReactNative-Bridge/src/types/__tests__/AgentConfig.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/__tests__/AgentConfig.test.ts
@@ -1,0 +1,70 @@
+import {
+  isServiceAgentConfig,
+  isEmployeeAgentConfig,
+  isLegacyConfig,
+  ServiceAgentConfig,
+  EmployeeAgentConfig,
+  LegacyServiceAgentConfig,
+} from '../AgentConfig';
+
+const serviceConfig: ServiceAgentConfig = {
+  type: 'service',
+  serviceApiURL: 'https://service.salesforce.com',
+  organizationId: '00Dxx0000001234',
+  esDeveloperName: 'MyServiceAgent',
+};
+
+const employeeConfig: EmployeeAgentConfig = {
+  type: 'employee',
+  instanceUrl: 'https://myorg.my.salesforce.com',
+  organizationId: '00Dxx0000001234',
+  userId: '005xx0000001234',
+  agentId: '0Xxxx0000001234',
+  accessToken: 'token',
+};
+
+const legacyConfig: LegacyServiceAgentConfig = {
+  serviceApiURL: 'https://service.salesforce.com',
+  organizationId: '00Dxx0000001234',
+  esDeveloperName: 'MyServiceAgent',
+};
+
+describe('AgentConfig type guards', () => {
+  describe('isServiceAgentConfig', () => {
+    it('returns true for a service config', () => {
+      expect(isServiceAgentConfig(serviceConfig)).toBe(true);
+    });
+
+    it('returns false for an employee config', () => {
+      expect(isServiceAgentConfig(employeeConfig)).toBe(false);
+    });
+
+    it('returns false for a legacy config (no type field)', () => {
+      expect(isServiceAgentConfig(legacyConfig)).toBe(false);
+    });
+  });
+
+  describe('isEmployeeAgentConfig', () => {
+    it('returns true for an employee config', () => {
+      expect(isEmployeeAgentConfig(employeeConfig)).toBe(true);
+    });
+
+    it('returns false for a service config', () => {
+      expect(isEmployeeAgentConfig(serviceConfig)).toBe(false);
+    });
+  });
+
+  describe('isLegacyConfig', () => {
+    it('returns true for a config without a type field', () => {
+      expect(isLegacyConfig(legacyConfig)).toBe(true);
+    });
+
+    it('returns false for a service config', () => {
+      expect(isLegacyConfig(serviceConfig)).toBe(false);
+    });
+
+    it('returns false for an employee config', () => {
+      expect(isLegacyConfig(employeeConfig)).toBe(false);
+    });
+  });
+});

--- a/ios/Tests/AgentModeTests.swift
+++ b/ios/Tests/AgentModeTests.swift
@@ -1,0 +1,140 @@
+/*
+ * Unit tests for AgentMode config parsing.
+ *
+ * AgentMode.swift is Foundation-only and is compiled directly into this test
+ * bundle (see ios/project.yml -> BridgeUnitTests), so its internal types are
+ * visible here without importing the (pod-delivered) bridge module.
+ */
+import XCTest
+
+final class AgentModeTests: XCTestCase {
+
+    // MARK: - typeString
+
+    func testTypeStringReflectsVariant() {
+        let service = AgentMode.service(
+            config: ServiceAgentModeConfig(
+                serviceApiURL: "https://x",
+                organizationId: "00D",
+                esDeveloperName: "Agent",
+                serviceUISettings: nil
+            )
+        )
+        let employee = AgentMode.employee(
+            config: EmployeeAgentModeConfig(
+                instanceUrl: "https://x",
+                organizationId: "00D",
+                userId: "005",
+                agentId: nil,
+                agentLabel: nil,
+                accessToken: "tok"
+            )
+        )
+        XCTAssertEqual("service", service.typeString)
+        XCTAssertEqual("employee", employee.typeString)
+    }
+
+    // MARK: - ServiceAgentModeConfig.from(dictionary:)
+
+    func testServiceConfigParsesRequiredFields() {
+        let config = ServiceAgentModeConfig.from(dictionary: [
+            "serviceApiURL": "https://service",
+            "organizationId": "00D",
+            "esDeveloperName": "MyAgent",
+        ])
+        XCTAssertEqual("https://service", config?.serviceApiURL)
+        XCTAssertEqual("00D", config?.organizationId)
+        XCTAssertEqual("MyAgent", config?.esDeveloperName)
+        XCTAssertNil(config?.serviceUISettings)
+    }
+
+    func testServiceConfigIsNilWhenFieldMissing() {
+        let config = ServiceAgentModeConfig.from(dictionary: [
+            "serviceApiURL": "https://service",
+            "organizationId": "00D",
+            // esDeveloperName missing
+        ])
+        XCTAssertNil(config)
+    }
+
+    func testServiceConfigParsesUISettings() {
+        let config = ServiceAgentModeConfig.from(dictionary: [
+            "serviceApiURL": "https://service",
+            "organizationId": "00D",
+            "esDeveloperName": "MyAgent",
+            "serviceUISettings": ["downloadTranscript": false, "endConversation": true],
+        ])
+        XCTAssertEqual(false, config?.serviceUISettings?["downloadTranscript"])
+        XCTAssertEqual(true, config?.serviceUISettings?["endConversation"])
+    }
+
+    // MARK: - EmployeeAgentModeConfig.from(dictionary:)
+
+    func testEmployeeConfigParsesRequiredFieldsAndAgentId() {
+        let config = EmployeeAgentModeConfig.from(dictionary: [
+            "instanceUrl": "https://myorg",
+            "organizationId": "00D",
+            "userId": "005",
+            "accessToken": "tok",
+            "agentId": "0Xa",
+        ])
+        XCTAssertEqual("https://myorg", config?.instanceUrl)
+        XCTAssertEqual("005", config?.userId)
+        XCTAssertEqual("tok", config?.accessToken)
+        XCTAssertEqual("0Xa", config?.agentId)
+    }
+
+    func testEmployeeConfigTreatsEmptyAgentIdAsNil() {
+        let config = EmployeeAgentModeConfig.from(dictionary: [
+            "instanceUrl": "https://myorg",
+            "organizationId": "00D",
+            "userId": "005",
+            "accessToken": "tok",
+            "agentId": "",
+        ])
+        XCTAssertNotNil(config)
+        XCTAssertNil(config?.agentId)
+    }
+
+    func testEmployeeConfigParsesOptionalAgentLabel() {
+        let withLabel = EmployeeAgentModeConfig.from(dictionary: [
+            "instanceUrl": "https://myorg",
+            "organizationId": "00D",
+            "userId": "005",
+            "accessToken": "tok",
+            "agentLabel": "Support Bot",
+        ])
+        XCTAssertEqual("Support Bot", withLabel?.agentLabel)
+
+        let withoutLabel = EmployeeAgentModeConfig.from(dictionary: [
+            "instanceUrl": "https://myorg",
+            "organizationId": "00D",
+            "userId": "005",
+            "accessToken": "tok",
+        ])
+        XCTAssertNil(withoutLabel?.agentLabel)
+    }
+
+    func testEmployeeConfigIsNilWhenAccessTokenMissing() {
+        let config = EmployeeAgentModeConfig.from(dictionary: [
+            "instanceUrl": "https://myorg",
+            "organizationId": "00D",
+            "userId": "005",
+            // accessToken missing
+        ])
+        XCTAssertNil(config)
+    }
+
+    // MARK: - AgentConfigError
+
+    func testAgentConfigErrorDescriptions() {
+        XCTAssertEqual(
+            "Missing required configuration field: userId",
+            AgentConfigError.missingRequiredField("userId").errorDescription
+        )
+        XCTAssertEqual(
+            "Employee Agent requires an access token.",
+            AgentConfigError.tokenRequired.errorDescription
+        )
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -111,6 +111,16 @@ schemes:
       config: Release
     shared: true
 
+  BridgeUnitTests:
+    build:
+      targets:
+        BridgeUnitTests: [test]
+    test:
+      config: Debug
+      targets:
+        - BridgeUnitTests
+    shared: true
+
   EmployeeAgent:
     build:
       targets:
@@ -153,3 +163,20 @@ targets:
           - "AppDelegate.m"
       - path: EmployeeAgent
         type: group
+
+  # Standalone unit-test bundle for the bridge's Foundation-only pure logic.
+  # It compiles the testable bridge source directly (no host app, no pods/SDK
+  # linking) so it runs fast and stays independent of the CocoaPods graph.
+  # SDK-coupled types (UnifiedCredentialProvider, BridgeNetwork) are out of scope.
+  BridgeUnitTests:
+    type: bundle.unit-test
+    platform: iOS
+    deploymentTarget: "17.0"
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: com.salesforce.reactagentforce.bridgetests
+      GENERATE_INFOPLIST_FILE: YES
+      CODE_SIGNING_ALLOWED: NO
+    sources:
+      - path: Tests
+        type: group
+      - path: ../AgentforceSDK-ReactNative-Bridge/ios/Agentforce/Models/AgentMode.swift

--- a/scripts/__tests__/generate-app-config.test.js
+++ b/scripts/__tests__/generate-app-config.test.js
@@ -1,0 +1,56 @@
+/**
+ * Tests for scripts/generate-app-config.js.
+ *
+ * The script writes AppConfig.generated.ts to a path relative to its own
+ * location, so it is copied into a temp dir (with a fake src/config tree) and
+ * run there as a child process — the real generated file is never touched.
+ */
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REAL_SCRIPT = path.join(__dirname, '..', 'generate-app-config.js');
+
+let tmpDir;
+let scriptCopy;
+let generatedPath;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gen-config-'));
+  const scriptsDir = path.join(tmpDir, 'scripts');
+  fs.mkdirSync(path.join(tmpDir, 'src', 'config'), { recursive: true });
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  scriptCopy = path.join(scriptsDir, 'generate-app-config.js');
+  fs.copyFileSync(REAL_SCRIPT, scriptCopy);
+  generatedPath = path.join(tmpDir, 'src', 'config', 'AppConfig.generated.ts');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function run(target) {
+  return execFileSync('node', target == null ? [scriptCopy] : [scriptCopy, target], {
+    encoding: 'utf8',
+  });
+}
+
+describe('generate-app-config', () => {
+  it.each(['service', 'employee', 'all'])('writes APP_MODE=%s for a valid target', target => {
+    run(target);
+    const content = fs.readFileSync(generatedPath, 'utf8');
+    expect(content).toContain(`export const APP_MODE = '${target}' as const;`);
+  });
+
+  it("defaults to 'all' when no target is given", () => {
+    run(null);
+    const content = fs.readFileSync(generatedPath, 'utf8');
+    expect(content).toContain("export const APP_MODE = 'all' as const;");
+  });
+
+  it('exits non-zero on an invalid target', () => {
+    expect(() => run('bogus')).toThrow();
+    expect(fs.existsSync(generatedPath)).toBe(false);
+  });
+});

--- a/scripts/__tests__/update-bootconfig.test.js
+++ b/scripts/__tests__/update-bootconfig.test.js
@@ -1,0 +1,154 @@
+/**
+ * Tests for scripts/update-bootconfig.js.
+ *
+ * Operates on bootconfig fixtures written into an OS temp dir so the real
+ * project files are never touched.
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  backupBootconfig,
+  updateIOSBootconfig,
+  updateAndroidBootconfig,
+} = require('../update-bootconfig');
+
+const IOS_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+\t<key>remoteAccessConsumerKey</key>
+\t<string>OLD_KEY</string>
+\t<key>oauthRedirectURI</key>
+\t<string>old://redirect</string>
+\t<key>oauthScopes</key>
+\t<array>
+\t\t<string>old</string>
+\t</array>
+</dict>
+</plist>
+`;
+
+const ANDROID_XML = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="remoteAccessConsumerKey">OLD_KEY</string>
+    <string name="oauthRedirectURI">old://redirect</string>
+    <string-array name="oauthScopes">
+        <item>old</item>
+    </string-array>
+</resources>
+`;
+
+const config = {
+  consumerKey: 'NEW_KEY_123',
+  redirectUri: 'sfdc:///oauth/done',
+  scopes: 'web, api ,refresh_token',
+};
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bootconfig-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('updateIOSBootconfig', () => {
+  it('replaces consumer key, redirect URI, and scopes', () => {
+    const file = path.join(tmpDir, 'bootconfig.plist');
+    fs.writeFileSync(file, IOS_PLIST);
+
+    const result = updateIOSBootconfig(file, config);
+    const content = fs.readFileSync(file, 'utf8');
+
+    expect(result.modified).toBe(true);
+    expect(result.warnings).toEqual([]);
+    expect(content).toContain('<string>NEW_KEY_123</string>');
+    expect(content).toContain('<string>sfdc:///oauth/done</string>');
+    // scopes are split, trimmed, and re-emitted as individual <string> entries
+    expect(content).toContain('<string>web</string>');
+    expect(content).toContain('<string>api</string>');
+    expect(content).toContain('<string>refresh_token</string>');
+    expect(content).not.toContain('<string>old</string>');
+  });
+
+  it('records warnings for patterns that are absent', () => {
+    const file = path.join(tmpDir, 'partial.plist');
+    fs.writeFileSync(file, '<plist><dict></dict></plist>');
+
+    const result = updateIOSBootconfig(file, config);
+
+    expect(result.modified).toBe(false);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        'remoteAccessConsumerKey pattern not found',
+        'oauthRedirectURI pattern not found',
+        'oauthScopes pattern not found',
+      ]),
+    );
+  });
+
+  it('throws when the file does not exist', () => {
+    expect(() => updateIOSBootconfig(path.join(tmpDir, 'missing.plist'), config)).toThrow(
+      /not found/,
+    );
+  });
+});
+
+describe('updateAndroidBootconfig', () => {
+  it('replaces consumer key, redirect URI, and scopes as <item> entries', () => {
+    const file = path.join(tmpDir, 'bootconfig.xml');
+    fs.writeFileSync(file, ANDROID_XML);
+
+    const result = updateAndroidBootconfig(file, config);
+    const content = fs.readFileSync(file, 'utf8');
+
+    expect(result.modified).toBe(true);
+    expect(result.warnings).toEqual([]);
+    expect(content).toContain('<string name="remoteAccessConsumerKey">NEW_KEY_123</string>');
+    expect(content).toContain('<string name="oauthRedirectURI">sfdc:///oauth/done</string>');
+    expect(content).toContain('<item>web</item>');
+    expect(content).toContain('<item>api</item>');
+    expect(content).toContain('<item>refresh_token</item>');
+    expect(content).not.toContain('<item>old</item>');
+  });
+
+  it('throws when the file does not exist', () => {
+    expect(() => updateAndroidBootconfig(path.join(tmpDir, 'missing.xml'), config)).toThrow(
+      /not found/,
+    );
+  });
+});
+
+describe('backupBootconfig', () => {
+  it('writes an iOS backup next to the original file', () => {
+    const file = path.join(tmpDir, 'bootconfig.plist');
+    fs.writeFileSync(file, IOS_PLIST);
+
+    const backupPath = backupBootconfig(file);
+
+    expect(backupPath).toBe(file + '.backup');
+    expect(fs.existsSync(backupPath)).toBe(true);
+    expect(fs.readFileSync(backupPath, 'utf8')).toBe(IOS_PLIST);
+  });
+
+  it('writes an Android backup outside the res/ directory', () => {
+    // The helper keys on the path containing "android" and "/res/".
+    const flavorDir = path.join(tmpDir, 'android', 'app', 'src', 'employeeAgent');
+    const resDir = path.join(flavorDir, 'res', 'values');
+    fs.mkdirSync(resDir, { recursive: true });
+    const file = path.join(resDir, 'bootconfig.xml');
+    fs.writeFileSync(file, ANDROID_XML);
+
+    const backupPath = backupBootconfig(file);
+
+    expect(backupPath).toBe(path.join(flavorDir, 'bootconfig.xml.backup'));
+    expect(fs.existsSync(backupPath)).toBe(true);
+  });
+
+  it('throws when the source file is missing', () => {
+    expect(() => backupBootconfig(path.join(tmpDir, 'nope.plist'))).toThrow(/not found/);
+  });
+});

--- a/src/config/__tests__/AppConfig.test.ts
+++ b/src/config/__tests__/AppConfig.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for AppConfig feature-flag derivation.
+ *
+ * APP_MODE comes from the generated AppConfig.generated module, so each case
+ * mocks that module and re-imports AppConfig via jest.isolateModules.
+ */
+
+function loadFeatures(mode: 'service' | 'employee' | 'all') {
+  let mod: typeof import('../AppConfig');
+  jest.isolateModules(() => {
+    jest.doMock('../AppConfig.generated', () => ({ APP_MODE: mode }));
+    mod = require('../AppConfig');
+  });
+  // @ts-expect-error assigned inside isolateModules
+  return mod;
+}
+
+describe('AppConfig FEATURES', () => {
+  it("enables both agents for 'all'", () => {
+    const { FEATURES, UI_FEATURES } = loadFeatures('all');
+    expect(FEATURES.SHOW_SERVICE_AGENT).toBe(true);
+    expect(FEATURES.SHOW_EMPLOYEE_AGENT).toBe(true);
+    expect(UI_FEATURES.SHOW_SERVICE_AGENT).toBe(true);
+    expect(UI_FEATURES.SHOW_EMPLOYEE_AGENT).toBe(true);
+  });
+
+  it("enables only the service agent for 'service'", () => {
+    const { FEATURES } = loadFeatures('service');
+    expect(FEATURES.SHOW_SERVICE_AGENT).toBe(true);
+    expect(FEATURES.SHOW_EMPLOYEE_AGENT).toBe(false);
+  });
+
+  it("enables only the employee agent for 'employee'", () => {
+    const { FEATURES } = loadFeatures('employee');
+    expect(FEATURES.SHOW_SERVICE_AGENT).toBe(false);
+    expect(FEATURES.SHOW_EMPLOYEE_AGENT).toBe(true);
+  });
+
+  it('mirrors FEATURES into UI_FEATURES', () => {
+    const { FEATURES, UI_FEATURES } = loadFeatures('service');
+    expect(UI_FEATURES.SHOW_SERVICE_AGENT).toBe(FEATURES.SHOW_SERVICE_AGENT);
+    expect(UI_FEATURES.SHOW_EMPLOYEE_AGENT).toBe(FEATURES.SHOW_EMPLOYEE_AGENT);
+  });
+});


### PR DESCRIPTION
## Summary

The repo had effectively zero test coverage — one jest test and no native test harness at all. This PR stands up unit-test harnesses on all three layers and adds **pure-logic** tests for the previously-untested bridge code, then wires the native suites into CI.

**100 tests total, all passing.**

## What's included

### TypeScript + node scripts (jest — existing harness)
- `AgentConfig` type guards
- `AgentforceService` (~1075-line singleton) via a mocked `react-native`: configure/legacy-normalization/platform routing, feature-flag merge + defaults, logger/navigation/UI delegate event forwarding, `setAdditionalContext` validation, the `modifyUtterance` request/response flow, and passthrough normalization
- `EmployeeAgentAuth` wrappers (bridge-present and bridge-missing branches)
- `AppConfig` `FEATURES` derivation
- `update-bootconfig.js` / `generate-app-config.js` build scripts
- 76 tests; lint, typecheck, and prettier clean

### Android (new JUnit + MockK harness)
- Added `testImplementation` deps + `testOptions.returnDefaultValues` to the bridge library module
- `AgentModeTest`: `ServiceAgentModeConfig`/`EmployeeAgentModeConfig.fromReadableMap` (required fields, blank `agentId`, `agentLabel` presence, `serviceUISettings`) + `typeString`, using a mockk-backed `ReadableMap`
- `UnifiedCredentialProviderTest`: service empty-token OAuth, employee cached-token fallback, `updateToken`, query props, `reset`
- 15 tests via `:react-native-agentforce:testDebugUnitTest`

### iOS (new XCTest target via XcodeGen)
- Added a standalone `BridgeUnitTests` bundle that compiles the Foundation-only `AgentMode.swift` directly — no host app or pod/SDK linking — so it's fast and decoupled from the CocoaPods graph
- `AgentModeTests`: `from(dictionary:)` parsing (required fields, empty `agentId` → nil, optional `agentLabel`, `serviceUISettings`), `typeString`, `AgentConfigError.errorDescription`
- 9 tests via `xcodebuild test`

### CI
- Added `android-unit-tests` and `ios-unit-tests` jobs to `pr-checks.yml`, both gating `all-checks-passed` (TS tests were already run by the existing `unit-tests` job)

## Out of scope (deferred)
Framework-bound code: Compose UI, Activity overlay, live RCT `@ReactMethod` round-trips, and the SDK-coupled `UnifiedCredentialProvider`/`BridgeNetwork` on iOS (these require linking the full CocoaPods dependency graph). The Android equivalent of the credential provider *is* covered because its SDK types are resolvable on the test classpath.

## Verification
- `npm test -- --coverage` — 76 pass
- `cd android && ./gradlew :react-native-agentforce:testDebugUnitTest` — 15 pass
- `xcodebuild test -scheme BridgeUnitTests` on simulator — 9 pass