### PR TITLE
Downgrade Android minSdk 30 -> 29

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/build.gradle
+++ b/AgentforceSDK-ReactNative-Bridge/android/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdkVersion 30
+        minSdkVersion 29
         targetSdkVersion 36
         versionCode 1
         versionName "1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,7 @@
 buildscript {
     ext {
         compileSdk = 36
-        // agentforce-sdk-voice 15.66.2 (262.0) requires minSdk 30.
-        minSdkVersion = 30
+        minSdkVersion = 29
         targetSdkVersion = 35
         kotlin_version = '2.2.0'
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.


### PR DESCRIPTION
## Summary

Reverts the Android `minSdk` bump introduced in #110 (commit `2d5684a`, 262.0 SDK bump), which raised `minSdk` from 29 to 30 citing `agentforce-sdk-voice 15.66.2`.

The current SDK pin (`15.101.5`) no longer forces `minSdk` 30 in its manifest, so 29 is restored in both places:

| File | Change |
|------|--------|
| `android/build.gradle` | `minSdkVersion = 30` → `29` (removed stale comment) |
| `AgentforceSDK-ReactNative-Bridge/android/build.gradle` | `minSdkVersion 30` → `29` |

## Verification

Both Android variants build cleanly on the current SDK pin:
- `assembleServiceAgentDebug` → BUILD SUCCESSFUL
- `assembleEmployeeAgentDebug` → BUILD SUCCESSFUL

Confirmed the downgrade took effect (not silently overridden by manifest merger) via `aapt2 dump badging`:
- `app-serviceAgent-debug.apk` → `minSdkVersion:'29'`
- `app-employeeAgent-debug.apk` → `minSdkVersion:'29'`

No bootconfig files touched; diff limited to the two gradle files.