### PR TITLE
@W-23175731 Enable voice for Service Agents (262.0)

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -992,8 +992,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         employeeAgentFactory = AgentforceVoiceProviderFactory(),
         serviceAgentConfig = ServiceAgentVoiceConfig(
             extension = MultimediaExtension,
+            // 3rd ctor arg (instrumentationHandler) defaults to null; omit it.
             factory = MiawVoiceProviderFactory { _, conversationClientProvider, multimediaClient ->
-                MiawVoiceProvider(conversationClientProvider, multimediaClient, null)
+                MiawVoiceProvider(conversationClientProvider, multimediaClient)
             }
         )
     )

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -25,10 +25,14 @@ import com.salesforce.android.agentforcesdkimpl.AgentforceClient
 import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceConfiguration
 import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceMode
 import com.salesforce.android.agentforcesdkimpl.configuration.ServiceAgentConfiguration
+import com.salesforce.android.agentforcesdkimpl.configuration.ServiceAgentVoiceConfig
 import com.salesforce.android.agentforcesdkimpl.configuration.ServiceUISettings
 import com.salesforce.android.agentforcesdkimpl.utils.AgentforceFeatureFlagSettings
 import com.salesforce.android.agentforcesdkvoice.AgentforceVoiceProviderFactory
 import com.salesforce.android.agentforcesdkvoice.AgentforceVoiceUIProvider
+import com.salesforce.android.agentforcesdkvoice.miaw.MiawVoiceProvider
+import com.salesforce.android.agentforceservice.voice.MiawVoiceProviderFactory
+import com.salesforce.android.smi.multimedia.core.MultimediaExtension
 import com.salesforce.android.agentforceservice.conversationservice.data.CopilotContextVariable
 import com.salesforce.android.agentforceservice.conversationservice.data.CopilotAdditionalContext
 import com.salesforce.android.reactagentforce.models.AgentMode as LocalAgentMode
@@ -185,12 +189,15 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     )
                     .setServiceUISettings(uiSettings)
                     .build()
+                // Voice shipped for Service Agents in 262.0 (MIAW). Honor the
+                // enableVoice flag like the Employee path; the MIAW voice provider is
+                // registered below via setBridgeVoiceModule().
                 val flags = getFeatureFlagsFromConfigOrPrefs(config)
                 val featureFlagSettings = AgentforceFeatureFlagSettings.builder()
                     .enableMultiAgent(flags.enableMultiAgent)
                     .enableMultiModalInput(flags.enableMultiModalInput)
                     .enablePDFUpload(flags.enablePDFUpload)
-                    .enableVoice(false)
+                    .enableVoice(flags.enableVoice)
                     .build()
 
                 val cameraUriProvider = AgentforceClientCameraUriProvider(reactApplicationContext.applicationContext)
@@ -207,7 +214,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     .setLogger(bridgeLogger)
                     .setNavigation(bridgeNavigation)
                 agentforceConfigBuilder.setPermission(permissions)
-                agentforceConfigBuilder.setAgentforceVoiceModule(AgentforceVoiceProviderFactory(), AgentforceVoiceUIProvider())
+                agentforceConfigBuilder.setBridgeVoiceModule()
                 // Always attach bridgeViewProvider so late registrations take effect.
                 // canHandle() returns false when the map is empty, matching no-provider behavior.
                 agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
@@ -361,7 +368,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                         )
                     )
                 agentforceConfigBuilder.setPermission(permissions)
-                agentforceConfigBuilder.setAgentforceVoiceModule(AgentforceVoiceProviderFactory(), AgentforceVoiceUIProvider())
+                agentforceConfigBuilder.setBridgeVoiceModule()
                 // Always attach bridgeViewProvider so late registrations take effect.
                 // canHandle() returns false when the map is empty, matching no-provider behavior.
                 agentforceConfigBuilder.setViewProvider(bridgeViewProvider)
@@ -968,6 +975,28 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             false
         }
     }
+
+    /**
+     * Registers voice with the SDK config builder using the non-deprecated
+     * [AgentforceConfiguration.Builder.setVoiceModule] entry point. Wires both:
+     *  - Employee Agent voice (LiveKit) via [AgentforceVoiceProviderFactory]
+     *  - Service Agent voice (MIAW) via [ServiceAgentVoiceConfig] — new in 262.0.
+     *
+     * Both modes share the same [AgentforceVoiceUIProvider]. The MIAW multimedia
+     * stack ([MultimediaExtension]) is provided transitively by `agentforce-sdk-voice`.
+     * Whether voice actually surfaces is still gated by the `enableVoice` feature flag
+     * and the backend advertising voice support for the conversation.
+     */
+    private fun AgentforceConfiguration.Builder.setBridgeVoiceModule() = setVoiceModule(
+        uiProvider = AgentforceVoiceUIProvider(),
+        employeeAgentFactory = AgentforceVoiceProviderFactory(),
+        serviceAgentConfig = ServiceAgentVoiceConfig(
+            extension = MultimediaExtension,
+            factory = MiawVoiceProviderFactory { _, conversationClientProvider, multimediaClient ->
+                MiawVoiceProvider(conversationClientProvider, multimediaClient, null)
+            }
+        )
+    )
 
     private fun ensureViewModel() {
         if (viewModel == null) {

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -976,29 +976,6 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         }
     }
 
-    /**
-     * Registers voice with the SDK config builder using the non-deprecated
-     * [AgentforceConfiguration.Builder.setVoiceModule] entry point. Wires both:
-     *  - Employee Agent voice (LiveKit) via [AgentforceVoiceProviderFactory]
-     *  - Service Agent voice (MIAW) via [ServiceAgentVoiceConfig] — new in 262.0.
-     *
-     * Both modes share the same [AgentforceVoiceUIProvider]. The MIAW multimedia
-     * stack ([MultimediaExtension]) is provided transitively by `agentforce-sdk-voice`.
-     * Whether voice actually surfaces is still gated by the `enableVoice` feature flag
-     * and the backend advertising voice support for the conversation.
-     */
-    private fun AgentforceConfiguration.Builder.setBridgeVoiceModule() = setVoiceModule(
-        uiProvider = AgentforceVoiceUIProvider(),
-        employeeAgentFactory = AgentforceVoiceProviderFactory(),
-        serviceAgentConfig = ServiceAgentVoiceConfig(
-            extension = MultimediaExtension,
-            // 3rd ctor arg (instrumentationHandler) defaults to null; omit it.
-            factory = MiawVoiceProviderFactory { _, conversationClientProvider, multimediaClient ->
-                MiawVoiceProvider(conversationClientProvider, multimediaClient)
-            }
-        )
-    )
-
     private fun ensureViewModel() {
         if (viewModel == null) {
             val activity = currentActivity
@@ -1021,3 +998,30 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
 
     // endregion
 }
+
+/**
+ * Registers voice with the SDK config builder using the non-deprecated
+ * [AgentforceConfiguration.Builder.setVoiceModule] entry point. Wires both:
+ *  - Employee Agent voice (LiveKit) via [AgentforceVoiceProviderFactory]
+ *  - Service Agent voice (MIAW) via [ServiceAgentVoiceConfig] — new in 262.0.
+ *
+ * Both modes share the same [AgentforceVoiceUIProvider]. The MIAW multimedia
+ * stack ([MultimediaExtension]) is provided transitively by `agentforce-sdk-voice`.
+ * Whether voice actually surfaces is still gated by the `enableVoice` feature flag
+ * and the backend advertising voice support for the conversation.
+ *
+ * Top-level `internal` (not a private member) so both [AgentforceModule] and the
+ * legacy [ServiceAgentViewModel] path register voice identically — one definition,
+ * no drift when the SDK `setVoiceModule` signature next changes.
+ */
+internal fun AgentforceConfiguration.Builder.setBridgeVoiceModule() = setVoiceModule(
+    uiProvider = AgentforceVoiceUIProvider(),
+    employeeAgentFactory = AgentforceVoiceProviderFactory(),
+    serviceAgentConfig = ServiceAgentVoiceConfig(
+        extension = MultimediaExtension,
+        // 3rd ctor arg (instrumentationHandler) defaults to null; omit it.
+        factory = MiawVoiceProviderFactory { _, conversationClientProvider, multimediaClient ->
+            MiawVoiceProvider(conversationClientProvider, multimediaClient)
+        }
+    )
+)

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/ServiceAgentViewModel.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/ServiceAgentViewModel.kt
@@ -15,15 +15,9 @@ import com.salesforce.android.agentforcesdkimpl.AgentforceConversation
 import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceConfiguration
 import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceMode
 import com.salesforce.android.agentforcesdkimpl.configuration.ServiceAgentConfiguration
-import com.salesforce.android.agentforcesdkimpl.configuration.ServiceAgentVoiceConfig
 import com.salesforce.android.agentforcesdkimpl.utils.AgentforceFeatureFlagSettings
-import com.salesforce.android.agentforcesdkvoice.AgentforceVoiceProviderFactory
-import com.salesforce.android.agentforcesdkvoice.AgentforceVoiceUIProvider
-import com.salesforce.android.agentforcesdkvoice.miaw.MiawVoiceProvider
 import com.salesforce.android.agentforceservice.AgentforceAuthCredentialProvider
 import com.salesforce.android.agentforceservice.AgentforceAuthCredentials
-import com.salesforce.android.agentforceservice.voice.MiawVoiceProviderFactory
-import com.salesforce.android.smi.multimedia.core.MultimediaExtension
 import com.salesforce.android.mobile.interfaces.user.Org
 import com.salesforce.android.mobile.interfaces.user.User
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -218,17 +212,9 @@ class ServiceAgentViewModel(application: Application) : AndroidViewModel(applica
                         .setCameraUriProvider(cameraUriProvider)
                         // Register Employee (LiveKit) + Service (MIAW) voice providers so
                         // service voice works when enableVoice is on. New in 262.0.
-                        .setVoiceModule(
-                            uiProvider = AgentforceVoiceUIProvider(),
-                            employeeAgentFactory = AgentforceVoiceProviderFactory(),
-                            serviceAgentConfig = ServiceAgentVoiceConfig(
-                                extension = MultimediaExtension,
-                                // 3rd ctor arg (instrumentationHandler) defaults to null; omit it.
-                                factory = MiawVoiceProviderFactory { _, conversationClientProvider, multimediaClient ->
-                                    MiawVoiceProvider(conversationClientProvider, multimediaClient)
-                                }
-                            )
-                        )
+                        // Shared with AgentforceModule via setBridgeVoiceModule() so the
+                        // two paths can't drift.
+                        .setBridgeVoiceModule()
                         .build()
                 )
 

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/ServiceAgentViewModel.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/ServiceAgentViewModel.kt
@@ -223,8 +223,9 @@ class ServiceAgentViewModel(application: Application) : AndroidViewModel(applica
                             employeeAgentFactory = AgentforceVoiceProviderFactory(),
                             serviceAgentConfig = ServiceAgentVoiceConfig(
                                 extension = MultimediaExtension,
+                                // 3rd ctor arg (instrumentationHandler) defaults to null; omit it.
                                 factory = MiawVoiceProviderFactory { _, conversationClientProvider, multimediaClient ->
-                                    MiawVoiceProvider(conversationClientProvider, multimediaClient, null)
+                                    MiawVoiceProvider(conversationClientProvider, multimediaClient)
                                 }
                             )
                         )

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/ServiceAgentViewModel.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/ServiceAgentViewModel.kt
@@ -15,9 +15,15 @@ import com.salesforce.android.agentforcesdkimpl.AgentforceConversation
 import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceConfiguration
 import com.salesforce.android.agentforcesdkimpl.configuration.AgentforceMode
 import com.salesforce.android.agentforcesdkimpl.configuration.ServiceAgentConfiguration
+import com.salesforce.android.agentforcesdkimpl.configuration.ServiceAgentVoiceConfig
 import com.salesforce.android.agentforcesdkimpl.utils.AgentforceFeatureFlagSettings
+import com.salesforce.android.agentforcesdkvoice.AgentforceVoiceProviderFactory
+import com.salesforce.android.agentforcesdkvoice.AgentforceVoiceUIProvider
+import com.salesforce.android.agentforcesdkvoice.miaw.MiawVoiceProvider
 import com.salesforce.android.agentforceservice.AgentforceAuthCredentialProvider
 import com.salesforce.android.agentforceservice.AgentforceAuthCredentials
+import com.salesforce.android.agentforceservice.voice.MiawVoiceProviderFactory
+import com.salesforce.android.smi.multimedia.core.MultimediaExtension
 import com.salesforce.android.mobile.interfaces.user.Org
 import com.salesforce.android.mobile.interfaces.user.User
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -181,7 +187,8 @@ class ServiceAgentViewModel(application: Application) : AndroidViewModel(applica
                     .enableMultiAgent(featureFlagsPrefs.getBoolean(KEY_ENABLE_MULTI_AGENT, true))
                     .enableMultiModalInput(featureFlagsPrefs.getBoolean(KEY_ENABLE_MULTI_MODAL_INPUT, false))
                     .enablePDFUpload(featureFlagsPrefs.getBoolean(KEY_ENABLE_PDF_UPLOAD, false))
-                    .enableVoice(false) // Voice off for Service Agent
+                    // Voice shipped for Service Agents in 262.0 (MIAW); honor the flag.
+                    .enableVoice(featureFlagsPrefs.getBoolean(KEY_ENABLE_VOICE, false))
                     .build()
 
                 val cameraUriProvider = AgentforceClientCameraUriProvider(getApplication())
@@ -209,6 +216,18 @@ class ServiceAgentViewModel(application: Application) : AndroidViewModel(applica
                         .setApplication(getApplication())
                         .setFeatureFlagSettings(featureFlagSettings)
                         .setCameraUriProvider(cameraUriProvider)
+                        // Register Employee (LiveKit) + Service (MIAW) voice providers so
+                        // service voice works when enableVoice is on. New in 262.0.
+                        .setVoiceModule(
+                            uiProvider = AgentforceVoiceUIProvider(),
+                            employeeAgentFactory = AgentforceVoiceProviderFactory(),
+                            serviceAgentConfig = ServiceAgentVoiceConfig(
+                                extension = MultimediaExtension,
+                                factory = MiawVoiceProviderFactory { _, conversationClientProvider, multimediaClient ->
+                                    MiawVoiceProvider(conversationClientProvider, multimediaClient, null)
+                                }
+                            )
+                        )
                         .build()
                 )
 

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -211,6 +211,21 @@ class AgentforceModule: RCTEventEmitter {
             )
         }
 
+        // Voice shipped for Service Agents in 262.0. Mirror the Employee path and
+        // thread the enableVoice flag through; the SDK wires the voice stack
+        // (LiveKit/MIAW) internally once the flag is on. shouldBlockMicrophone stays
+        // false so the mic isn't gated; other public flags carry through too.
+        let flags = getFeatureFlagsFromConfigOrUserDefaults(configDict)
+        let featureFlagSettings = AgentforceFeatureFlagSettings(
+            enableMultiModalInput: flags.enableMultiModalInput,
+            enablePDFFileUpload: flags.enablePDFUpload,
+            multiAgent: flags.enableMultiAgent,
+            shouldBlockMicrophone: false,
+            enableVoice: flags.enableVoice,
+            enableOnboarding: false,
+            internalFlags: [:]
+        )
+
         // Use .serviceAgent() mode with overrides for logger and navigation.
         let serviceConfig = ServiceAgentConfiguration(
             esDeveloperName: config.esDeveloperName,
@@ -219,6 +234,7 @@ class AgentforceModule: RCTEventEmitter {
             serviceUISettings: uiSettings,
             forceConfigEndPoint: config.serviceApiURL
         )
+        .withFeatureFlags(featureFlagSettings)
         .withLogger(bridgeLogger)
         .withNavigation(bridgeNavigation)
 

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -7,6 +7,10 @@ require File.join(File.dirname(`node --print "require.resolve('react-native/pack
 def shared_pods
   source 'https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs.git'
   source 'https://github.com/livekit/podspecs.git'
+  # Hosts the Messaging-Multimedia-Core podspec (vends SMIMultimediaCore.framework).
+  # Not mirrored on the CDN, so the source must be declared explicitly for the
+  # AgentforceVoice service-voice multimedia dependency to resolve.
+  source 'https://github.com/Salesforce-Async-Messaging/podspecs.git'
   source 'https://cdn.cocoapods.org/'
 
   $config = use_native_modules!
@@ -19,6 +23,15 @@ def shared_pods
   pod 'AgentforceSDK', '15.33.3'
   pod 'AgentforceVoice', '2.1.7'
   pod 'Messaging-InApp-Core', '> 1.10.0'
+  # Messaging-Multimedia-Core vends SMIMultimediaCore.framework, which
+  # AgentforceVoice 2.1.7 links at runtime (@rpath/SMIMultimediaCore.framework).
+  # The AgentforceVoice podspec resolved from this Specs source declares only
+  # AgentforceService/SalesforceLogging/SalesforceNetwork (not the Binary subspec
+  # that the iOS SDK uses), so this transitive multimedia dep isn't pulled in and
+  # the framework is never embedded — surfacing as a dyld "Library not loaded"
+  # crash once Service Agent voice is enabled. Declare it explicitly so it's
+  # installed and embedded. Same > 1.10.0 constraint as the sibling pods (→ 1.11.2).
+  pod 'Messaging-Multimedia-Core', '> 1.10.0'
 
   # JWTKit is required by AgentforceService but not resolved automatically
   pod 'JWTKit'
@@ -30,8 +43,12 @@ def shared_pods
   pod 'SharedUI', '1.3.1'
   pod 'SLDSIcons', '1.2.2'
 
-  # LiveKit is needed for both Service and Employee agents
-  pod 'LiveKitClient' # Required so CocoaPods looks in the correct source location
+  # LiveKit is needed for both Service and Employee agents.
+  # Pin to 2.11.0 (matches the iOS SDK lock): it pins LiveKitWebRTC 137.7151.10,
+  # which is the same version Messaging-Multimedia-Core 1.11.2 requires. Leaving
+  # it unpinned floats to 2.14.1 (WebRTC 144.x) and collides with the multimedia
+  # pod added for Service Agent voice.
+  pod 'LiveKitClient', '2.11.0' # Required so CocoaPods looks in the correct source location
 
   # AgentforceService links to Crypto.framework at runtime; SwiftCrypto provides it (avoids dyld "Library not loaded: Crypto.framework").
   pod 'SwiftCrypto', '~> 3.15'

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -31,12 +31,14 @@ def shared_pods
   # the framework is never embedded — surfacing as a dyld "Library not loaded"
   # crash once Service Agent voice is enabled. Declare it explicitly so it's
   # installed and embedded.
-  # Constrained to ~> 1.11 (not the looser '> 1.10.0' the siblings use): every
-  # 1.11.x pins LiveKitWebRTC 137.7151.10, the exact version the LiveKitClient
-  # '2.11.0' pin below targets. A future 1.12+/2.x could pull a different
+  # Constrained to ~> 1.11.0 (i.e. >= 1.11.0, < 1.12.0 — not the looser
+  # '> 1.10.0' the siblings use, nor '~> 1.11' which would still admit 1.12+):
+  # every 1.11.x pins LiveKitWebRTC 137.7151.10, the exact version the
+  # LiveKitClient '2.11.0' pin below targets. A 1.12+/2.x could pull a different
   # LiveKitWebRTC and reintroduce the collision the LiveKit pin exists to prevent,
-  # so the two coupled pods are kept moving together deliberately.
-  pod 'Messaging-Multimedia-Core', '~> 1.11'
+  # so the two coupled pods are kept on the same minor line deliberately; bumping
+  # past 1.11.x should be a conscious act made alongside the LiveKit pin.
+  pod 'Messaging-Multimedia-Core', '~> 1.11.0'
 
   # JWTKit is required by AgentforceService but not resolved automatically
   pod 'JWTKit'

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -30,8 +30,13 @@ def shared_pods
   # that the iOS SDK uses), so this transitive multimedia dep isn't pulled in and
   # the framework is never embedded — surfacing as a dyld "Library not loaded"
   # crash once Service Agent voice is enabled. Declare it explicitly so it's
-  # installed and embedded. Same > 1.10.0 constraint as the sibling pods (→ 1.11.2).
-  pod 'Messaging-Multimedia-Core', '> 1.10.0'
+  # installed and embedded.
+  # Constrained to ~> 1.11 (not the looser '> 1.10.0' the siblings use): every
+  # 1.11.x pins LiveKitWebRTC 137.7151.10, the exact version the LiveKitClient
+  # '2.11.0' pin below targets. A future 1.12+/2.x could pull a different
+  # LiveKitWebRTC and reintroduce the collision the LiveKit pin exists to prevent,
+  # so the two coupled pods are kept moving together deliberately.
+  pod 'Messaging-Multimedia-Core', '~> 1.11'
 
   # JWTKit is required by AgentforceService but not resolved automatically
   pod 'JWTKit'


### PR DESCRIPTION
## Summary

Voice shipped for **Service Agents** in the 262.0 SDK release. The bridge was hard-disabling voice on the service-agent path on both platforms. This PR threads the `enableVoice` feature flag through to the service path and registers the new service voice provider, so toggling **Voice** in the Feature Flags screen now enables it for service agents (subject to backend support for the conversation).

**Work item:** W-23175731 (follows #110, the 262.0 SDK bump)

## Changes

### iOS — `AgentforceModule.swift`
- `configureServiceAgent` now builds `AgentforceFeatureFlagSettings(enableVoice: flags.enableVoice, …)` and applies it via `ServiceAgentConfiguration.withFeatureFlags(...)`, mirroring the Employee path. The SDK wires the voice stack (LiveKit/MIAW) internally once the flag is on.

### Android
- **`AgentforceModule.kt`**: stop forcing `enableVoice(false)` on the service path. Add `setBridgeVoiceModule()`, which registers **both** the Employee (LiveKit) and Service (MIAW) voice providers through the non-deprecated `AgentforceConfiguration.Builder.setVoiceModule(uiProvider, employeeAgentFactory, serviceAgentConfig)` — new in 262.0 — and use it on both the service and employee config paths (replacing the deprecated `setAgentforceVoiceModule`).
- **`ServiceAgentViewModel.kt`** (legacy/backward-compat path): honor the stored `enableVoice` flag and register the same voice module.

The Service Agent (MIAW) voice config uses `ServiceAgentVoiceConfig(extension = MultimediaExtension, factory = MiawVoiceProviderFactory { … MiawVoiceProvider(…) })`. MIAW multimedia (`messaging-inapp-multimedia-core`) resolves transitively from `agentforce-sdk-voice` — no new Maven repo required.

### No JS changes
The JS/TS types, `AgentforceService.configure()`, and the Feature Flags toggle already thread `enableVoice` uniformly across service and employee.

## Permissions
- Android `RECORD_AUDIO` — already declared in the app manifest.
- iOS `NSMicrophoneUsageDescription` + `NSSpeechRecognitionUsageDescription` — already present in the ServiceAgent Info.plist; deployment target already iOS 17.

## Verification
- ✅ iOS Service + Employee — **BUILD SUCCEEDED**
- ✅ Android Service + Employee — **BUILD SUCCESSFUL**
- ✅ `npm run typecheck` (0 errors)
- ✅ `npm run lint` (0 errors)
- ✅ `npm run format` (Prettier clean)