### PR TITLE
@W-23290581 Expose sendUtterance on AgentforceConversation (RN bridge)

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -546,6 +546,41 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         }
     }
 
+    /**
+     * Send an utterance (text message) to the current conversation.
+     * Must be called after launching a conversation.
+     *
+     * @param utterance The text to send to the agent
+     * @param promise Promise to resolve/reject
+     */
+    @ReactMethod
+    fun sendUtterance(utterance: String, promise: Promise) {
+        Log.d(TAG, "sendUtterance() called")
+
+        scope.launch(Dispatchers.Main) {
+            val conversation = AgentforceClientHolder.currentConversation
+            if (conversation == null) {
+                Log.w(TAG, "No active conversation for sendUtterance")
+                promise.reject(
+                    "NO_CONVERSATION",
+                    "No active conversation. Launch conversation first, then send an utterance."
+                )
+                return@launch
+            }
+
+            try {
+                conversation.sendUtterance(utterance)
+                Log.d(TAG, "Utterance sent")
+                promise.resolve(Arguments.createMap().apply {
+                    putBoolean("success", true)
+                })
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to send utterance", e)
+                promise.reject("SEND_UTTERANCE_ERROR", e.message, e)
+            }
+        }
+    }
+
     // endregion
 
     // region Configuration Query Methods

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
@@ -71,6 +71,10 @@ RCT_EXTERN_METHOD(closeConversation:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(startNewConversation:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(sendUtterance:(NSString *)utterance
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 // MARK: - Hidden PreChat Fields
 
 RCT_EXTERN_METHOD(registerHiddenPreChatFields:(NSDictionary *)fields

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -1177,6 +1177,39 @@ class AgentforceModule: RCTEventEmitter {
         }
     }
 
+    /// Send an utterance (text message) to the current conversation.
+    /// Must be called after launching a conversation.
+    ///
+    /// @param utterance The text to send to the agent
+    /// @param resolve Promise resolver
+    /// @param reject Promise rejecter
+    @objc
+    func sendUtterance(
+        _ utterance: String,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        Task { @MainActor in
+            // Skip if the RN bridge has torn this module down (hot reload) so we
+            // don't run bridge work or resolve promises into a dead JS runtime.
+            guard !isInvalidated else { return }
+
+            // Check if conversation exists
+            guard let conversation = currentConversation else {
+                reject(
+                    "NO_CONVERSATION",
+                    "No active conversation. Launch conversation first, then send an utterance.",
+                    nil
+                )
+                return
+            }
+
+            await conversation.sendUtterance(utterance: utterance, attachment: nil)
+            print("[AgentforceModule] ✓ Utterance sent")
+            resolve(["success": true])
+        }
+    }
+
     /// Reset all settings
     @objc
     func resetSettings(

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -869,6 +869,50 @@ class AgentforceService {
   }
 
   /**
+   * Send an utterance (a text message) to the active conversation.
+   *
+   * Programmatically sends the given text to the agent, as if the user had typed
+   * and submitted it. Works for both Service Agent and Employee Agent modes.
+   *
+   * **Must be called after launching a conversation** — if no conversation is
+   * active, the native module rejects and this method throws.
+   *
+   * @param utterance - The non-empty text to send to the agent.
+   * @returns Promise<boolean> indicating success
+   * @throws Error if the utterance is empty/invalid, or if no conversation is active
+   *
+   * @example
+   * ```typescript
+   * await AgentforceService.launchConversation();
+   * await AgentforceService.sendUtterance('What is the status of my order?');
+   * ```
+   */
+  async sendUtterance(utterance: string): Promise<boolean> {
+    if (Platform.OS !== 'android' && Platform.OS !== 'ios') {
+      console.warn('Agentforce only supported on Android and iOS');
+      return false;
+    }
+
+    if (!AgentforceModule) {
+      console.error('AgentforceModule native module not found');
+      return false;
+    }
+
+    if (typeof utterance !== 'string' || utterance.trim().length === 0) {
+      throw new Error('Invalid utterance: must be a non-empty string');
+    }
+
+    try {
+      const result = await AgentforceModule.sendUtterance(utterance);
+      console.log('[AgentforceService] Utterance sent');
+      return result?.success ?? true;
+    } catch (error) {
+      console.error('[AgentforceService] Failed to send utterance:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Set additional context for the conversation.
    *
    * Provides contextual information to the Agentforce conversation,

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.test.ts
@@ -26,6 +26,7 @@ jest.mock('react-native', () => {
     launchConversation: jest.fn().mockResolvedValue({ success: true }),
     startNewConversation: jest.fn().mockResolvedValue({ success: true }),
     closeConversation: jest.fn().mockResolvedValue({ success: true }),
+    sendUtterance: jest.fn().mockResolvedValue({ success: true }),
     isConfigured: jest.fn(),
     getConfiguration: jest.fn(),
     getConfigurationInfo: jest.fn(),
@@ -372,5 +373,53 @@ describe('AgentforceService passthrough + normalization', () => {
   it('clearHiddenPreChatFields registers an empty map', async () => {
     await AgentforceService.clearHiddenPreChatFields();
     expect(nativeModule.registerHiddenPreChatFields).toHaveBeenCalledWith({});
+  });
+});
+
+describe('AgentforceService.sendUtterance', () => {
+  beforeEach(() => {
+    setPlatform('ios');
+    nativeModule.sendUtterance.mockClear();
+    nativeModule.sendUtterance.mockResolvedValue({ success: true });
+  });
+
+  // SC1: happy path — forwards the utterance and resolves the native success flag.
+  it('sends the utterance to the native module and resolves true', async () => {
+    await expect(AgentforceService.sendUtterance('hello')).resolves.toBe(true);
+    expect(nativeModule.sendUtterance).toHaveBeenCalledWith('hello');
+  });
+
+  // SC2: normalization — default to true when native omits success, honor explicit false.
+  it('defaults to true when the native result omits success', async () => {
+    nativeModule.sendUtterance.mockResolvedValueOnce({});
+    await expect(AgentforceService.sendUtterance('hi')).resolves.toBe(true);
+  });
+
+  it('resolves false when the native result reports success: false', async () => {
+    nativeModule.sendUtterance.mockResolvedValueOnce({ success: false });
+    await expect(AgentforceService.sendUtterance('hi')).resolves.toBe(false);
+  });
+
+  // SC3: platform guard — unsupported platforms return false without touching native.
+  it('returns false and skips the native call on unsupported platforms', async () => {
+    setPlatform('web');
+    await expect(AgentforceService.sendUtterance('hi')).resolves.toBe(false);
+    expect(nativeModule.sendUtterance).not.toHaveBeenCalled();
+  });
+
+  // SC4: validation — empty / whitespace / non-string throw and never reach native.
+  it('rejects an empty or whitespace-only utterance without calling native', async () => {
+    await expect(AgentforceService.sendUtterance('')).rejects.toThrow('Invalid utterance');
+    await expect(AgentforceService.sendUtterance('   ')).rejects.toThrow('Invalid utterance');
+    await expect(AgentforceService.sendUtterance(undefined as unknown as string)).rejects.toThrow(
+      'Invalid utterance',
+    );
+    expect(nativeModule.sendUtterance).not.toHaveBeenCalled();
+  });
+
+  // SC5: error propagation — a native rejection surfaces to the caller.
+  it('propagates native errors', async () => {
+    nativeModule.sendUtterance.mockRejectedValueOnce(new Error('NO_CONVERSATION'));
+    await expect(AgentforceService.sendUtterance('hi')).rejects.toThrow('NO_CONVERSATION');
   });
 });

--- a/android/app/src/main/java/com/salesforce/android/reactagentforce/app/MainApplication.java
+++ b/android/app/src/main/java/com/salesforce/android/reactagentforce/app/MainApplication.java
@@ -35,6 +35,7 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
 import com.facebook.react.defaults.DefaultReactNativeHost;
 import com.facebook.soloader.SoLoader;
+import com.salesforce.android.reactagentforce.AgentforcePackage;
 
 import java.util.List;
 
@@ -53,9 +54,13 @@ public class MainApplication extends Application implements ReactApplication {
 
 		@Override
 		protected List<ReactPackage> getPackages() {
-			@SuppressWarnings("UnnecessaryLocalVariable")
 			List<ReactPackage> packages = new PackageList(this).getPackages();
-			// Agentforce is provided by react-native-agentforce bridge (autolinking)
+			// Autolinking is disabled for the Agentforce bridge (see react-native.config.js
+			// — the scoped @salesforce/react-native-agentforce rename caused a Gradle
+			// double-registration), so register the package manually here. AgentforcePackage
+			// registers AgentforceModule always and EmployeeAgentAuthBridge only when the
+			// Mobile SDK is on the classpath (employeeAgent flavor).
+			packages.add(new AgentforcePackage());
 			return packages;
 		}
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -52,6 +52,16 @@ interface HomeScreenProps {
   navigation: any;
 }
 
+// Preset utterances the user can pick from and fire via sendUtterance.
+// A real host app would source these from suggested-prompt chips, deep links,
+// or its own UI — this list just demonstrates the API.
+const SAMPLE_UTTERANCES = [
+  'What can you help me with?',
+  'Summarize my open cases',
+  'What is the status of my latest order?',
+  'Show me my account details',
+];
+
 // Sample logger delegate — forwards Agentforce SDK logs to console
 const agentforceLogger: LoggerDelegate = {
   onLog(level: LogLevel, message: string, error?: string) {
@@ -84,6 +94,8 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   const [isEmployeeAgentConfigured, setIsEmployeeAgentConfigured] = useState(false);
   const [isChecking, setIsChecking] = useState(true);
   const [currentMode, setCurrentMode] = useState<'none' | 'service' | 'employee'>('none');
+  const [selectedUtterance, setSelectedUtterance] = useState(SAMPLE_UTTERANCES[0]);
+  const [isSending, setIsSending] = useState(false);
 
   useEffect(() => {
     // Register logger delegate so SDK logs are forwarded to JS
@@ -256,6 +268,35 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
     }
   };
 
+  // Send the selected utterance to the ACTIVE conversation. sendUtterance is
+  // agent-mode-agnostic: it delivers to whichever agent (Service or Employee)
+  // is currently launched, so we require an active conversation rather than
+  // assuming a mode. The native layer rejects with NO_CONVERSATION otherwise.
+  const handleSendUtterance = async () => {
+    if (currentMode === 'none') {
+      Alert.alert(
+        'No Active Conversation',
+        'Launch a Service or Employee Agent first, then send an utterance to it.',
+      );
+      return;
+    }
+
+    setIsSending(true);
+    try {
+      // The conversation is already active (currentMode is 'service' or
+      // 'employee'), so send straight to it — no reconfigure, no relaunch.
+      const sent = await AgentforceService.sendUtterance(selectedUtterance);
+      console.log(
+        `[HomeScreen] sendUtterance("${selectedUtterance}") -> ${sent} (mode: ${currentMode})`,
+      );
+    } catch (error: any) {
+      Alert.alert('Error', error?.message || 'Failed to send the utterance to the agent.');
+      console.error('Send utterance error:', error);
+    } finally {
+      setIsSending(false);
+    }
+  };
+
   return (
     <View style={styles.container}>
       <ScrollView
@@ -329,6 +370,41 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
               {isEmployeeAgentConfigured && <Text style={styles.launchButtonArrow}>›</Text>}
             </TouchableOpacity>
           )}
+        </View>
+
+        <View style={styles.utteranceContainer}>
+          <Text style={styles.utteranceHeader}>Send an utterance</Text>
+          <Text style={styles.utteranceSubheader}>
+            {currentMode === 'none'
+              ? 'Launch a Service or Employee Agent above first — sendUtterance delivers to whichever agent is active.'
+              : `Pick a prompt, then Send. Delivered programmatically to the active ${currentMode} agent via sendUtterance.`}
+          </Text>
+
+          {SAMPLE_UTTERANCES.map(utterance => {
+            const selected = utterance === selectedUtterance;
+            return (
+              <TouchableOpacity
+                key={utterance}
+                style={styles.radioRow}
+                onPress={() => setSelectedUtterance(utterance)}
+                disabled={isSending}>
+                <View style={[styles.radioOuter, selected && styles.radioOuterSelected]}>
+                  {selected && <View style={styles.radioInner} />}
+                </View>
+                <Text style={styles.radioLabel}>{utterance}</Text>
+              </TouchableOpacity>
+            );
+          })}
+
+          <TouchableOpacity
+            style={[
+              styles.sendButton,
+              (currentMode === 'none' || isSending) && styles.launchButtonDisabled,
+            ]}
+            onPress={handleSendUtterance}
+            disabled={isChecking || isSending || currentMode === 'none'}>
+            <Text style={styles.sendButtonText}>{isSending ? 'Sending…' : 'Send Utterance'}</Text>
+          </TouchableOpacity>
         </View>
 
         <TouchableOpacity
@@ -456,6 +532,72 @@ const styles = StyleSheet.create({
     fontSize: 24,
     color: '#7B1FA2',
     fontWeight: '300',
+  },
+  utteranceContainer: {
+    width: '100%',
+    padding: 20,
+    borderRadius: 12,
+    backgroundColor: '#ffffff',
+    marginBottom: 24,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
+    elevation: 4,
+    borderLeftWidth: 4,
+    borderLeftColor: '#7B1FA2',
+  },
+  utteranceHeader: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#212529',
+    marginBottom: 4,
+  },
+  utteranceSubheader: {
+    fontSize: 13,
+    color: '#6c757d',
+    marginBottom: 16,
+  },
+  radioRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  radioOuter: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    borderColor: '#adb5bd',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  radioOuterSelected: {
+    borderColor: '#7B1FA2',
+  },
+  radioInner: {
+    width: 11,
+    height: 11,
+    borderRadius: 6,
+    backgroundColor: '#7B1FA2',
+  },
+  radioLabel: {
+    flex: 1,
+    fontSize: 15,
+    color: '#212529',
+  },
+  sendButton: {
+    marginTop: 16,
+    padding: 16,
+    borderRadius: 8,
+    backgroundColor: '#7B1FA2',
+    alignItems: 'center',
+  },
+  sendButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#ffffff',
   },
   settingsButton: {
     padding: 16,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -52,16 +52,6 @@ interface HomeScreenProps {
   navigation: any;
 }
 
-// Preset utterances the user can pick from and fire via sendUtterance.
-// A real host app would source these from suggested-prompt chips, deep links,
-// or its own UI — this list just demonstrates the API.
-const SAMPLE_UTTERANCES = [
-  'What can you help me with?',
-  'Summarize my open cases',
-  'What is the status of my latest order?',
-  'Show me my account details',
-];
-
 // Sample logger delegate — forwards Agentforce SDK logs to console
 const agentforceLogger: LoggerDelegate = {
   onLog(level: LogLevel, message: string, error?: string) {
@@ -94,8 +84,6 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   const [isEmployeeAgentConfigured, setIsEmployeeAgentConfigured] = useState(false);
   const [isChecking, setIsChecking] = useState(true);
   const [currentMode, setCurrentMode] = useState<'none' | 'service' | 'employee'>('none');
-  const [selectedUtterance, setSelectedUtterance] = useState(SAMPLE_UTTERANCES[0]);
-  const [isSending, setIsSending] = useState(false);
 
   useEffect(() => {
     // Register logger delegate so SDK logs are forwarded to JS
@@ -268,35 +256,6 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
     }
   };
 
-  // Send the selected utterance to the ACTIVE conversation. sendUtterance is
-  // agent-mode-agnostic: it delivers to whichever agent (Service or Employee)
-  // is currently launched, so we require an active conversation rather than
-  // assuming a mode. The native layer rejects with NO_CONVERSATION otherwise.
-  const handleSendUtterance = async () => {
-    if (currentMode === 'none') {
-      Alert.alert(
-        'No Active Conversation',
-        'Launch a Service or Employee Agent first, then send an utterance to it.',
-      );
-      return;
-    }
-
-    setIsSending(true);
-    try {
-      // The conversation is already active (currentMode is 'service' or
-      // 'employee'), so send straight to it — no reconfigure, no relaunch.
-      const sent = await AgentforceService.sendUtterance(selectedUtterance);
-      console.log(
-        `[HomeScreen] sendUtterance("${selectedUtterance}") -> ${sent} (mode: ${currentMode})`,
-      );
-    } catch (error: any) {
-      Alert.alert('Error', error?.message || 'Failed to send the utterance to the agent.');
-      console.error('Send utterance error:', error);
-    } finally {
-      setIsSending(false);
-    }
-  };
-
   return (
     <View style={styles.container}>
       <ScrollView
@@ -370,41 +329,6 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
               {isEmployeeAgentConfigured && <Text style={styles.launchButtonArrow}>›</Text>}
             </TouchableOpacity>
           )}
-        </View>
-
-        <View style={styles.utteranceContainer}>
-          <Text style={styles.utteranceHeader}>Send an utterance</Text>
-          <Text style={styles.utteranceSubheader}>
-            {currentMode === 'none'
-              ? 'Launch a Service or Employee Agent above first — sendUtterance delivers to whichever agent is active.'
-              : `Pick a prompt, then Send. Delivered programmatically to the active ${currentMode} agent via sendUtterance.`}
-          </Text>
-
-          {SAMPLE_UTTERANCES.map(utterance => {
-            const selected = utterance === selectedUtterance;
-            return (
-              <TouchableOpacity
-                key={utterance}
-                style={styles.radioRow}
-                onPress={() => setSelectedUtterance(utterance)}
-                disabled={isSending}>
-                <View style={[styles.radioOuter, selected && styles.radioOuterSelected]}>
-                  {selected && <View style={styles.radioInner} />}
-                </View>
-                <Text style={styles.radioLabel}>{utterance}</Text>
-              </TouchableOpacity>
-            );
-          })}
-
-          <TouchableOpacity
-            style={[
-              styles.sendButton,
-              (currentMode === 'none' || isSending) && styles.launchButtonDisabled,
-            ]}
-            onPress={handleSendUtterance}
-            disabled={isChecking || isSending || currentMode === 'none'}>
-            <Text style={styles.sendButtonText}>{isSending ? 'Sending…' : 'Send Utterance'}</Text>
-          </TouchableOpacity>
         </View>
 
         <TouchableOpacity
@@ -532,72 +456,6 @@ const styles = StyleSheet.create({
     fontSize: 24,
     color: '#7B1FA2',
     fontWeight: '300',
-  },
-  utteranceContainer: {
-    width: '100%',
-    padding: 20,
-    borderRadius: 12,
-    backgroundColor: '#ffffff',
-    marginBottom: 24,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-    borderLeftWidth: 4,
-    borderLeftColor: '#7B1FA2',
-  },
-  utteranceHeader: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: '#212529',
-    marginBottom: 4,
-  },
-  utteranceSubheader: {
-    fontSize: 13,
-    color: '#6c757d',
-    marginBottom: 16,
-  },
-  radioRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 10,
-  },
-  radioOuter: {
-    width: 22,
-    height: 22,
-    borderRadius: 11,
-    borderWidth: 2,
-    borderColor: '#adb5bd',
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginRight: 12,
-  },
-  radioOuterSelected: {
-    borderColor: '#7B1FA2',
-  },
-  radioInner: {
-    width: 11,
-    height: 11,
-    borderRadius: 6,
-    backgroundColor: '#7B1FA2',
-  },
-  radioLabel: {
-    flex: 1,
-    fontSize: 15,
-    color: '#212529',
-  },
-  sendButton: {
-    marginTop: 16,
-    padding: 16,
-    borderRadius: 8,
-    backgroundColor: '#7B1FA2',
-    alignItems: 'center',
-  },
-  sendButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#ffffff',
   },
   settingsButton: {
     padding: 16,

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -56,6 +56,16 @@ import { getContextVariables, setContextVariables } from '../store/ContextVariab
 
 type TabType = 'service' | 'employee' | 'features';
 
+// Preset utterances offered as quick-fill chips in the Send Utterance section.
+// A real host app would source these from suggested-prompt chips, deep links,
+// or its own UI — this list just demonstrates the sendUtterance API.
+const SAMPLE_UTTERANCES = [
+  'What can you help me with?',
+  'Summarize my open cases',
+  'What is the status of my latest order?',
+  'Show me my account details',
+];
+
 const FLAG_KEYS: (keyof FeatureFlags)[] = [
   'enableMultiAgent',
   'enableMultiModalInput',
@@ -140,6 +150,9 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
   const [newEmployeeCtxType, setNewEmployeeCtxType] =
     useState<AgentforceContextVariableType>('Text');
   const [newEmployeeCtxValue, setNewEmployeeCtxValue] = useState('');
+
+  const [utteranceText, setUtteranceText] = useState('');
+  const [sendingUtterance, setSendingUtterance] = useState(false);
 
   useEffect(() => {
     loadSavedConfiguration();
@@ -462,6 +475,79 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
     ]);
   };
 
+  // Send a free-form (or preset) utterance to the ACTIVE conversation.
+  // sendUtterance is agent-mode-agnostic — it delivers to whichever agent
+  // (Service or Employee) is currently launched. The native layer rejects with
+  // NO_CONVERSATION if nothing is active, so launch a conversation from the Home
+  // screen first, then return here to send.
+  const handleSendUtterance = async () => {
+    const text = utteranceText.trim();
+    if (!text) {
+      return;
+    }
+    setSendingUtterance(true);
+    try {
+      const sent = await AgentforceService.sendUtterance(text);
+      console.log(`[Settings] sendUtterance("${text}") -> ${sent}`);
+      Alert.alert('Utterance Sent', 'Open the agent from the Home screen to see it in the chat.');
+      setUtteranceText('');
+    } catch (error: any) {
+      // Most common case: no conversation launched yet (NO_CONVERSATION).
+      Alert.alert(
+        'Could Not Send',
+        error?.message ||
+          'Failed to send the utterance. Launch a conversation from the Home screen first.',
+      );
+      console.error('Send utterance error:', error);
+    } finally {
+      setSendingUtterance(false);
+    }
+  };
+
+  const renderSendUtteranceSection = (agentLabel: 'Service' | 'Employee') => (
+    <View style={styles.formContainer}>
+      <Text style={styles.label}>Send Utterance</Text>
+      <Text style={styles.hint}>
+        Programmatically send a message to the active {agentLabel} Agent conversation via
+        sendUtterance. Launch the conversation from the Home screen first, then send here.
+      </Text>
+
+      <View style={styles.quickAddRow}>
+        {SAMPLE_UTTERANCES.map(sample => (
+          <TouchableOpacity
+            key={sample}
+            style={styles.quickAddChip}
+            onPress={() => setUtteranceText(sample)}
+            disabled={sendingUtterance}>
+            <Text style={styles.quickAddChipText}>{sample}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <TextInput
+        style={[styles.input, styles.utteranceInput]}
+        value={utteranceText}
+        onChangeText={setUtteranceText}
+        placeholder="Type an utterance to send…"
+        placeholderTextColor="#999"
+        multiline
+        editable={!sendingUtterance}
+      />
+
+      <TouchableOpacity
+        style={[
+          styles.saveButton,
+          (!utteranceText.trim() || sendingUtterance) && styles.buttonDisabled,
+        ]}
+        onPress={handleSendUtterance}
+        disabled={!utteranceText.trim() || sendingUtterance}>
+        <Text style={styles.saveButtonText}>
+          {sendingUtterance ? 'Sending…' : 'Send Utterance'}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+
   const renderTabs = () => (
     <View style={styles.tabContainer}>
       {UI_FEATURES.SHOW_SERVICE_AGENT && (
@@ -764,6 +850,8 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
 
       {renderHiddenPreChatFieldsSection()}
 
+      {renderSendUtteranceSection('Service')}
+
       <View style={styles.buttonContainer}>
         <TouchableOpacity
           style={[styles.saveButton, loading && styles.buttonDisabled]}
@@ -859,6 +947,8 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
       )}
 
       {authSupported && renderContextVariablesSection()}
+
+      {authSupported && employeeLoggedIn && renderSendUtteranceSection('Employee')}
 
       {authSupported && employeeLoggedIn && (
         <View style={styles.buttonContainer}>
@@ -1116,6 +1206,12 @@ const styles = StyleSheet.create({
     fontSize: 15,
     color: '#212529',
     backgroundColor: '#ffffff',
+  },
+  utteranceInput: {
+    minHeight: 72,
+    textAlignVertical: 'top',
+    marginTop: 4,
+    marginBottom: 12,
   },
   buttonContainer: {
     gap: 12,


### PR DESCRIPTION
## What & why

Exposes `sendUtterance` on the React Native bridge so host apps can programmatically send a message into the active Agentforce conversation (Service or Employee), mirroring the native SDK's `AgentConversation.sendUtterance`.

Resolves **@W-23290581**.

## Changes

**Bridge API (`sendUtterance`)**
- **iOS** — `AgentforceModule.swift` bridges `sendUtterance(utterance:)` → native `conversation.sendUtterance(utterance:attachment:)`; registered in `AgentforceModule.m`. Guards on `isInvalidated` (hot reload) and `NO_CONVERSATION`, matching the existing `setAdditionalContext` handler.
- **Android** — `AgentforceModule.kt` `@ReactMethod sendUtterance` → native `conversation.sendUtterance(utterance)` on `Dispatchers.Main`, same `NO_CONVERSATION` guard.
- **TS** — `AgentforceService.sendUtterance(utterance)` with platform guard, non-empty-string validation, and success normalization.

**Sample app**
- Adds a **Send Utterance** section to the Settings screen (Service and Employee tabs), alongside Hidden PreChat Fields / Context Variables — preset quick-fill chips plus a free-form input. Launch a conversation from Home, then send from Settings.

**Android autolinking fix (bundled)**
- `MainApplication.java` now manually registers `AgentforcePackage`. Autolinking for the scoped `@salesforce/react-native-agentforce` package is disabled in `react-native.config.js` (from the npm-packaging change), so without manual registration `AgentforceModule` never loaded — surfacing as "Native module not available" and the Employee-agent Mobile SDK bridge not registering. This restores native module registration on Android.

## Testing
- 6 new Jest tests for `AgentforceService.sendUtterance` (happy path, success normalization, platform guard, validation, error propagation) — all passing.
- `tsc --noEmit` clean; ESLint clean on changed files.
- Verified on Android emulator: "Native module not available" warning gone, `EmployeeAgentAuthBridge` loads, and utterances deliver to the active conversation.