### PR TITLE
Expose dismissConversation to preserve chat history on dismiss

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/README.md
+++ b/AgentforceSDK-ReactNative-Bridge/README.md
@@ -105,3 +105,39 @@ await AgentforceService.setAdditionalContext({
 - Context persists for the current conversation session
 
 ---
+
+### Dismissing the conversation
+
+There are two ways to programmatically dismiss the chat UI, and they differ in what happens to the conversation:
+
+```typescript
+// Hide the chat but KEEP the conversation and its history.
+// This is the programmatic equivalent of the in-chat close (X) button.
+// A subsequent launchConversation() resumes where the user left off.
+await AgentforceService.dismissConversation();
+
+// End the conversation and DISCARD its history.
+// The next launchConversation() starts a fresh conversation.
+await AgentforceService.closeConversation();
+```
+
+Use `dismissConversation()` when you need to hide the chat on an event such as a
+navigation request without losing history:
+
+```typescript
+AgentforceService.setNavigationDelegate({
+  async onNavigate(request) {
+    await AgentforceService.dismissConversation();
+    if (request.type === 'link' && request.uri) {
+      Linking.openURL(request.uri);
+    }
+  },
+});
+```
+
+**Platform note (Android):** if the app navigates to a *different Android Activity*
+and then reconfigures the agent, conversation state may still be rebuilt on the next
+launch — a platform constraint independent of `dismissConversation()`. Staying within a
+single Activity preserves history across dismiss/relaunch.
+
+---

--- a/AgentforceSDK-ReactNative-Bridge/README.md
+++ b/AgentforceSDK-ReactNative-Bridge/README.md
@@ -135,7 +135,7 @@ AgentforceService.setNavigationDelegate({
 });
 ```
 
-**Platform note (Android):** if the app navigates to a *different Android Activity*
+**Platform note (Android):** if the app navigates to a _different Android Activity_
 and then reconfigures the agent, conversation state may still be rebuilt on the next
 launch — a platform constraint independent of `dismissConversation()`. Staying within a
 single Activity preserves history across dismiss/relaunch.

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -821,6 +821,27 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         }
     }
 
+    /**
+     * Dismiss the conversation UI while preserving the conversation and its history.
+     *
+     * This is the programmatic equivalent of the in-chat close (X) button: it only
+     * hides the overlay (see [AgentforceConversationOverlay.hide]) and leaves the
+     * client + conversation in [AgentforceClientHolder] intact, so the next
+     * [launchConversation] reuses the existing conversation with history preserved.
+     *
+     * Contrast with [closeConversation], which destroys the overlay and clears the
+     * conversation, forcing a fresh conversation on the next launch.
+     */
+    @ReactMethod
+    fun dismissConversation(promise: Promise) {
+        scope.launch(Dispatchers.Main) {
+            AgentforceConversationOverlay.hide()
+            promise.resolve(Arguments.createMap().apply {
+                putBoolean("success", true)
+            })
+        }
+    }
+
     @ReactMethod
     fun resetSettings(promise: Promise) {
         scope.launch(Dispatchers.Main) {

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
@@ -68,6 +68,9 @@ RCT_EXTERN_METHOD(launchConversation:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(closeConversation:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(dismissConversation:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(startNewConversation:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -1034,6 +1034,27 @@ class AgentforceModule: RCTEventEmitter {
         }
     }
 
+    /// Dismiss the conversation UI while preserving the conversation and its history.
+    ///
+    /// Programmatic equivalent of the in-chat close (X) button: it only dismisses the
+    /// presented UI via `dismissConversation()` and deliberately leaves
+    /// `currentConversation` alive, so the next `launchConversation` reuses it with
+    /// history preserved. Contrast with `closeConversation`, which ends the conversation
+    /// (via `closeCurrentConversation()`) before dismissing.
+    @objc
+    func dismissConversation(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        Task { @MainActor in
+            // Skip if the RN bridge has torn this module down (hot reload) so we
+            // don't run bridge work or resolve promises into a dead JS runtime.
+            guard !isInvalidated else { return }
+            dismissConversation()
+            resolve(["success": true])
+        }
+    }
+
     // MARK: - Hidden PreChat Fields
 
     /// Pre-register hidden prechat field values for the next Service Agent session.

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -847,6 +847,11 @@ class AgentforceService {
   /**
    * Close the current conversation.
    *
+   * Ends the conversation and discards its history — the next
+   * `launchConversation()` starts a fresh conversation. Use
+   * `dismissConversation()` instead if you want to hide the UI while
+   * keeping the conversation (and its history) alive.
+   *
    * @returns Promise<boolean> indicating success
    */
   async closeConversation(): Promise<boolean> {
@@ -864,6 +869,61 @@ class AgentforceService {
       return result?.success ?? true;
     } catch (error) {
       console.error('[AgentforceService] Failed to close conversation:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Dismiss the conversation UI while preserving the conversation and its history.
+   *
+   * This is the programmatic equivalent of the in-chat close (X) button: it hides
+   * the chat surface but keeps the underlying conversation alive, so a subsequent
+   * `launchConversation()` resumes where the user left off with history intact.
+   *
+   * Use this — rather than `closeConversation()` — when you need to dismiss the
+   * chat on events like a navigation request, without losing the conversation.
+   *
+   * @remarks
+   * On Android, if the app then navigates to a different Activity and reconfigures
+   * the agent, conversation state may still be rebuilt on the next launch (a
+   * platform constraint independent of this method). Staying on a single Activity
+   * preserves history across dismiss/relaunch.
+   *
+   * @returns Promise<boolean> indicating success
+   *
+   * @example
+   * ```typescript
+   * AgentforceService.setNavigationDelegate({
+   *   async onNavigate(request) {
+   *     // Hide the chat but keep history, then handle the navigation.
+   *     await AgentforceService.dismissConversation();
+   *     if (request.type === 'link' && request.uri) {
+   *       Linking.openURL(request.uri);
+   *     }
+   *   },
+   * });
+   * ```
+   */
+  async dismissConversation(): Promise<boolean> {
+    if (Platform.OS !== 'android' && Platform.OS !== 'ios') {
+      return false;
+    }
+
+    if (!AgentforceModule) {
+      return false;
+    }
+
+    if (!AgentforceModule.dismissConversation) {
+      console.warn('[AgentforceService] dismissConversation not available on native module');
+      return false;
+    }
+
+    try {
+      const result = await AgentforceModule.dismissConversation();
+      console.log('[AgentforceService] Conversation dismissed (history preserved)');
+      return result?.success ?? true;
+    } catch (error) {
+      console.error('[AgentforceService] Failed to dismiss conversation:', error);
       return false;
     }
   }

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.test.ts
@@ -26,6 +26,7 @@ jest.mock('react-native', () => {
     launchConversation: jest.fn().mockResolvedValue({ success: true }),
     startNewConversation: jest.fn().mockResolvedValue({ success: true }),
     closeConversation: jest.fn().mockResolvedValue({ success: true }),
+    dismissConversation: jest.fn().mockResolvedValue({ success: true }),
     sendUtterance: jest.fn().mockResolvedValue({ success: true }),
     isConfigured: jest.fn(),
     getConfiguration: jest.fn(),
@@ -421,5 +422,57 @@ describe('AgentforceService.sendUtterance', () => {
   it('propagates native errors', async () => {
     nativeModule.sendUtterance.mockRejectedValueOnce(new Error('NO_CONVERSATION'));
     await expect(AgentforceService.sendUtterance('hi')).rejects.toThrow('NO_CONVERSATION');
+  });
+});
+
+describe('AgentforceService.dismissConversation', () => {
+  beforeEach(() => {
+    setPlatform('ios');
+    nativeModule.dismissConversation.mockClear();
+    nativeModule.dismissConversation.mockResolvedValue({ success: true });
+  });
+
+  // Happy path — forwards to the native dismiss (preserve-history) method.
+  it('calls the native dismissConversation and resolves the success flag', async () => {
+    await expect(AgentforceService.dismissConversation()).resolves.toBe(true);
+    expect(nativeModule.dismissConversation).toHaveBeenCalledTimes(1);
+  });
+
+  // Distinct from closeConversation — dismiss must not tear the conversation down.
+  it('does not call the destructive closeConversation', async () => {
+    await AgentforceService.dismissConversation();
+    expect(nativeModule.closeConversation).not.toHaveBeenCalled();
+  });
+
+  // Normalization — default to true when native omits success, honor explicit false.
+  it('defaults to true when the native result omits success', async () => {
+    nativeModule.dismissConversation.mockResolvedValueOnce({});
+    await expect(AgentforceService.dismissConversation()).resolves.toBe(true);
+  });
+
+  it('resolves false when the native result reports success: false', async () => {
+    nativeModule.dismissConversation.mockResolvedValueOnce({ success: false });
+    await expect(AgentforceService.dismissConversation()).resolves.toBe(false);
+  });
+
+  // Platform guard — unsupported platforms return false without touching native.
+  it('returns false and skips the native call on unsupported platforms', async () => {
+    setPlatform('web');
+    await expect(AgentforceService.dismissConversation()).resolves.toBe(false);
+    expect(nativeModule.dismissConversation).not.toHaveBeenCalled();
+  });
+
+  // Back-compat guard — older native modules without the method resolve false, not throw.
+  it('returns false when the native module lacks dismissConversation', async () => {
+    const original = nativeModule.dismissConversation;
+    (nativeModule as any).dismissConversation = undefined;
+    await expect(AgentforceService.dismissConversation()).resolves.toBe(false);
+    (nativeModule as any).dismissConversation = original;
+  });
+
+  // Error handling — a native rejection is swallowed and reported as false.
+  it('returns false when the native call rejects', async () => {
+    nativeModule.dismissConversation.mockRejectedValueOnce(new Error('boom'));
+    await expect(AgentforceService.dismissConversation()).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds a `dismissConversation()` method that hides the chat UI while **preserving the conversation and its history** — the programmatic equivalent of the in-chat close (X) button.

Previously the only exported dismiss path was `closeConversation()`, which ends the conversation and discards history. Consumers therefore had no way to programmatically dismiss the chat (e.g. on a navigation request) without losing history on reopen.

## Root cause

The in-chat X button and the exported `closeConversation()` are **not** the same operation:

| | Behavior | History |
|---|---|---|
| X button | dismiss only, keeps conversation alive | ✅ preserved |
| `closeConversation()` | ends conversation + clears reference | ❌ wiped on reopen |

On both platforms the history-preserving dismiss primitive existed internally (Android `AgentforceConversationOverlay.hide()`, iOS private `dismissConversation()`) but was never surfaced as a bridge method. This PR exposes it.

## Changes

- **JS** — `AgentforceService.dismissConversation()` with platform and missing-native-method guards
- **Android** — `@ReactMethod dismissConversation` calling `AgentforceConversationOverlay.hide()` (leaves client + conversation in `AgentforceClientHolder` intact)
- **iOS** — `@objc` method + `RCT_EXTERN_METHOD` calling the preserve-history `dismissConversation()` helper
- **Tests** — 7 new JS tests (full bridge suite: 76 passing); TypeScript + ESLint clean
- **Docs** — README section documenting `dismissConversation()` vs `closeConversation()` with a navigation-delegate example

## Known limitation (Android)

On Android, if the app navigates to a **separate Activity** and then reconfigures the agent, conversation state may still be rebuilt on next launch — the activity-scoped SDK bootstrap constraint (the by-design discovery-404 workaround), independent of this method. Documented in the JSDoc and README. Single-Activity hosts preserve history across dismiss/relaunch.

## Test plan

- [x] `jest AgentforceSDK-ReactNative-Bridge` — 76 passing
- [x] `tsc -p tsconfig.build.json --noEmit` — clean
- [x] `eslint` on changed files — clean
- [ ] Native rebuild required for the method to be live (Android build / `pod install` + iOS build)