### PR TITLE
Host conversation in a dedicated stable singleTask Activity (re-launch fix)

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/AndroidManifest.xml
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/AndroidManifest.xml
@@ -8,5 +8,21 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-    <application />
+    <application>
+        <!--
+         Dedicated host for the Agentforce conversation UI. singleTask + a distinct
+         taskAffinity keep it a single, stable instance independent of the host app's
+         Activity stack, so the SDK's activity-scoped conversation ViewModel and its
+         one-shot bootstrap survive dismiss/re-launch (dismiss backgrounds, it is not
+         finished). configChanges avoids recreation on rotation/keyboard/etc., which
+         would also drop the SDK ViewModel. See [[project_rn_android_bootstrap_fix]].
+        -->
+        <activity
+            android:name=".AgentforceConversationActivity"
+            android:exported="false"
+            android:launchMode="singleTask"
+            android:taskAffinity="${applicationId}.agentforce.conversation"
+            android:theme="@style/AppTheme"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize|uiMode" />
+    </application>
 </manifest>

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationActivity.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationActivity.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ */
+package com.salesforce.android.reactagentforce
+
+import android.os.Bundle
+import android.util.Log
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowCompat
+
+/**
+ * Dedicated, bridge-owned host Activity for the Agentforce conversation UI.
+ *
+ * Why a separate Activity instead of an overlay on the host's current Activity:
+ * the SDK scopes its conversation ViewModel — and the one-shot bootstrap that
+ * lives inside [AgentforceConversationContainer]'s `LaunchedEffect(Unit)` — to the
+ * host Activity via `getActivityScopedViewModelStoreOwner()`. An in-host-Activity
+ * overlay only survives a dismiss/re-launch when the host hands back the SAME
+ * Activity instance. Some host apps (multi-activity nav, recreated RN host) don't,
+ * so the overlay re-attaches to a new Activity, the SDK ViewModel is recreated,
+ * bootstrap re-fires on the reused conversation, hits the by-design discovery 404
+ * it can't recover from, and the chat hangs on "I'm on my way…".
+ * See [[project_rn_android_bootstrap_fix]].
+ *
+ * This Activity is declared `singleTask` with its own taskAffinity, so it is a
+ * single, stable instance independent of the host app's Activity stack. Dismiss
+ * sends it to the background (it is NOT finished — see [AgentforceConversationOverlay]),
+ * so the instance, its ViewModelStore, and the completed bootstrap all survive.
+ * Re-launch brings the same instance forward (no recreation, no re-bootstrap),
+ * preserving conversation history regardless of what the host app's navigation does.
+ */
+class AgentforceConversationActivity : ComponentActivity() {
+
+    companion object {
+        private const val TAG = "AgentforceConvActivity"
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        AgentforceConversationOverlay.registerActivity(this)
+
+        // Draw edge-to-edge and let the IME resize the content, matching the prior overlay.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        @Suppress("DEPRECATION")
+        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+
+        setContent {
+            // Read the shared client + conversation. If state was cleared (logout, reset,
+            // mode switch) finish immediately rather than render an empty container.
+            val client = AgentforceClientHolder.agentforceClient
+            val conversation = AgentforceClientHolder.currentConversation
+            if (client == null || conversation == null) {
+                Log.w(TAG, "No client/conversation when rendering - finishing")
+                finish()
+                return@setContent
+            }
+
+            // Render the SDK container directly — it draws its own header (showTopBar
+            // defaults true); the agentLabel override is wired via BridgeTopAppBarBuilder
+            // in AgentforceModule.configureEmployeeAgent. onClose backgrounds this Activity
+            // (see AgentforceConversationOverlay.hide) so SDK state survives re-launch.
+            MaterialTheme {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .statusBarsPadding()
+                        .padding(top = 12.dp)
+                        .navigationBarsPadding()
+                        .imePadding()
+                ) {
+                    client.AgentforceConversationContainer(
+                        conversation = conversation,
+                        onClose = { AgentforceConversationOverlay.hide() }
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Hardware/gesture back dismisses the conversation the same way the SDK's close
+     * action does — background (don't finish) so bootstrap state survives re-launch.
+     */
+    @Deprecated("Deprecated in Java")
+    override fun onBackPressed() {
+        AgentforceConversationOverlay.hide()
+    }
+
+    override fun onDestroy() {
+        AgentforceConversationOverlay.unregisterActivity(this)
+        super.onDestroy()
+    }
+}

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
@@ -5,195 +5,97 @@
 package com.salesforce.android.reactagentforce
 
 import android.app.Activity
+import android.content.Intent
 import android.util.Log
-import android.view.MotionEvent
-import android.view.ViewGroup
-import android.view.WindowManager
-import android.widget.FrameLayout
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.BackHandler
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.unit.dp
-import androidx.core.view.WindowCompat
-import androidx.lifecycle.setViewTreeLifecycleOwner
-import androidx.lifecycle.setViewTreeViewModelStoreOwner
-import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 
 /**
- * Manages the Agentforce conversation UI as an overlay on the current Activity.
+ * Drives the Agentforce conversation UI hosted in the dedicated, bridge-owned
+ * [AgentforceConversationActivity].
  *
- * This matches the SDK test harness pattern: the AgentforceConversationContainer
- * composable lives in the same Activity's composition tree, so the SDK's internal
- * ViewModel persists across show/hide cycles. This prevents stale state issues
- * (like secure forms reappearing) that occur when using a separate Activity.
+ * Previously the conversation was an overlay ComposeView attached to the host app's
+ * current Activity. That made the SDK's activity-scoped conversation ViewModel (and its
+ * one-shot bootstrap) depend on the host handing back the SAME Activity instance across
+ * dismiss/re-launch — which some host apps don't, causing a re-bootstrap 404 hang on
+ * re-launch. See [[project_rn_android_bootstrap_fix]].
+ *
+ * Now the conversation lives in its own `singleTask` Activity with a stable instance.
+ * - [show]   starts (or brings forward) the conversation Activity.
+ * - [hide]   sends it to the background WITHOUT finishing it, so its ViewModelStore and
+ *            completed bootstrap survive — re-launch reuses the same instance, no
+ *            re-bootstrap, conversation history preserved.
+ * - [destroy] actually finishes the Activity; call when a fresh conversation is required
+ *            (logout, reset, mode/agent switch).
+ *
+ * The public API (show/hide/destroy/isVisible) is unchanged so existing AgentforceModule
+ * call-sites keep working.
  */
 object AgentforceConversationOverlay {
 
     private const val TAG = "AgentforceConvOverlay"
 
-    internal var isVisible = mutableStateOf(false)
-    private var overlayContainer: ViewGroup? = null
-    private var attachedActivity: ComponentActivity? = null
+    /**
+     * Whether the conversation is currently presented. Kept as a plain flag (not Compose
+     * state) for parity with the previous API; the Activity owns its own composition now.
+     */
+    @Volatile
+    internal var isVisible: Boolean = false
+        private set
+
+    /** The live conversation Activity instance, set from its own lifecycle callbacks. */
+    @Volatile
+    private var activityRef: AgentforceConversationActivity? = null
+
+    /** Called by [AgentforceConversationActivity.onCreate]/onDestroy to track the instance. */
+    internal fun registerActivity(activity: AgentforceConversationActivity) {
+        activityRef = activity
+    }
+
+    internal fun unregisterActivity(activity: AgentforceConversationActivity) {
+        if (activityRef === activity) {
+            activityRef = null
+        }
+    }
 
     /**
-     * Show the conversation overlay on the given Activity.
-     * Creates the ComposeView on first call, then toggles visibility.
+     * Present the conversation. Launches [AgentforceConversationActivity] if not already
+     * running, or brings the existing (backgrounded) instance forward — which does NOT
+     * recreate it, so the SDK bootstrap state is preserved.
      */
     fun show(activity: Activity) {
-        if (activity !is ComponentActivity) {
-            Log.e(TAG, "Activity must be a ComponentActivity")
-            return
+        val intent = Intent(activity, AgentforceConversationActivity::class.java).apply {
+            // Reuse the existing single task instance instead of creating a new one.
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
         }
-
-        if (overlayContainer == null || attachedActivity !== activity) {
-            attachToActivity(activity)
-        }
-
-        isVisible.value = true
-        Log.d(TAG, "Conversation overlay shown")
+        activity.startActivity(intent)
+        isVisible = true
+        Log.d(TAG, "Conversation activity shown")
     }
 
     /**
-     * Hide the conversation overlay (preserves state).
+     * Dismiss the conversation WITHOUT finishing the Activity, so its ViewModelStore and
+     * the SDK's completed bootstrap survive for the next [show]. Backgrounds the task.
      */
     fun hide() {
-        isVisible.value = false
-        Log.d(TAG, "Conversation overlay hidden")
+        isVisible = false
+        activityRef?.let { activity ->
+            activity.runOnUiThread {
+                // moveTaskToBack keeps the Activity instance (and its ViewModelStore) alive.
+                activity.moveTaskToBack(true)
+            }
+        }
+        Log.d(TAG, "Conversation activity hidden (backgrounded, state preserved)")
     }
 
     /**
-     * Detach and destroy the overlay. Call when configuration changes
-     * require a fresh conversation. Must be called on the main thread.
+     * Finish the conversation Activity entirely. Call when a fresh conversation is
+     * required (logout, reset, mode/agent switch) — the next [show] starts clean.
      */
     fun destroy() {
-        attachedActivity?.let { activity ->
-            WindowCompat.setDecorFitsSystemWindows(activity.window, true)
-            activity.window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_UNSPECIFIED)
+        isVisible = false
+        activityRef?.let { activity ->
+            activity.runOnUiThread { activity.finish() }
         }
-        overlayContainer?.let { container ->
-            (container.parent as? ViewGroup)?.removeView(container)
-        }
-        overlayContainer = null
-        attachedActivity = null
-        isVisible.value = false
-        Log.d(TAG, "Conversation overlay destroyed")
-    }
-
-    private fun attachToActivity(activity: ComponentActivity) {
-        destroy()
-
-        WindowCompat.setDecorFitsSystemWindows(activity.window, false)
-        @Suppress("DEPRECATION")
-        activity.window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
-
-        val overlayState = isVisible
-        val wrapper = object : FrameLayout(activity) {
-            override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
-                if (!overlayState.value) return false
-                return super.dispatchTouchEvent(ev)
-            }
-        }
-
-        val overlay = ComposeView(activity).apply {
-            setViewTreeLifecycleOwner(activity)
-            setViewTreeViewModelStoreOwner(activity)
-            setViewTreeSavedStateRegistryOwner(activity)
-
-            setContent {
-                ConversationOverlayContent(
-                    onClose = { hide() }
-                )
-            }
-        }
-
-        wrapper.addView(
-            overlay,
-            FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                FrameLayout.LayoutParams.MATCH_PARENT
-            )
-        )
-
-        val contentView = activity.findViewById<ViewGroup>(android.R.id.content)
-        contentView.addView(
-            wrapper,
-            FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                FrameLayout.LayoutParams.MATCH_PARENT
-            )
-        )
-
-        overlayContainer = wrapper
-        attachedActivity = activity
-        Log.d(TAG, "Overlay attached to activity: ${activity.javaClass.simpleName}")
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ConversationOverlayContent(onClose: () -> Unit) {
-    val visible by AgentforceConversationOverlay.isVisible
-
-    val client = AgentforceClientHolder.agentforceClient
-    val conversation = AgentforceClientHolder.currentConversation
-
-    if (conversation == null || client == null) return
-
-    // Keep the container permanently composed and animate visibility via translationY only.
-    // AnimatedVisibility would remove it from the composition on hide and re-run the SDK's
-    // one-shot bootstrap on the next show, which 404s on a reused conversation. See
-    // [[project_rn_android_bootstrap_fix]].
-    if (visible) {
-        BackHandler { onClose() }
-    }
-
-    var heightPx by remember { mutableIntStateOf(0) }
-    // Slide fully off-screen (downward) when hidden; rest at 0 (fully shown) when visible.
-    val translationY by animateFloatAsState(
-        targetValue = if (visible) 0f else heightPx.toFloat(),
-        animationSpec = tween(durationMillis = 250),
-        label = "overlaySlide"
-    )
-
-    // Render the SDK container directly — no bridge-owned top bar. The SDK
-    // draws its own header (showTopBar defaults to true), and the agent label
-    // override is applied via BridgeTopAppBarBuilder wired into the SDK config
-    // in AgentforceModule.configureEmployeeAgent. Wrapping it in our own
-    // Scaffold/TopAppBar previously produced a duplicate, redundant header.
-    MaterialTheme {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .onSizeChanged { heightPx = it.height }
-                .graphicsLayer { this.translationY = translationY }
-                .statusBarsPadding()
-                .padding(top = 12.dp)
-                .navigationBarsPadding()
-                .imePadding()
-        ) {
-            client.AgentforceConversationContainer(
-                conversation = conversation,
-                onClose = onClose
-            )
-        }
+        activityRef = null
+        Log.d(TAG, "Conversation activity destroyed")
     }
 }


### PR DESCRIPTION
## Summary

Fixes the Android Employee Agent re-launch hang (chat stuck on **"I'm on my way…"**) that the #101 fix did not resolve for host apps whose Activity instance is not stable across dismiss/re-launch.

## Root cause

The SDK scopes its conversation ViewModel — and the one-shot bootstrap inside `AgentforceConversationContainer`'s `LaunchedEffect(Unit)` — to the host Activity via `getActivityScopedViewModelStoreOwner()`. #101 keeps the SDK container composed to avoid re-bootstrap, but that only holds while the **host Activity instance is stable**. Host apps that hand back a different Activity on re-launch (multi-activity nav, recreated RN host) cause the overlay to re-attach a fresh `ComposeView`, re-firing bootstrap on the reused conversation → the by-design discovery 404 it can't recover from → permanent spinner. The single-Activity sample app never triggers this, which is why the earlier fix looked complete there.

## Change

Move the conversation out of an in-host-Activity overlay into a dedicated, bridge-owned `AgentforceConversationActivity`, declared `singleTask` with its own `taskAffinity` — a single stable instance independent of the host app's Activity stack:

- **`show()`** — start / bring the conversation Activity forward (no recreation on reuse)
- **`hide()`** — `moveTaskToBack`: background **without** finishing, so the SDK ViewModel + completed bootstrap survive → re-launch reuses the same instance, no re-bootstrap, **conversation history preserved**
- **`destroy()`** — finish the Activity for logout / reset / mode switch (fresh next launch)

`AgentforceConversationOverlay` keeps its public API (`show`/`hide`/`destroy`/`isVisible`), so the `AgentforceModule` call-sites are unchanged.

## Files
- `AgentforceConversationActivity.kt` (new) — dedicated host Activity
- `AgentforceConversationOverlay.kt` — now drives the Activity instead of an in-host ComposeView
- `AndroidManifest.xml` — registers the Activity (`singleTask`, distinct `taskAffinity`, `configChanges`)

## Testing
Verified locally: dismiss + re-launch re-initializes correctly (no 404 hang) and conversation history is preserved. Bridge module compiles clean (`:react-native-agentforce:compileDebugKotlin`). iOS is unaffected (no change).

## Behavioral note
The conversation now presents as its own window/task rather than an in-place overlay, so dismiss returns to the host app and enter/exit uses the system Activity transition rather than the prior custom slide. Theming/insets come from the Activity's own theme. This is inherent to the dedicated-Activity approach; polish (translucent theme, custom transition) can follow if desired.