### PR TITLE
Bump @salesforce/react-native-agentforce to 0.3.0 (sync dev)

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/package.json
+++ b/AgentforceSDK-ReactNative-Bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/react-native-agentforce",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Agentforce React Native bridge: JS API and native module for Service Agent and Employee Agent (auth bridge included; host app adds Mobile SDK).",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## What
Bump the bridge package version to `0.3.0` on `dev`.

## Why
Keeps `dev` in sync with the `0.3.0` release cut from `main` (companion PR), so the next release cycle starts from the correct baseline instead of the stale `1.0.0`.

Companion PR: release into `main` (which is the one that gets tagged `v0.3.0` and published).