### PR TITLE
Set valid GUSINFO in CODEOWNERS (scrum team + product tag)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
 #ECCN:Open Source
-#GUSINFO:Open Source,Open Source Workflow
+#GUSINFO:Agentforce Mobile Experience,Mobile Agentforce SDK - React Native


### PR DESCRIPTION
## Summary
Fixes the OSPO compliance issue flagged for this repo: the `CODEOWNERS` file's `#GUSINFO:` line used the invalid placeholder `Open Source,Open Source Workflow`, which OSPO explicitly disallows.

## Change
```
- #GUSINFO:Open Source,Open Source Workflow
+ #GUSINFO:Agentforce Mobile Experience,Mobile Agentforce SDK - React Native
```

Both values were resolved from GUS and confirmed as **Active** records:
- **Scrum Team:** Agentforce Mobile Experience
- **Product Tag:** Mobile Agentforce SDK - React Native

Format follows the `oss-template` spec (left-aligned `#GUSINFO:<Team>,<Tag>`).

## Context
Requested by the Salesforce OSPO (Jim Jagielski) as part of FY27 compliance checking of GitHub repos managed by the OSPO.