### PR TITLE
@W-22724903@ Fix gap between input box and keyboard in Android service agent

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
@@ -16,11 +16,14 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -208,8 +211,15 @@ private fun ConversationOverlayContent(onClose: () -> Unit) {
                 .background(surfaceColor)
                 .statusBarsPadding()
                 .padding(top = 12.dp)
-                .navigationBarsPadding()
-                .imePadding()
+                // Pad the bottom by the UNION (max) of the nav-bar and IME insets, not
+                // their sum. Chaining .navigationBarsPadding().imePadding() is additive:
+                // when the keyboard is up, the IME inset already reaches the screen bottom
+                // (subsuming the nav-bar region), so stacking both pushed content up by
+                // navBar + ime while the keyboard top sat only ime above the bottom —
+                // leaving a nav-bar-height gap between the input box and the keyboard.
+                // The union resolves to ime while the keyboard is visible and to navBar
+                // when it's hidden (ime == 0), eliminating the gap.
+                .windowInsetsPadding(WindowInsets.navigationBars.union(WindowInsets.ime))
         ) {
             client.AgentforceConversationContainer(
                 conversation = conversation,


### PR DESCRIPTION
## Summary
Fixes a navigation-bar-height gap between the text input box and the top of the soft keyboard in the Android Service Agent conversation overlay.

## Root cause
`ConversationOverlayContent`'s `Box` padded its bottom with `.navigationBarsPadding()` followed by `.imePadding()`. These modifiers are **additive**. When the keyboard is open, the IME inset already extends to the screen bottom (subsuming the navigation-bar region), so chaining both pushed content up by `navBar + ime`, while the keyboard top sits only `ime` above the bottom — leaving a nav-bar-height gap between the input box and the keyboard. With the keyboard hidden (`ime == 0`) only `navBar` applied, which is why the gap only appeared while typing.

## Fix
Pad the bottom by the **union (max)** of the two insets instead of their sum:

```kotlin
.windowInsetsPadding(WindowInsets.navigationBars.union(WindowInsets.ime))
```

The union resolves to `ime` while the keyboard is visible (eliminating the gap) and to `navBar` when it is hidden, preserving correct spacing in both states. Single-file change in `AgentforceConversationOverlay.kt`.

## Testing
- `:react-native-agentforce:compileDebugKotlin` — BUILD SUCCESSFUL
- `:react-native-agentforce:testDebugUnitTest` — 15 tests, 0 failures (no regressions)
- A JVM regression test was intentionally **not** added: this module has only JUnit + MockK (`unitTests.returnDefaultValues = true`) and no Robolectric / `compose-ui-test` harness, so window-inset behavior is not exercisable in a unit test. The change should be verified manually: open the Service Agent conversation on Android, focus the message input, raise the keyboard, and confirm the input box sits flush on top of the keyboard with no gap.

Work Link: [W-22724903](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-22724903)

🤖 Drafted by the ADLC bug-to-draft-PR pipeline. Opened as a DRAFT for human review.