### PR TITLE
Bump Agentforce iOS SDK 15.33.3 -> 15.33.5 (262.0.1)

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
+++ b/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
     core.dependency "React-Core"
     core.dependency "AgentforceSDK"
     core.dependency "AgentforceVoice", "2.1.7"
-    # AgentforceSDK 15.33.3 (262.0) publicly imports the SharedUI module but
+    # AgentforceSDK 15.33.5 (262.0) publicly imports the SharedUI module but
     # omits it from its podspec; declare it so this target can resolve it.
     core.dependency "SharedUI", "1.3.1"
   end

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -20,7 +20,7 @@ def shared_pods
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'AgentforceSDK', '15.33.3'
+  pod 'AgentforceSDK', '15.33.5'
   pod 'AgentforceVoice', '2.1.7'
   pod 'Messaging-InApp-Core', '> 1.10.0'
   # Messaging-Multimedia-Core vends SMIMultimediaCore.framework, which
@@ -44,7 +44,7 @@ def shared_pods
   pod 'JWTKit'
 
   # SharedUI provides the design-system module (Colors/Fonts/Dimensions) that
-  # AgentforceSDK 15.33.3 (262.0) publicly imports but does not declare in its
+  # AgentforceSDK 15.33.5 (262.0) publicly imports but does not declare in its
   # podspec. Pin to the flat spec the iOS SDK ships with; SLDSIcons is held at
   # 1.2.2 to avoid the "Multiple commands produce SLDSIcons.framework" collision.
   pod 'SharedUI', '1.3.1'


### PR DESCRIPTION
## Summary
Bumps the Agentforce iOS SDK pin from **15.33.3 → 15.33.5**, adopting the recently released iOS SDK version (262.0.1) that addresses a language duplication issue.

## Changes
- `ios/Podfile.common.rb` — `pod 'AgentforceSDK'` pinned to `15.33.5` (and the accompanying SharedUI comment reference updated).
- `AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec` — version reference in the SharedUI dependency comment updated to `15.33.5`.

## Verification
- **BUILD SUCCEEDED**.