### PR TITLE
Fix bridge build in standalone CI (sync dev)

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/package.json
+++ b/AgentforceSDK-ReactNative-Bridge/package.json
@@ -58,6 +58,10 @@
     "react-native": "*"
   },
   "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.2.0",
+    "react": "18.2.0",
+    "react-native": "0.74.7",
     "rimraf": "^5.0.5",
     "typescript": "^5.0.4"
   },

--- a/AgentforceSDK-ReactNative-Bridge/tsconfig.json
+++ b/AgentforceSDK-ReactNative-Bridge/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
+    "lib": ["es2017"],
     "module": "commonjs",
     "jsx": "react",
     "strict": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,9 +48,13 @@
     },
     "AgentforceSDK-ReactNative-Bridge": {
       "name": "@salesforce/react-native-agentforce",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@types/node": "^20.11.0",
+        "@types/react": "^18.2.0",
+        "react": "18.2.0",
+        "react-native": "0.74.7",
         "rimraf": "^5.0.5",
         "typescript": "^5.0.4"
       },
@@ -61,6 +65,23 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "AgentforceSDK-ReactNative-Bridge/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "AgentforceSDK-ReactNative-Bridge/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",


### PR DESCRIPTION
Sync `dev` with the standalone-build fix landing on `main` (companion PR): add react/react-native/@types as devDependencies and bump tsconfig target/lib to es2017 so `tsc` passes in the isolated publish build.