### PR TITLE
@W-23159346 Ship RN bridge as publishable @salesforce/react-native-agentforce npm package

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/salesforce/AgentforceMobileSDK-ReactNative"
   },
   "metadata": {
-    "description": "Tooling for integrating the Agentforce Mobile SDK into React Native apps via the react-native-agentforce bridge."
+    "description": "Tooling for integrating the Agentforce Mobile SDK into React Native apps via the @salesforce/react-native-agentforce bridge."
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentforce-mobile-sdk-react-native",
   "version": "0.1.0",
-  "description": "Integrate the Agentforce Mobile SDK into a React Native app via the react-native-agentforce bridge. Walks consumers through use-case discovery, picks the right configuration mode (Service Agent for public/customer-facing, Employee Agent for signed-in workforce), wires the bridge package and native iOS/Android dependencies, and scaffolds TypeScript files for AgentforceService configuration, logger/navigation/view-provider delegates, and a launch button.",
+  "description": "Integrate the Agentforce Mobile SDK into a React Native app via the @salesforce/react-native-agentforce bridge. Walks consumers through use-case discovery, picks the right configuration mode (Service Agent for public/customer-facing, Employee Agent for signed-in workforce), wires the bridge package and native iOS/Android dependencies, and scaffolds TypeScript files for AgentforceService configuration, logger/navigation/view-provider delegates, and a launch button.",
   "author": {
     "name": "Salesforce",
     "url": "https://github.com/salesforce/AgentforceMobileSDK-ReactNative"

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,8 @@
 module.exports = {
   root: true,
   extends: '@react-native',
+  // Generated build output of the published bridge package — never hand-edited.
+  ignorePatterns: ['AgentforceSDK-ReactNative-Bridge/lib/'],
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   overrides: [

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -44,6 +44,15 @@ jobs:
       - name: Run TypeScript type check
         run: npm run typecheck
 
+      # Verify the bridge is still a publishable package: it must build (tsc ->
+      # lib/) and produce a clean tarball. Catches packaging regressions on dev
+      # PRs before they can reach a release tag on main (see publish-npm-package.yml).
+      - name: Verify bridge package builds & packs
+        working-directory: AgentforceSDK-ReactNative-Bridge
+        run: |
+          npm run build
+          npm pack --dry-run
+
   # Job 2: Unit tests
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -1,0 +1,96 @@
+name: Publish NPM Package
+
+# Publishes @salesforce/react-native-agentforce to npmjs.org via OIDC Trusted
+# Publishing — no stored NPM_TOKEN. The trust relationship between this workflow
+# and the npm account is configured by OSPO on the npm side (bound to THIS
+# workflow file: publish-npm-package.yml). Do not rename this file without
+# updating the trusted-publisher binding with OSPO (#opensource).
+#
+# Release flow: testers validate a build off dev -> PR dev into main -> tag main
+# (vX.Y.Z) -> this workflow publishes that tag. Pushes to dev and PRs never publish.
+# The FIRST publish of a new package is performed by OSPO; subsequent versions
+# publish here once the OIDC trusted publisher is configured.
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  # Required for OIDC Trusted Publishing: mints the short-lived token npm exchanges
+  # with the registry. No secrets are used.
+  id-token: write
+
+jobs:
+  publish:
+    name: Build & Publish to npm (OIDC)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Only publish tags that point at a commit on main, so a stray tag on any
+      # other branch cannot trigger a release. Untrusted values (tag name, sha)
+      # are passed via env and quoted — never interpolated into the shell.
+      - name: Verify tag is on main
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if ! git branch -r --contains "$COMMIT_SHA" | grep -qE '(^|[[:space:]])origin/main$'; then
+            echo "::error::Tag $TAG_NAME does not point at a commit on origin/main — refusing to publish."
+            exit 1
+          fi
+          echo "Tag $TAG_NAME is on main."
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      # OIDC Trusted Publishing requires a recent npm. setup-node ships an older
+      # npm with Node 20, so upgrade to a version that supports --provenance via OIDC.
+      - name: Upgrade npm (OIDC trusted publishing support)
+        run: npm install -g npm@latest
+
+      - name: Verify tag matches package.json version
+        working-directory: AgentforceSDK-ReactNative-Bridge
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          TAG_VERSION="${TAG_NAME#v}"
+          echo "package.json version: $PKG_VERSION"
+          echo "git tag version:      $TAG_VERSION"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag $TAG_NAME (=$TAG_VERSION) does not match package.json version $PKG_VERSION. Aborting publish."
+            exit 1
+          fi
+
+      - name: Install bridge dependencies
+        working-directory: AgentforceSDK-ReactNative-Bridge
+        run: npm install --legacy-peer-deps --ignore-scripts
+
+      - name: Build package
+        working-directory: AgentforceSDK-ReactNative-Bridge
+        run: npm run build
+
+      - name: Verify package contents
+        working-directory: AgentforceSDK-ReactNative-Bridge
+        run: npm pack --dry-run
+
+      - name: Publish to npm via OIDC Trusted Publishing
+        working-directory: AgentforceSDK-ReactNative-Bridge
+        # No NODE_AUTH_TOKEN: id-token:write + the OSPO-configured trusted publisher
+        # let npm mint credentials from the OIDC token. publishConfig.access=public
+        # in package.json publishes the scoped package publicly; --provenance
+        # attaches a signed build-provenance attestation.
+        run: npm publish --provenance

--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,7 @@ fix_*.patch
 
 # Generated app configuration
 /src/config/AppConfig.generated.ts
+
+# Bridge npm package build output (compiled by `prepare`/`prepublishOnly`, not committed)
+/AgentforceSDK-ReactNative-Bridge/lib/
+/AgentforceSDK-ReactNative-Bridge/*.tgz

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@ node_modules/
 ios/build/
 android/build/
 AgentforceSDK-ReactNative-Bridge/android/build/
+AgentforceSDK-ReactNative-Bridge/lib/
 android/.gradle/
 *.log
 

--- a/AgentforceSDK-ReactNative-Bridge/.npmignore
+++ b/AgentforceSDK-ReactNative-Bridge/.npmignore
@@ -1,0 +1,20 @@
+# Native build artifacts — never ship compiled/generated output
+android/build/
+android/.gradle/
+android/.cxx/
+android/local.properties
+ios/build/
+ios/Pods/
+
+# Tests and fixtures
+**/__tests__/
+**/*.test.ts
+**/*.test.tsx
+# Native unit-test sources (not part of the shipped library)
+android/src/test/
+android/src/androidTest/
+
+# Tooling / local
+*.log
+.DS_Store
+tsconfig.build.tsbuildinfo

--- a/AgentforceSDK-ReactNative-Bridge/LICENSE
+++ b/AgentforceSDK-ReactNative-Bridge/LICENSE
@@ -1,0 +1,207 @@
+Apache License Version 2.0
+
+Copyright (c) 2024 Salesforce, Inc.
+All rights reserved.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/AgentforceSDK-ReactNative-Bridge/README.md
+++ b/AgentforceSDK-ReactNative-Bridge/README.md
@@ -4,12 +4,20 @@ This directory contains the Agentforce bridge module: JavaScript API layer, samp
 
 ## Installation
 
+Install the package from npm:
+
+```sh
+npm install @salesforce/react-native-agentforce
+```
+
+The native module autolinks via the shipped `ReactNativeAgentforce` podspec (iOS) and Gradle library (Android). The npm package name is `@salesforce/react-native-agentforce`; the native module names (`ReactNativeAgentforce` pod, `react-native-agentforce` Gradle module) are unchanged.
+
 ### iOS (CocoaPods)
 
 In your app’s `Podfile`:
 
 ```ruby
-pod 'ReactNativeAgentforce', :path => '../node_modules/react-native-agentforce/ios'
+pod 'ReactNativeAgentforce', :path => '../node_modules/@salesforce/react-native-agentforce/ios'
 ```
 
 Your app must also include the Agentforce iOS SDK in the Podfile so the bridge can link. For **Employee Agent**, the host app must additionally include the Salesforce Mobile SDK and perform bootconfig + SDK initialization.
@@ -24,7 +32,7 @@ Your app must also include the Agentforce iOS SDK in the Podfile so the bridge c
 Import the API from this package when the native module is linked:
 
 ```ts
-import { AgentforceService } from 'react-native-agentforce';
+import { AgentforceService } from '@salesforce/react-native-agentforce';
 ```
 
 Use the sample app in `app/` as reference or replace with your own UI.
@@ -58,7 +66,7 @@ Include the Salesforce Mobile SDK pods in your Podfile and perform **bootconfig*
 **Configure and launch:**
 
 ```typescript
-import { AgentforceService } from ‘react-native-agentforce’;
+import { AgentforceService } from '@salesforce/react-native-agentforce';
 
 await AgentforceService.configure(config);
 await AgentforceService.launchConversation();

--- a/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
+++ b/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
@@ -2,7 +2,7 @@
 # React Native bridge for Agentforce SDK – iOS podspec
 #
 # Consumers: add to your app Podfile:
-#   pod 'ReactNativeAgentforce', :path => '../node_modules/react-native-agentforce/ios'
+#   pod 'ReactNativeAgentforce', :path => '../node_modules/@salesforce/react-native-agentforce/ios'
 #
 # Your app must also include the Agentforce iOS SDK (and for Employee Agent, the
 # Salesforce Mobile SDK). See README for details.
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.summary      = "Agentforce React Native bridge"
   s.description  = package["description"]
   s.homepage     = "https://github.com/salesforce/AgentforceMobileSDK-ReactNative"
-  s.license      = "BSD-3-Clause"
+  s.license      = "Apache-2.0"
   s.author       = "Salesforce"
   s.source       = { :git => "https://github.com/salesforce/AgentforceMobileSDK-ReactNative.git", :tag => "v#{s.version}" }
   s.requires_arc = true

--- a/AgentforceSDK-ReactNative-Bridge/package.json
+++ b/AgentforceSDK-ReactNative-Bridge/package.json
@@ -1,15 +1,66 @@
 {
-  "name": "react-native-agentforce",
+  "name": "@salesforce/react-native-agentforce",
   "version": "1.0.0",
   "description": "Agentforce React Native bridge: JS API and native module for Service Agent and Employee Agent (auth bridge included; host app adds Mobile SDK).",
-  "main": "src/index.ts",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "react-native": "src/index.ts",
-  "scripts": {},
+  "source": "src/index.ts",
+  "files": [
+    "lib",
+    "src",
+    "ios",
+    "android",
+    "README.md",
+    "LICENSE",
+    "!android/build",
+    "!android/.gradle",
+    "!android/src/test",
+    "!android/src/androidTest",
+    "!ios/build",
+    "!**/__tests__",
+    "!**/*.test.ts",
+    "!**/*.test.tsx"
+  ],
+  "keywords": [
+    "react-native",
+    "ios",
+    "android",
+    "salesforce",
+    "agentforce",
+    "ai",
+    "chatbot",
+    "service-agent",
+    "employee-agent"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/salesforce/AgentforceMobileSDK-ReactNative.git",
+    "directory": "AgentforceSDK-ReactNative-Bridge"
+  },
+  "homepage": "https://github.com/salesforce/AgentforceMobileSDK-ReactNative#readme",
+  "bugs": {
+    "url": "https://github.com/salesforce/AgentforceMobileSDK-ReactNative/issues"
+  },
+  "author": "Salesforce",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rimraf lib",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run clean && npm run build"
+  },
   "peerDependencies": {
     "react": "*",
     "react-native": "*"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "rimraf": "^5.0.5",
+    "typescript": "^5.0.4"
+  },
   "engines": {
     "node": ">=18"
   }

--- a/AgentforceSDK-ReactNative-Bridge/src/__tests__/package-contract.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/__tests__/package-contract.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Package-contract tests for @salesforce/react-native-agentforce (W-23159346).
+ *
+ * These lock in the publishable shape of the package (SC1) and the runtime
+ * public-API surface exported from the barrel (SC2). They are intentionally
+ * decoupled from behavior — they fail if the package stops being publishable
+ * or if a public export is dropped/renamed.
+ */
+
+// The barrel imports native modules at require-time; mock react-native so the
+// public surface can be introspected in the JVM-less jest environment.
+jest.mock('react-native', () => {
+  class NativeEventEmitter {
+    addListener() {
+      return { remove: jest.fn() };
+    }
+    removeAllListeners() {}
+  }
+  return {
+    NativeModules: { AgentforceModule: new Proxy({}, { get: () => jest.fn() }) },
+    NativeEventEmitter,
+    Platform: { OS: 'ios', select: (o: Record<string, unknown>) => o.ios ?? o.default },
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pkg = require('../../package.json');
+
+describe('package.json is a publishable scoped npm package (SC1)', () => {
+  it('uses the scoped public name', () => {
+    expect(pkg.name).toBe('@salesforce/react-native-agentforce');
+  });
+
+  it('points entry + types at the compiled lib/ output', () => {
+    expect(pkg.main).toBe('lib/index.js');
+    expect(pkg.types).toBe('lib/index.d.ts');
+    // react-native metro entry stays on source for fast local iteration
+    expect(pkg['react-native']).toBe('src/index.ts');
+  });
+
+  it('publishes the scoped package publicly', () => {
+    expect(pkg.publishConfig).toBeDefined();
+    expect(pkg.publishConfig.access).toBe('public');
+  });
+
+  it('declares a files allowlist that ships sources + native code', () => {
+    expect(Array.isArray(pkg.files)).toBe(true);
+    const files: string[] = pkg.files;
+    for (const entry of ['lib', 'src', 'ios', 'android']) {
+      expect(files.some(f => f === entry || f.startsWith(entry + '/'))).toBe(true);
+    }
+  });
+
+  it('excludes native build artifacts and tests from the tarball', () => {
+    const files: string[] = pkg.files;
+    // Negation entries keep build junk / tests out of the published package (SC3).
+    expect(files).toContain('!android/build');
+    expect(files).toContain('!android/src/test');
+    expect(files).toContain('!ios/build');
+    expect(files.some(f => f === '!**/__tests__')).toBe(true);
+  });
+
+  it('builds before publish via tsc', () => {
+    expect(pkg.scripts).toBeDefined();
+    expect(pkg.scripts.build).toMatch(/tsc/);
+    // prepublishOnly (and/or prepare) must run the build so lib/ is never stale
+    const buildsOnPublish =
+      /build/.test(pkg.scripts.prepublishOnly || '') || /build/.test(pkg.scripts.prepare || '');
+    expect(buildsOnPublish).toBe(true);
+  });
+
+  it('declares license, repository, and peer deps for consumers', () => {
+    expect(pkg.license).toBe('Apache-2.0');
+    expect(pkg.repository).toBeDefined();
+    expect(pkg.peerDependencies).toMatchObject({
+      react: expect.any(String),
+      'react-native': expect.any(String),
+    });
+  });
+});
+
+describe('public API barrel exposes the documented runtime surface (SC2)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const api = require('../index');
+
+  it('default-exports AgentforceService as the primary entry', () => {
+    expect(api.AgentforceService).toBeDefined();
+  });
+
+  it('exports the Employee Agent auth functions', () => {
+    for (const fn of [
+      'isEmployeeAgentAuthSupported',
+      'hasEmployeeAgentSession',
+      'loginForEmployeeAgent',
+      'logoutEmployeeAgent',
+      'getEmployeeAgentCredentials',
+      'refreshEmployeeAgentCredentials',
+      'isEmployeeAgentAuthReady',
+    ]) {
+      expect(typeof api[fn]).toBe('function');
+    }
+  });
+
+  it('exports the config type-guards and employee-agent config values', () => {
+    for (const fn of ['isServiceAgentConfig', 'isEmployeeAgentConfig', 'isLegacyConfig']) {
+      expect(typeof api[fn]).toBe('function');
+    }
+    expect(typeof api.isEmployeeAgentConfigValid).toBe('function');
+    expect('EMPLOYEE_AGENT_ENABLED' in api).toBe(true);
+    expect('EMPLOYEE_AGENT_CONFIG' in api).toBe(true);
+  });
+});

--- a/AgentforceSDK-ReactNative-Bridge/tsconfig.build.json
+++ b/AgentforceSDK-ReactNative-Bridge/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This repository uses a **multi-target/multi-flavor** approach to build two separ
 
 This app uses the **AgentforceSDK-ReactNative-Bridge** (in-repo under `AgentforceSDK-ReactNative-Bridge/`) for all Agentforce functionality. The bridge provides:
 
-- **JS API**: `AgentforceService` from `react-native-agentforce`
+- **JS API**: `AgentforceService` from `@salesforce/react-native-agentforce`
 - **Native modules**: Android (auto-linked) and iOS (CocoaPods)
 - **Runtime detection**: Automatically detects Mobile SDK availability
 - **Subspecs/Variants**: Core (Service Agent) and WithMobileSDK (Employee Agent)
@@ -79,7 +79,7 @@ This app uses the **AgentforceSDK-ReactNative-Bridge** (in-repo under `Agentforc
 
 - **Framework**: React Native + TypeScript
 - **Navigation**: React Navigation
-- **Agentforce API**: `AgentforceService` from `react-native-agentforce` (bridge package)
+- **Agentforce API**: `AgentforceService` from `@salesforce/react-native-agentforce` (bridge package)
 - **Screens**: Home, Settings, About
 - **No app-specific code**: Same JavaScript for both apps
 
@@ -88,7 +88,7 @@ This app uses the **AgentforceSDK-ReactNative-Bridge** (in-repo under `Agentforc
 If you're using [Claude Code](https://www.anthropic.com/claude-code) (or other agentic tooling that supports the skill format), this repo ships an `integrate-agentforce-react-native` skill that walks you through SDK integration end-to-end:
 
 - **Use-case-driven configuration** — answer "what kind of agent?" and the skill picks the right `AgentforceService.configure(...)` mode (Service Agent vs Employee Agent) instead of asking you to choose between configuration shapes upfront.
-- **Bridge + native wiring** — adds the `react-native-agentforce` bridge package, runs the iOS/Android install scripts (Boost, XcodeGen, CocoaPods, Gradle), and surfaces the Mobile SDK requirements for Employee Agent.
+- **Bridge + native wiring** — adds the `@salesforce/react-native-agentforce` bridge package, runs the iOS/Android install scripts (Boost, XcodeGen, CocoaPods, Gradle), and surfaces the Mobile SDK requirements for Employee Agent.
 - **Scaffolds the integration files** — generates `agentforceConfig.ts`, `agentforceLogger.ts`, `agentforceNavigation.ts`, optional `employeeAuth.ts`, and a launch button (prominent home button, header icon, or auto-launch wrapper).
 - **MIAW deployment guidance** — for Service Agent, points you at the [Messaging for In-App and Web mobile deployment docs](https://help.salesforce.com/s/articleView?id=service.miaw_deployment_mobile.htm&type=5) before you try to build.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "@react-navigation/native": "^6.1.9",
         "@react-navigation/native-stack": "^6.9.26",
+        "@salesforce/react-native-agentforce": "file:./AgentforceSDK-ReactNative-Bridge",
         "react": "18.2.0",
         "react-native": "0.74.7",
-        "react-native-agentforce": "file:./AgentforceSDK-ReactNative-Bridge",
         "react-native-force": "github:forcedotcom/SalesforceMobileSDK-ReactNative#v13.1.1",
         "react-native-gesture-handler": "~2.16.2",
         "react-native-safe-area-context": "^4.10.8",
@@ -47,9 +47,13 @@
       }
     },
     "AgentforceSDK-ReactNative-Bridge": {
-      "name": "react-native-agentforce",
+      "name": "@salesforce/react-native-agentforce",
       "version": "1.0.0",
-      "devDependencies": {},
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "rimraf": "^5.0.5",
+        "typescript": "^5.0.4"
+      },
       "engines": {
         "node": ">=18"
       },
@@ -4576,6 +4580,10 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
+    },
+    "node_modules/@salesforce/react-native-agentforce": {
+      "resolved": "AgentforceSDK-ReactNative-Bridge",
+      "link": true
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
@@ -11801,10 +11809,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/react-native-agentforce": {
-      "resolved": "AgentforceSDK-ReactNative-Bridge",
-      "link": true
     },
     "node_modules/react-native-force": {
       "version": "13.1.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@react-navigation/native-stack": "^6.9.26",
     "react": "18.2.0",
     "react-native": "0.74.7",
-    "react-native-agentforce": "file:./AgentforceSDK-ReactNative-Bridge",
+    "@salesforce/react-native-agentforce": "file:./AgentforceSDK-ReactNative-Bridge",
     "react-native-force": "github:forcedotcom/SalesforceMobileSDK-ReactNative#v13.1.1",
     "react-native-gesture-handler": "~2.16.2",
     "react-native-safe-area-context": "^4.10.8",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -8,5 +8,19 @@ module.exports = {
         android: null, // Disable auto-linking on Android
       },
     },
+    // Exclude the Agentforce bridge from auto-linking. The sample app consumes it
+    // as an in-repo source module — Android via settings.gradle `include
+    // ':react-native-agentforce'`, iOS via an explicit `pod 'ReactNativeAgentforce'
+    // :path => ...` in the Podfile. Once the package was renamed to the scoped
+    // '@salesforce/react-native-agentforce', autolinking additionally discovered it
+    // and registered a SECOND Gradle project (:salesforce_react-native-agentforce)
+    // against the same source dir (node_modules symlink), colliding on release-AAR
+    // class output. Disabling autolink here keeps the single manual registration.
+    '@salesforce/react-native-agentforce': {
+      platforms: {
+        ios: null, // Disable auto-linking on iOS (manual pod in Podfile)
+        android: null, // Disable auto-linking on Android (manual include in settings.gradle)
+      },
+    },
   },
 };

--- a/skills/integrate-agentforce-react-native/SKILL.md
+++ b/skills/integrate-agentforce-react-native/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: integrate-agentforce-react-native
-description: Integrate the Agentforce Mobile SDK into an existing React Native app. Walks the consumer through use-case discovery, picks the right configuration (Service Agent for public/customer-facing, Employee Agent for signed-in workforce), wires the `react-native-agentforce` bridge package + native iOS/Android dependencies, and scaffolds TypeScript files for the AgentforceService configuration, logger/navigation/view-provider delegates, and a launch button. Use when a developer asks to "add Agentforce", "integrate the Agentforce SDK", "set up Agentforce chat", or wire a React Native app up to a Salesforce agent.
+description: Integrate the Agentforce Mobile SDK into an existing React Native app. Walks the consumer through use-case discovery, picks the right configuration (Service Agent for public/customer-facing, Employee Agent for signed-in workforce), wires the `@salesforce/react-native-agentforce` bridge package + native iOS/Android dependencies, and scaffolds TypeScript files for the AgentforceService configuration, logger/navigation/view-provider delegates, and a launch button. Use when a developer asks to "add Agentforce", "integrate the Agentforce SDK", "set up Agentforce chat", or wire a React Native app up to a Salesforce agent.
 ---
 
 # integrate-agentforce-react-native
 
-This skill walks a consumer through wiring the **Agentforce Mobile SDK** (via the `react-native-agentforce` bridge) into their React Native app. It is **interactive** — ask the user the questions in each phase before generating code. Don't assume; the wrong configuration mode is the most common integration mistake.
+This skill walks a consumer through wiring the **Agentforce Mobile SDK** (via the `@salesforce/react-native-agentforce` bridge) into their React Native app. It is **interactive** — ask the user the questions in each phase before generating code. Don't assume; the wrong configuration mode is the most common integration mistake.
 
 ## Operating rules
 
@@ -133,7 +133,7 @@ implementation("com.salesforce.mobilesdk:SalesforceReact:13.1.1")
 
 ## Phase 4 — Add the bridge dependency
 
-The bridge ships as a local package `react-native-agentforce`. Two install paths:
+The bridge ships as a local package `@salesforce/react-native-agentforce`. Two install paths:
 
 ### Path 1: Install from this repo (recommended for now)
 
@@ -141,14 +141,14 @@ The bridge ships as a local package `react-native-agentforce`. Two install paths
 # Add the bridge package as a tarball or git dependency
 npm install salesforce/AgentforceMobileSDK-ReactNative#dev --save
 # or, if the bridge is published to a registry your org uses:
-npm install react-native-agentforce
+npm install @salesforce/react-native-agentforce
 ```
 
 Then run the platform install scripts shipped with the bridge (these patch CocoaPods / Gradle, install Boost, etc.):
 
 ```bash
-node node_modules/react-native-agentforce/installios.js service   # or 'employee' / 'all'
-node node_modules/react-native-agentforce/installandroid.js service
+node node_modules/@salesforce/react-native-agentforce/installios.js service   # or 'employee' / 'all'
+node node_modules/@salesforce/react-native-agentforce/installandroid.js service
 ```
 
 ### Path 2: In-repo bridge (for forks / patches)
@@ -158,7 +158,7 @@ If the consumer is forking or contributing back, vendor `AgentforceSDK-ReactNati
 ```json
 {
   "dependencies": {
-    "react-native-agentforce": "file:./AgentforceSDK-ReactNative-Bridge"
+    "@salesforce/react-native-agentforce": "file:./AgentforceSDK-ReactNative-Bridge"
   }
 }
 ```

--- a/skills/integrate-agentforce-react-native/references/api-reference.md
+++ b/skills/integrate-agentforce-react-native/references/api-reference.md
@@ -1,11 +1,11 @@
 # `AgentforceService` API reference
 
-The bridge exports a singleton `AgentforceService` from `react-native-agentforce`. All methods return Promises and are no-ops on web/desktop (return `false` or empty values).
+The bridge exports a singleton `AgentforceService` from `@salesforce/react-native-agentforce`. All methods return Promises and are no-ops on web/desktop (return `false` or empty values).
 
 ## Lifecycle
 
 ```ts
-import { AgentforceService } from 'react-native-agentforce';
+import { AgentforceService } from '@salesforce/react-native-agentforce';
 
 // 1. Register delegates first (so they catch init-time SDK output)
 AgentforceService.setLoggerDelegate(myLogger);
@@ -171,7 +171,7 @@ import {
   logoutEmployeeAgent,
   getEmployeeAgentCredentials,
   refreshEmployeeAgentCredentials,
-} from 'react-native-agentforce';
+} from '@salesforce/react-native-agentforce';
 ```
 
 See `auth-flows.md` for the full flow.

--- a/skills/integrate-agentforce-react-native/references/auth-flows.md
+++ b/skills/integrate-agentforce-react-native/references/auth-flows.md
@@ -69,7 +69,7 @@ You don't need to write any auth provider — the bridge handles it.
 
 ## Employee Agent — Mobile SDK flow
 
-The bridge exposes `EmployeeAgentAuthBridge` (only present in builds that include the Mobile SDK). Surfaced via these JS helpers from `react-native-agentforce`:
+The bridge exposes `EmployeeAgentAuthBridge` (only present in builds that include the Mobile SDK). Surfaced via these JS helpers from `@salesforce/react-native-agentforce`:
 
 ```ts
 import {
@@ -80,7 +80,7 @@ import {
   logoutEmployeeAgent,
   getEmployeeAgentCredentials,
   refreshEmployeeAgentCredentials,
-} from 'react-native-agentforce';
+} from '@salesforce/react-native-agentforce';
 ```
 
 Typical flow:

--- a/skills/integrate-agentforce-react-native/references/chat-presentation.md
+++ b/skills/integrate-agentforce-react-native/references/chat-presentation.md
@@ -11,7 +11,7 @@ That means presentation choices on RN are limited to **where the launch trigger 
 Best for "open the assistant" CTAs. Visible, discoverable, easy to gate on configuration state.
 
 ```tsx
-import { AgentforceService } from 'react-native-agentforce';
+import { AgentforceService } from '@salesforce/react-native-agentforce';
 
 function HomeScreen() {
   const onLaunch = async () => {

--- a/skills/integrate-agentforce-react-native/references/dep-detection.md
+++ b/skills/integrate-agentforce-react-native/references/dep-detection.md
@@ -29,8 +29,8 @@ npm install salesforce/AgentforceMobileSDK-ReactNative#dev --save
 …or pin to a specific commit/tag. Then run the platform install scripts that ship with the bridge:
 
 ```bash
-node node_modules/react-native-agentforce/installios.js service     # or 'employee' / 'all'
-node node_modules/react-native-agentforce/installandroid.js service
+node node_modules/@salesforce/react-native-agentforce/installios.js service     # or 'employee' / 'all'
+node node_modules/@salesforce/react-native-agentforce/installandroid.js service
 ```
 
 These scripts:
@@ -47,7 +47,7 @@ Clone or vendor `AgentforceSDK-ReactNative-Bridge/` into the consumer's repo, th
 ```json
 {
   "dependencies": {
-    "react-native-agentforce": "file:./AgentforceSDK-ReactNative-Bridge"
+    "@salesforce/react-native-agentforce": "file:./AgentforceSDK-ReactNative-Bridge"
   }
 }
 ```
@@ -69,7 +69,7 @@ For Service Agent only:
 
 ```ruby
 target 'YourApp' do
-  pod 'ReactNativeAgentforce', :path => '../node_modules/react-native-agentforce/ios'
+  pod 'ReactNativeAgentforce', :path => '../node_modules/@salesforce/react-native-agentforce/ios'
   # ...rest of your Podfile
 end
 ```
@@ -78,7 +78,7 @@ For Employee Agent (host app must include Mobile SDK pods):
 
 ```ruby
 target 'YourApp' do
-  pod 'ReactNativeAgentforce', :path => '../node_modules/react-native-agentforce/ios'
+  pod 'ReactNativeAgentforce', :path => '../node_modules/@salesforce/react-native-agentforce/ios'
   pod 'SalesforceReact'
   pod 'SalesforceSDKCore'
   pod 'SmartStore'
@@ -122,7 +122,7 @@ For Employee Agent, add:
 implementation "com.salesforce.mobilesdk:SalesforceReact:13.1.1"
 ```
 
-Autolinking handles `react-native-agentforce` itself — no manual `implementation` line needed for the bridge.
+Autolinking handles `@salesforce/react-native-agentforce` itself — no manual `implementation` line needed for the bridge.
 
 ### Sync
 
@@ -146,7 +146,7 @@ If the user is on Linux or Windows (no Homebrew), point them at `docs/ci-guide.m
 
 ```bash
 # JS side
-npm ls react-native-agentforce
+npm ls @salesforce/react-native-agentforce
 
 # iOS — pod is linked
 grep -i ReactNativeAgentforce ios/Podfile.lock

--- a/skills/integrate-agentforce-react-native/references/snippets/AutoLaunchOnMount.tsx
+++ b/skills/integrate-agentforce-react-native/references/snippets/AutoLaunchOnMount.tsx
@@ -7,7 +7,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, View } from 'react-native';
-import { AgentforceService } from 'react-native-agentforce';
+import { AgentforceService } from '@salesforce/react-native-agentforce';
 import { configureAgentforce } from './agentforceConfig';
 
 export function AutoLaunchOnMount({ children }: { children: React.ReactNode }) {

--- a/skills/integrate-agentforce-react-native/references/snippets/ChatLaunchButton.tsx
+++ b/skills/integrate-agentforce-react-native/references/snippets/ChatLaunchButton.tsx
@@ -4,7 +4,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { AgentforceService } from 'react-native-agentforce';
+import { AgentforceService } from '@salesforce/react-native-agentforce';
 
 export function ChatLaunchButton() {
   const [configured, setConfigured] = useState(false);

--- a/skills/integrate-agentforce-react-native/references/snippets/HeaderLaunchButton.tsx
+++ b/skills/integrate-agentforce-react-native/references/snippets/HeaderLaunchButton.tsx
@@ -10,7 +10,7 @@
 
 import React from 'react';
 import { Text, TouchableOpacity } from 'react-native';
-import { AgentforceService } from 'react-native-agentforce';
+import { AgentforceService } from '@salesforce/react-native-agentforce';
 
 export function HeaderLaunchButton() {
   return (

--- a/skills/integrate-agentforce-react-native/references/snippets/agentforceLogger.ts
+++ b/skills/integrate-agentforce-react-native/references/snippets/agentforceLogger.ts
@@ -2,7 +2,7 @@
 //
 // If you have a logging service (Sentry, Datadog, etc.), wire it up here.
 
-import type { LoggerDelegate, LogLevel } from 'react-native-agentforce';
+import type { LoggerDelegate, LogLevel } from '@salesforce/react-native-agentforce';
 
 export const agentforceLogger: LoggerDelegate = {
   onLog(level: LogLevel, message: string, error?: string) {

--- a/skills/integrate-agentforce-react-native/references/snippets/agentforceNavigation.ts
+++ b/skills/integrate-agentforce-react-native/references/snippets/agentforceNavigation.ts
@@ -5,7 +5,7 @@
 // own React Navigation stack, deep linking, or in-app browser.
 
 import { Alert, Linking } from 'react-native';
-import type { NavigationDelegate, NavigationRequest } from 'react-native-agentforce';
+import type { NavigationDelegate, NavigationRequest } from '@salesforce/react-native-agentforce';
 
 export const agentforceNavigation: NavigationDelegate = {
   onNavigate(request: NavigationRequest) {

--- a/skills/integrate-agentforce-react-native/references/snippets/configure-employee.ts
+++ b/skills/integrate-agentforce-react-native/references/snippets/configure-employee.ts
@@ -12,7 +12,7 @@ import {
   hasEmployeeAgentSession,
   loginForEmployeeAgent,
   getEmployeeAgentCredentials,
-} from 'react-native-agentforce';
+} from '@salesforce/react-native-agentforce';
 import { agentforceLogger } from './agentforceLogger';
 import { agentforceNavigation } from './agentforceNavigation';
 

--- a/skills/integrate-agentforce-react-native/references/snippets/configure-service.ts
+++ b/skills/integrate-agentforce-react-native/references/snippets/configure-service.ts
@@ -4,7 +4,7 @@
 // once at app startup, then `AgentforceService.launchConversation()`
 // when the user opens the chat.
 
-import { AgentforceService } from 'react-native-agentforce';
+import { AgentforceService } from '@salesforce/react-native-agentforce';
 import { agentforceLogger } from './agentforceLogger';
 import { agentforceNavigation } from './agentforceNavigation';
 

--- a/skills/integrate-agentforce-react-native/references/snippets/employee-auth.ts
+++ b/skills/integrate-agentforce-react-native/references/snippets/employee-auth.ts
@@ -12,7 +12,7 @@ import {
   logoutEmployeeAgent,
   getEmployeeAgentCredentials,
   refreshEmployeeAgentCredentials,
-} from 'react-native-agentforce';
+} from '@salesforce/react-native-agentforce';
 
 export async function ensureEmployeeAgentLogin(): Promise<void> {
   if (!(await isEmployeeAgentAuthSupported())) {

--- a/src/components/ComplexAgentforceDataView.tsx
+++ b/src/components/ComplexAgentforceDataView.tsx
@@ -11,7 +11,7 @@
 
 import React from 'react';
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
-import type { ViewProviderComponentData } from 'react-native-agentforce';
+import type { ViewProviderComponentData } from '@salesforce/react-native-agentforce';
 
 interface ComplexAgentforceDataViewProps {
   definition?: string;

--- a/src/components/CustomAgentforceView.tsx
+++ b/src/components/CustomAgentforceView.tsx
@@ -25,7 +25,7 @@
 
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import type { ViewProviderComponentData } from 'react-native-agentforce';
+import type { ViewProviderComponentData } from '@salesforce/react-native-agentforce';
 
 /** Props passed from the native BridgeViewProvider via RCTRootView / ReactRootView. */
 interface CustomAgentforceViewProps {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -44,7 +44,7 @@ import {
   LogLevel,
   NavigationDelegate,
   NavigationRequest,
-} from 'react-native-agentforce';
+} from '@salesforce/react-native-agentforce';
 import { UI_FEATURES } from '../config/AppConfig';
 import { getContextVariables } from '../store/ContextVariablesStore';
 

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -44,13 +44,13 @@ import {
   hasEmployeeAgentSession,
   loginForEmployeeAgent,
   logoutEmployeeAgent,
-} from 'react-native-agentforce';
+} from '@salesforce/react-native-agentforce';
 import type {
   FeatureFlags,
   HiddenPreChatFields,
   AgentforceContextVariable,
   AgentforceContextVariableType,
-} from 'react-native-agentforce';
+} from '@salesforce/react-native-agentforce';
 import { UI_FEATURES } from '../config/AppConfig';
 import { getContextVariables, setContextVariables } from '../store/ContextVariablesStore';
 

--- a/src/store/ContextVariablesStore.ts
+++ b/src/store/ContextVariablesStore.ts
@@ -1,4 +1,4 @@
-import type { AgentforceContextVariable } from 'react-native-agentforce';
+import type { AgentforceContextVariable } from '@salesforce/react-native-agentforce';
 
 let store: AgentforceContextVariable[] = [];
 

--- a/src/store/__tests__/ContextVariablesStore.test.ts
+++ b/src/store/__tests__/ContextVariablesStore.test.ts
@@ -1,4 +1,4 @@
-import type { AgentforceContextVariable } from 'react-native-agentforce';
+import type { AgentforceContextVariable } from '@salesforce/react-native-agentforce';
 import {
   getContextVariables,
   setContextVariables,


### PR DESCRIPTION
## What & why

GUS: **W-23159346** — *[React Native] Ship the React Native bridge as a published NPM package (`@salesforce/react-native-agentforce`)*

Makes `AgentforceSDK-ReactNative-Bridge/` a publishable **scoped** npm package, mirroring the sibling Salesforce SDK [`react-native-force`](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative) (plain `tsc` build → compiled output, publish from a release tag). **No behavioral change** to the bridge API — this is packaging + a scoped rename.

## Changes

**Packaging (`AgentforceSDK-ReactNative-Bridge/`)**
- Rename → `@salesforce/react-native-agentforce`; `main`/`types` → `lib/`, `react-native` → `src/`, `files` allowlist, `publishConfig.access: public`, `repository`/`license`/`keywords`, `build` + `prepare` + `prepublishOnly` scripts.
- `tsconfig.build.json` emits JS + `.d.ts` to `lib/` (tests excluded).
- `.npmignore` + `files` negations keep build artifacts and native test sources out of the tarball.
- Package `LICENSE` (Apache-2.0); corrected podspec license `BSD-3-Clause` → `Apache-2.0`.
- `lib/` is build output (gitignored) — produced by `prepare`/`prepublishOnly`, **not committed** (same as `react-native-force`).

**Consumers** — scoped-name rename across root `package.json` `file:` dep, 7 `src/**` imports, 8 skill snippets, plugin/marketplace descriptions, and integration-guide docs. **Native module names are intentionally unchanged** (iOS pod `ReactNativeAgentforce`, Gradle `:react-native-agentforce`) — the npm scope is independent of native names (exactly like `react-native-force` / pod `SalesforceReact`).

**CI**
- `publish-npm-package.yml` (new): publishes on a `v*` tag on `main` via **OIDC Trusted Publishing** (no `NPM_TOKEN`); guards tag-on-`main` + `tag == package.json version`; `npm publish --provenance`.
- `pr-checks.yml`: added bridge `npm run build` + `npm pack --dry-run` sanity on dev PRs.

## Verification
- `npm run build` (tsc) → `lib/index.js` + `lib/index.d.ts`, exit 0
- `npm pack --dry-run` → 100 files; ships `lib`/`src`/`ios`+podspec/`android/src/main`/README/LICENSE; excludes `*/build`, tests, `node_modules`
- Sample app `tsc --noEmit` → 0; full `jest` → **85/85** (incl. 10 package-contract assertions)
- lint 0 errors, prettier clean, podspec `ruby -c` OK

## ⚠️ Publishing is gated on OSPO OIDC onboarding (not this PR)
Nothing publishes on merge — the workflow only fires on a `v*` tag on `main`, and only succeeds once OSPO configures the trusted-publisher binding. Remaining steps (tracked separately):
- [x] OSS approval in place; Apache-2.0 `LICENSE.txt` present in repo
- [ ] File GUS WI for OSPO (package name, org/repo, workflow file `publish-npm-package.yml`, OSS approval link)
- [ ] Post in **#opensource** → OSPO configures OIDC Trusted Publishing + performs the **first** publish
- [ ] Do **not** cut a `v*` tag on `main` until the OIDC binding is live (otherwise the publish step fails)

> Note: OSPO binds the trust relationship to the workflow **filename** `publish-npm-package.yml` — do not rename without updating the binding.