### PR TITLE
@W-23294974 Synthesize standard__recordPage pageReference for Android record navigation

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNavigation.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNavigation.kt
@@ -87,7 +87,15 @@ class BridgeNavigation(private val reactContext: ReactContext) : Navigation {
                 params.putString("type", "record")
                 params.putString("recordId", destination.id)
                 destination.type?.let { params.putString("objectType", it) }
-                destination.pageReference?.let { params.putString("pageReference", it) }
+                // The Android SDK leaves Record.pageReference null on a tapped record (its nav
+                // call sites use the short Record(id, type) constructor), whereas the iOS SDK's
+                // Record self-populates a standard__recordPage pageReference. Synthesize the same
+                // shape here so JS consumers get a consistent payload cross-platform (W-23294974).
+                // Use the SDK-provided value when present so the edit flow's pageReference (and a
+                // future SDK that populates it) is never clobbered.
+                val pageReference = destination.pageReference
+                    ?: recordPageReference(destination.id, destination.type)
+                params.putString("pageReference", pageReference)
             }
             is ObjectHome -> {
                 params.putString("type", "objectHome")

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/NavigationPageReference.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/NavigationPageReference.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Helpers for synthesizing navigation pageReferences forwarded to React Native JS.
+ */
+package com.salesforce.android.reactagentforce
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Builds a `standard__recordPage` pageReference JSON string for a record.
+ *
+ * The Android SDK's `Record` destination leaves `pageReference` null on a tapped record — its
+ * navigation call sites use the short `Record(id, type)` constructor and the Android
+ * SalesforceMobileInterfaces `Record` (unlike iOS) does not self-populate a pageReference. The
+ * iOS SDK's `Record` initializer produces `{recordId, actionName: "view", objectApiName}`, so
+ * JS consumers of `onNavigationRequest` see a `pageReference` on iOS but not Android
+ * (W-23294974). This helper synthesizes the same shape so the bridge can emit a consistent
+ * payload cross-platform.
+ *
+ * This is a temporary bridge-layer workaround. The durable fix is for the Android
+ * SalesforceMobileInterfaces `Record` type to self-derive its pageReference like iOS; once that
+ * ships, callers here will receive a non-null `Record.pageReference` and this synthesis becomes
+ * a no-op fallback.
+ *
+ * kotlinx.serialization (not `org.json`) is used deliberately so the logic is pure-JVM and
+ * unit-testable — the bridge test module sets `unitTests.returnDefaultValues = true`, which stubs
+ * out Android's `org.json.JSONObject`.
+ *
+ * @param recordId the record id (18-char entity id)
+ * @param objectType the object API name, if known; omitted from `attributes` when null/blank
+ * @return the serialized `standard__recordPage` pageReference
+ */
+internal fun recordPageReference(recordId: String, objectType: String?): String {
+    val attributes = buildMap {
+        put(RECORD_ID_KEY, recordId)
+        put(ACTION_NAME_KEY, VIEW_ACTION)
+        if (!objectType.isNullOrBlank()) {
+            put(OBJECT_API_NAME_KEY, objectType)
+        }
+    }
+    return Json.encodeToString(
+        NavigationPageReferencePayload(type = STANDARD_RECORD_PAGE, attributes = attributes)
+    )
+}
+
+@Serializable
+private data class NavigationPageReferencePayload(
+    val type: String,
+    val attributes: Map<String, String>,
+)
+
+private const val STANDARD_RECORD_PAGE = "standard__recordPage"
+private const val RECORD_ID_KEY = "recordId"
+private const val OBJECT_API_NAME_KEY = "objectApiName"
+private const val ACTION_NAME_KEY = "actionName"
+private const val VIEW_ACTION = "view"

--- a/AgentforceSDK-ReactNative-Bridge/android/src/test/java/com/salesforce/android/reactagentforce/NavigationPageReferenceTest.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/test/java/com/salesforce/android/reactagentforce/NavigationPageReferenceTest.kt
@@ -1,0 +1,50 @@
+package com.salesforce.android.reactagentforce
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies the record pageReference synthesized by the bridge matches the shape the iOS SDK's
+ * `Record` initializer emits, so JS consumers get a consistent cross-platform payload (W-23294974).
+ */
+class NavigationPageReferenceTest {
+
+    @Test
+    fun `record pageReference matches iOS standard__recordPage shape`() {
+        val json = Json.parseToJsonElement(
+            recordPageReference("001bG00000F4PyXQAV", "Account")
+        ).jsonObject
+
+        assertEquals("standard__recordPage", json["type"]?.jsonPrimitive?.content)
+
+        val attributes = json["attributes"]?.jsonObject!!
+        assertEquals("001bG00000F4PyXQAV", attributes["recordId"]?.jsonPrimitive?.content)
+        assertEquals("view", attributes["actionName"]?.jsonPrimitive?.content)
+        assertEquals("Account", attributes["objectApiName"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `objectApiName is omitted when objectType is null`() {
+        val attributes = Json.parseToJsonElement(
+            recordPageReference("001bG00000F4PyXQAV", null)
+        ).jsonObject["attributes"]?.jsonObject!!
+
+        assertFalse("objectApiName should be absent", attributes.containsKey("objectApiName"))
+        assertTrue(attributes.containsKey("recordId"))
+        assertEquals("view", attributes["actionName"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `objectApiName is omitted when objectType is blank`() {
+        val attributes = Json.parseToJsonElement(
+            recordPageReference("001bG00000F4PyXQAV", "   ")
+        ).jsonObject["attributes"]?.jsonObject!!
+
+        assertFalse("objectApiName should be absent for blank type", attributes.containsKey("objectApiName"))
+    }
+}


### PR DESCRIPTION
## Summary
Android record navigation requests forwarded to React Native JS were missing the `pageReference` field that iOS includes. This makes the `onNavigationRequest` payload consistent cross-platform.

**Before (Android):**
```
{ "objectType": "Account", "recordId": "001...", "type": "record" }
```
**After (matches iOS):**
```
{ "objectType": "Account", "recordId": "001...", "type": "record",
  "pageReference": "{\"type\":\"standard__recordPage\",\"attributes\":{\"recordId\":\"001...\",\"actionName\":\"view\",\"objectApiName\":\"Account\"}}" }
```

## Root cause
The divergence is upstream in **SalesforceMobileInterfaces (SMI)**, not the bridge:
- **iOS** `Record.swift` auto-derives a `pageReference` in its initializer — every `Record` carries `{recordId, actionName: "view", objectApiName}`.
- **Android** `Record.kt` declares `pageReference: String? = null` as a passthrough that defaults to null. Record-tap call sites use the short `Record(id, type)` constructor, so `pageReference` is null.
- The bridge forwarded `pageReference` only when non-null, so the key was omitted on Android. The bridge was faithful — the gap is upstream.

## Fix (temporary bridge-layer workaround)
When `Record.pageReference` is null, synthesize the same `standard__recordPage` shape iOS produces. The SDK-provided value is used when present, so the edit flow's `pageReference` is never clobbered. Implemented with `kotlinx.serialization` (pure-JVM, unit-testable — the bridge test module stubs `org.json`).

## Durable follow-up (tracked separately)
Fix the Android SMI `Record` type to self-derive its `pageReference` like iOS (full parity for native + SApp consumers), then remove this bridge workaround. A draft of the SDK-side approach exists on `W-relaunch-android-record-pageref` (`RecordDestinationFactory`).

## Test
- `NavigationPageReferenceTest` — asserts JSON shape/iOS parity, `actionName: "view"`, and `objectApiName` omission when null/blank.
- Full `:react-native-agentforce:testDebugUnitTest` suite passes.

Work item: W-23294974