### PR TITLE
Fix Android conversation overlay system-bar inset bleed-through

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
@@ -14,6 +14,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
@@ -37,6 +38,7 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.salesforce.android.agentforcesdk.components.theme.LocalAgentforceTheme
 
 /**
  * Manages the Agentforce conversation UI as an overlay on the current Activity.
@@ -192,12 +194,18 @@ private fun ConversationOverlayContent(onClose: () -> Unit) {
     // override is applied via BridgeTopAppBarBuilder wired into the SDK config
     // in AgentforceModule.configureEmployeeAgent. Wrapping it in our own
     // Scaffold/TopAppBar previously produced a duplicate, redundant header.
+    // Fill the system-bar insets with the SDK's chat surface (surface1) so they match.
+    val surfaceColor = LocalAgentforceTheme.current.colors().surface1
+
     MaterialTheme {
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .onSizeChanged { heightPx = it.height }
                 .graphicsLayer { this.translationY = translationY }
+                // Background before the insets, so the padded strips aren't transparent
+                // (host screen bleed-through); after graphicsLayer so it slides on hide.
+                .background(surfaceColor)
                 .statusBarsPadding()
                 .padding(top = 12.dp)
                 .navigationBarsPadding()


### PR DESCRIPTION
## What

Fills the conversation overlay's system-bar inset strips with the SDK's chat surface color so the host app's screen no longer bleeds through behind the gesture bar (and status bar) on Android.

## Why

The overlay `Box` applies `statusBarsPadding()` + `navigationBarsPadding()` to keep the chat content above the system bars, but the `Box` itself had no background. The padded strips were therefore transparent, exposing the host React Native screen behind them — visible as a colored band at the bottom of the chat.

## Fix

Apply `.background(surfaceColor)` to the `Box` *before* the inset paddings, using `LocalAgentforceTheme.current.colors().surface1` — the same surface the SDK's top bar, chat body, and input bar use. This makes the strips a seamless extension of the conversation and adapts to dark mode / host theme overrides. Placed after `graphicsLayer` so the fill slides with the overlay on hide.

`surface1` is used rather than `chatBackground` because the published SDK artifact (15.20.3) doesn't expose `chatBackground`; in the SDK both `chatBackground` and `inputBarBackground` fall back to `surface1`, so it's the version-safe match.

## Testing

Verified on a Pixel 10 Pro emulator (API 36.1) — the green host-screen band behind the gesture bar is gone and the inset strips match the white chat surface.