### PR TITLE
@W-23515856 Bump Agentforce SDK to 262.1 external release

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/build.gradle
+++ b/AgentforceSDK-ReactNative-Bridge/android/build.gradle
@@ -60,12 +60,8 @@ repositories {
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
     implementation "com.facebook.react:react-android"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk:15.66.2"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk-voice:15.66.2"
-    // shared-ui 2.0.21 pins slds-icons 0.1.0, which was never published to the
-    // public SLDSIcons Maven repo (only 0.1.7 is). Pin the available version so
-    // the transitive request resolves. Remove once shared-ui repins to a published tag.
-    api "com.salesforce.android.sldsicons:slds-icons:0.1.7"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk:15.101.5"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk-voice:15.101.5"
     // compileOnly: host app adds this for Employee Agent. Bridge compiles; host provides at runtime.
     compileOnly "com.salesforce.mobilesdk:SalesforceReact:13.1.1"
 

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNavigation.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeNavigation.kt
@@ -13,7 +13,6 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.salesforce.android.mobile.interfaces.navigation.Navigation
-import com.salesforce.android.mobile.interfaces.navigation.NavigationTarget
 import com.salesforce.android.mobile.interfaces.navigation.destination.App
 import com.salesforce.android.mobile.interfaces.navigation.destination.Destination
 import com.salesforce.android.mobile.interfaces.navigation.destination.Link
@@ -40,14 +39,6 @@ class BridgeNavigation(private val reactContext: ReactContext) : Navigation {
     }
 
     override fun goto(destination: Destination, replace: Boolean) {
-        if (!forwardingEnabled) return
-        emitDestination(destination, replace = replace)
-    }
-
-    // SDK 262.0 added a target-aware overload. The bridge surfaces a single
-    // navigation event to JS and does not distinguish targets, so forward the
-    // destination using the same emit path (honoring replace).
-    override fun goto(destination: Destination, target: NavigationTarget, replace: Boolean) {
         if (!forwardingEnabled) return
         emitDestination(destination, replace = replace)
     }

--- a/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
+++ b/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
@@ -34,9 +34,9 @@ Pod::Spec.new do |s|
     ]
     core.dependency "React-Core"
     core.dependency "AgentforceSDK"
-    core.dependency "AgentforceVoice", "2.1.7"
-    # AgentforceSDK 15.33.5 (262.0) publicly imports the SharedUI module but
-    # omits it from its podspec; declare it so this target can resolve it.
+    core.dependency "AgentforceVoice", "2.5.2"
+    # AgentforceSDK 17.31.6 (262.1) depends on SharedUI ('~> 1'); declare it so
+    # this target can resolve the design-system module.
     core.dependency "SharedUI", "1.3.1"
   end
 

--- a/AgentforceSDK-ReactNative-Bridge/src/types/AgentConfig.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/AgentConfig.ts
@@ -46,8 +46,6 @@ export interface ServiceUISettings {
   showQueueStatus?: boolean;
   /** Enable video upload in conversations (default: false, iOS only) */
   enableVideoUpload?: boolean;
-  /** Enable Lightning Type mapping for experience model types (default: false) */
-  enableLightningType?: boolean;
   /** Enable secure forms during conversations (default: false, iOS only) */
   secureForms?: boolean;
   /** Enable audio upload in conversations (default: false, iOS only) */
@@ -69,7 +67,6 @@ export interface ServiceUISettings {
  *   esDeveloperName: 'MyServiceAgent',
  *   serviceUISettings: {
  *     downloadTranscript: false,
- *     enableLightningType: true,
  *   },
  * };
  * ```

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -20,11 +20,11 @@ def shared_pods
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'AgentforceSDK', '15.33.5'
-  pod 'AgentforceVoice', '2.1.7'
+  pod 'AgentforceSDK', '17.31.6'
+  pod 'AgentforceVoice', '2.5.2'
   pod 'Messaging-InApp-Core', '> 1.10.0'
   # Messaging-Multimedia-Core vends SMIMultimediaCore.framework, which
-  # AgentforceVoice 2.1.7 links at runtime (@rpath/SMIMultimediaCore.framework).
+  # AgentforceVoice 2.5.2 links at runtime (@rpath/SMIMultimediaCore.framework).
   # The AgentforceVoice podspec resolved from this Specs source declares only
   # AgentforceService/SalesforceLogging/SalesforceNetwork (not the Binary subspec
   # that the iOS SDK uses), so this transitive multimedia dep isn't pulled in and
@@ -44,9 +44,9 @@ def shared_pods
   pod 'JWTKit'
 
   # SharedUI provides the design-system module (Colors/Fonts/Dimensions) that
-  # AgentforceSDK 15.33.5 (262.0) publicly imports but does not declare in its
-  # podspec. Pin to the flat spec the iOS SDK ships with; SLDSIcons is held at
-  # 1.2.2 to avoid the "Multiple commands produce SLDSIcons.framework" collision.
+  # AgentforceSDK 17.31.6 (262.1) depends on ('SharedUI', '~> 1'). Pin to the
+  # exact flat spec the iOS SDK ships with; SLDSIcons is held at 1.2.2 to avoid
+  # the "Multiple commands produce SLDSIcons.framework" collision.
   pod 'SharedUI', '1.3.1'
   pod 'SLDSIcons', '1.2.2'
 


### PR DESCRIPTION
## Summary

Bumps the Agentforce SDK dependencies to the **262.1 external release** across both platforms, and handles the two breaking API changes that come with it.

### Version changes

| Platform | Dependency | Old | New |
|---|---|---|---|
| iOS | AgentforceSDK | 15.33.5 | **17.31.6** |
| iOS | AgentforceVoice | 2.1.7 | **2.5.2** |
| iOS | AgentforceService (transitive) | — | 6.6.2 |
| Android | agentforce-sdk | 15.66.2 | **15.101.5** |
| Android | agentforce-sdk-voice | 15.66.2 | **15.101.5** |

### Breaking changes handled

- **`Navigation` interface (Android):** 262.1 removed the target-aware `goto(Destination, NavigationTarget, Boolean)` overload and the `NavigationTarget` type. Removed the now-invalid override and its import from `BridgeNavigation`; the surviving `goto(Destination)` / `goto(Destination, Boolean)` overloads cover event forwarding (the bridge never distinguished targets).
- **`ServiceUISettings` (cross-platform):** `enableLightningType` was dropped from the native init in 262.1. Removed the `enableLightningType` field (and its `@example` usage) from the `ServiceUISettings` TS type.

### Cleanup

- Dropped the temporary `slds-icons:0.1.7` workaround pin from the Android bridge `build.gradle`. That pin existed because an older `shared-ui` pinned an unpublished `slds-icons:0.1.0`; 262.1's `shared-ui` resolves a published `slds-icons` transitively, so the manual override is no longer needed.

## Verification

- ✅ iOS Service build
- ✅ iOS Employee build
- ✅ Android Service build
- ✅ Android Employee build
- ✅ `npm run format` clean
- ✅ `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run typecheck` — only pre-existing example-app errors (unresolved `@salesforce/react-native-agentforce` module + long-standing `SettingsScreen` types); none in the bridge files touched here.

## Work item

W-23515856