### PR TITLE
Fix npm publish workflow: Node 20 -> 22 (EBADENGINE)

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -53,11 +53,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       # OIDC Trusted Publishing requires a recent npm. setup-node ships an older
-      # npm with Node 20, so upgrade to a version that supports --provenance via OIDC.
+      # npm with Node 22, so upgrade to a version that supports --provenance via OIDC.
+      # Node 22 (>=22.22.2) is required by current npm@latest — Node 20 fails EBADENGINE.
       - name: Upgrade npm (OIDC trusted publishing support)
         run: npm install -g npm@latest
 


### PR DESCRIPTION
## Problem
The `v0.3.0` tag triggered `publish-npm-package.yml`, but it failed at the `npm install -g npm@latest` step:

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

Current `npm@latest` (12.x) dropped Node 20 support. The global upgrade fell back to the stock `npm@10.8.2`, and the run failed before publishing. **npm is still at `0.0.0` — `0.3.0` did not publish.**

## Fix
Bump `actions/setup-node` from Node 20 to Node 22 so `npm@latest` installs and the OIDC `--provenance` publish works.

## Follow-up after merge
The `v0.3.0` tag must be moved to the commit containing this fix (tag-triggered workflows run the workflow file *at the tagged commit*), then re-pushed to re-trigger the publish. I'll handle that once this merges.

Companion PR syncs `dev`.