### PR TITLE
@W-23161348 Bump Agentforce SDK to 262.0 on both platforms

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/build.gradle
+++ b/AgentforceSDK-ReactNative-Bridge/android/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdkVersion 29
+        minSdkVersion 30
         targetSdkVersion 36
         versionCode 1
         versionName "1.0"
@@ -48,6 +48,11 @@ repositories {
     mavenCentral()
     maven { url 'https://jitpack.io' }
     maven { url 'https://opensource.salesforce.com/AgentforceMobileSDK-Android/agentforce-sdk-repository' }
+    // SharedUI design-system library: agentforce-sdk 15.66.2 (262.0) pulls in
+    // com.salesforce.android.sharedui:shared-ui transitively from this repo.
+    maven { url 'https://opensource.salesforce.com/SharedUI-Android/shared-ui-repository' }
+    // SLDSIcons: shared-ui depends transitively on com.salesforce.android.sldsicons:slds-icons.
+    maven { url 'https://opensource.salesforce.com/SLDSIcons-Android/slds-icons-repository' }
     maven { url 'https://s3.amazonaws.com/inapp.salesforce.com/public/android' }
     maven { url 'https://s3.amazonaws.com/salesforce-async-messaging-experimental/public/android' }
 }
@@ -55,8 +60,12 @@ repositories {
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
     implementation "com.facebook.react:react-android"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk:15.20.3"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk-voice:15.20.3"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk:15.66.2"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk-voice:15.66.2"
+    // shared-ui 2.0.21 pins slds-icons 0.1.0, which was never published to the
+    // public SLDSIcons Maven repo (only 0.1.7 is). Pin the available version so
+    // the transitive request resolves. Remove once shared-ui repins to a published tag.
+    api "com.salesforce.android.sldsicons:slds-icons:0.1.7"
     // compileOnly: host app adds this for Employee Agent. Bridge compiles; host provides at runtime.
     compileOnly "com.salesforce.mobilesdk:SalesforceReact:13.1.1"
 

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
@@ -207,7 +207,6 @@ private fun ConversationOverlayContent(onClose: () -> Unit) {
                 // (host screen bleed-through); after graphicsLayer so it slides on hide.
                 .background(surfaceColor)
                 .statusBarsPadding()
-                .padding(top = 12.dp)
                 .navigationBarsPadding()
                 .imePadding()
         ) {

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -172,7 +172,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     ServiceUISettings(
                         downloadTranscript = raw["downloadTranscript"] ?: true,
                         endConversation = raw["endConversation"] ?: true,
-                        enableLightingType = raw["enableLightningType"] ?: false
+                        clearChat = raw["clearChat"] ?: false
                     )
                 } ?: ServiceUISettings()
 

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNavigation.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNavigation.kt
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.salesforce.android.mobile.interfaces.navigation.Navigation
+import com.salesforce.android.mobile.interfaces.navigation.NavigationTarget
 import com.salesforce.android.mobile.interfaces.navigation.destination.App
 import com.salesforce.android.mobile.interfaces.navigation.destination.Destination
 import com.salesforce.android.mobile.interfaces.navigation.destination.Link
@@ -39,6 +40,14 @@ class BridgeNavigation(private val reactContext: ReactContext) : Navigation {
     }
 
     override fun goto(destination: Destination, replace: Boolean) {
+        if (!forwardingEnabled) return
+        emitDestination(destination, replace = replace)
+    }
+
+    // SDK 262.0 added a target-aware overload. The bridge surfaces a single
+    // navigation event to JS and does not distinguish targets, so forward the
+    // destination using the same emit path (honoring replace).
+    override fun goto(destination: Destination, target: NavigationTarget, replace: Boolean) {
         if (!forwardingEnabled) return
         emitDestination(destination, replace = replace)
     }

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeTopAppBarBuilder.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeTopAppBarBuilder.kt
@@ -100,7 +100,7 @@ private fun ClientLabelTopBar(label: String, state: TopAppBarState) {
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(min = 56.dp)
-                .background(colors.chatHeaderBackground)
+                .background(colors.titleBarBackground)
                 .padding(horizontal = 16.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -201,7 +201,6 @@ class AgentforceModule: RCTEventEmitter {
                 useWelcomeUtterances: raw["useWelcomeUtterances"] ?? false,
                 showQueueStatus: raw["showQueueStatus"] ?? true,
                 enableVideoUpload: raw["enableVideoUpload"] ?? false,
-                enableLightningType: raw["enableLightningType"] ?? false,
                 secureForms: raw["secureForms"] ?? true,
                 enableAudioUpload: raw["enableAudioUpload"] ?? false
             )

--- a/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
+++ b/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
@@ -34,7 +34,10 @@ Pod::Spec.new do |s|
     ]
     core.dependency "React-Core"
     core.dependency "AgentforceSDK"
-    core.dependency "AgentforceVoice", "1.1.3"
+    core.dependency "AgentforceVoice", "2.1.7"
+    # AgentforceSDK 15.33.3 (262.0) publicly imports the SharedUI module but
+    # omits it from its podspec; declare it so this target can resolve it.
+    core.dependency "SharedUI", "1.3.1"
   end
 
   # Optional: add for Employee Agent auth (OAuth via Salesforce Mobile SDK).

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,8 @@
 buildscript {
     ext {
         compileSdk = 36
-        minSdkVersion = 29
+        // agentforce-sdk-voice 15.66.2 (262.0) requires minSdk 30.
+        minSdkVersion = 30
         targetSdkVersion = 35
         kotlin_version = '2.2.0'
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
@@ -40,6 +41,10 @@ allprojects {
         // Required for AgentforceSDK
         maven { url('https://jitpack.io') }
         maven { url('https://opensource.salesforce.com/AgentforceMobileSDK-Android/agentforce-sdk-repository') }
+        // SharedUI design-system library pulled transitively by agentforce-sdk 15.66.2 (262.0)
+        maven { url('https://opensource.salesforce.com/SharedUI-Android/shared-ui-repository') }
+        // SLDSIcons: shared-ui depends transitively on com.salesforce.android.sldsicons:slds-icons
+        maven { url('https://opensource.salesforce.com/SLDSIcons-Android/slds-icons-repository') }
         maven { url("https://s3.amazonaws.com/inapp.salesforce.com/public/android") }
         maven { url('https://s3.amazonaws.com/salesforce-async-messaging-experimental/public/android') }
     }

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -16,12 +16,19 @@ def shared_pods
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'AgentforceSDK', '15.11.7'
-  pod 'AgentforceVoice', '1.1.3'
+  pod 'AgentforceSDK', '15.33.3'
+  pod 'AgentforceVoice', '2.1.7'
   pod 'Messaging-InApp-Core', '> 1.10.0'
 
   # JWTKit is required by AgentforceService but not resolved automatically
   pod 'JWTKit'
+
+  # SharedUI provides the design-system module (Colors/Fonts/Dimensions) that
+  # AgentforceSDK 15.33.3 (262.0) publicly imports but does not declare in its
+  # podspec. Pin to the flat spec the iOS SDK ships with; SLDSIcons is held at
+  # 1.2.2 to avoid the "Multiple commands produce SLDSIcons.framework" collision.
+  pod 'SharedUI', '1.3.1'
+  pod 'SLDSIcons', '1.2.2'
 
   # LiveKit is needed for both Service and Employee agents
   pod 'LiveKitClient' # Required so CocoaPods looks in the correct source location


### PR DESCRIPTION
## Summary

Bumps the React Native bridge-layer Agentforce SDK pins to the **262.0 external release** on both platforms and adapts the bridge to its breaking changes.

**Work item:** W-23161348

### Version bumps
| Platform | Dependency | From | To |
|----------|-----------|------|----|
| iOS | AgentforceSDK | 15.11.7 | 15.33.3 |
| iOS | AgentforceVoice | 1.1.3 | 2.1.7 |
| Android | agentforce-sdk | 15.20.3 | 15.66.2 |
| Android | agentforce-sdk-voice | 15.20.3 | 15.66.2 |

### 262.0 integration changes
- **SharedUI design-system module** — 262.0 publicly imports `SharedUI` (Colors/Fonts/Dimensions) but does not declare it.
  - iOS: add `pod 'SharedUI', '1.3.1'` + pinned `SLDSIcons 1.2.2` (mirrors the iOS SDK's own Podfile, which holds SLDSIcons at 1.2.2 to avoid the "Multiple commands produce SLDSIcons.framework" collision), and declare `SharedUI` in the bridge podspec so the `ReactNativeAgentforce` target can resolve the module.
  - Android: add the `SharedUI-Android` and `SLDSIcons-Android` Maven repos. `shared-ui 2.0.21` transitively pins `slds-icons 0.1.0`, which was never published to the public Maven repo (only `0.1.7` is), so pin the available `0.1.7`.
- **`ServiceUISettings`** — `enableLightningType` was removed. Dropped on iOS; Android replaces it with the new `clearChat` option.
- **`Navigation`** — implement the new `goto(destination, target, replace)` overload added to the SDK Navigation interface.
- **Theme** — `chatHeaderBackground` renamed to `titleBarBackground`.
- **minSdk** — `agentforce-sdk-voice 15.66.2` requires `minSdk 30` (was 29).

This PR also carries the conversation-overlay top-padding tweak that was in flight on `dev`.

### Verification
- ✅ All four variants build: iOS/Android × Service/Employee
- ✅ `npm run typecheck` (0 errors)
- ✅ `npm run lint` (0 errors)
- ✅ `npm run format` (Prettier clean)