### PR TITLE
W-23664173: Fix onAgentResponse no-op on iOS

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -124,6 +124,7 @@ class AgentforceModule: RCTEventEmitter {
             "onNavigationRequest",
             "onUtteranceSent",
             "onAgentSwitch",
+            "onAgentResponse",
             "onModifyUtteranceRequest",
         ]
     }
@@ -1059,6 +1060,11 @@ class AgentforceModule: RCTEventEmitter {
     func emitAgentSwitchEvent(_ payload: [String: Any]) {
         guard listenerLock.withLock({ _hasListeners }) else { return }
         sendEvent(withName: "onAgentSwitch", body: payload)
+    }
+
+    func emitAgentResponseEvent(_ payload: [String: Any]) {
+        guard listenerLock.withLock({ _hasListeners }) else { return }
+        sendEvent(withName: "onAgentResponse", body: payload)
     }
 
     // MARK: - View Provider

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeUIDelegate.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeUIDelegate.swift
@@ -93,9 +93,20 @@ class BridgeUIDelegate: AgentforceUIDelegate {
         // Voice is managed internally in 260.5 - no forwarding needed.
     }
 
-    // didReceiveResponse is a no-op on iOS: AgentforceMessage properties are internal
-    // in SDK 260.5, so the bridge cannot extract message text, type, or timestamp.
-    // Android exposes these publicly via its data class. Re-evaluate when the iOS SDK
-    // makes AgentforceMessage fields public.
-    func didReceiveResponse(_ message: AgentforceMessage, from conversation: any AgentConversation) {}
+    func didReceiveResponse(_ message: AgentforceMessage, from conversation: any AgentConversation) {
+        guard forwardingEnabled, message.state == .finished else { return }
+
+        // AgentforceSDK.AgentforceMessage does not yet expose `id` or `type`.
+        // Generate a local responseId and derive type from isUserMessage until
+        // the SDK surfaces those properties.
+        let payload: [String: Any] = [
+            "responseId": UUID().uuidString,
+            "message": message.message ?? NSNull(),
+            "type": message.isUserMessage ? "user" : "agent",
+            "conversationId": conversation.conversationId.uuidString,
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+        ]
+
+        module?.emitAgentResponseEvent(payload)
+    }
 }

--- a/AgentforceSDK-ReactNative-Bridge/src/types/UIDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/UIDelegate.ts
@@ -69,7 +69,7 @@ export interface ModifyUtteranceRequest {
  * ```
  */
 export interface UIDelegate {
-  /** Called when the agent sends a response. Android only — iOS SDK does not expose message fields publicly. */
+  /** Called when the agent sends a completed (non-streaming) response. */
   onAgentResponse?(event: AgentResponseEvent): void;
   onUtteranceSent?(event: UtteranceSentEvent): void;
   onAgentSwitch?(event: AgentSwitchEvent): void;


### PR DESCRIPTION
## W-23664173: `onAgentResponse` never fires on iOS

### Problem
`BridgeUIDelegate.didReceiveResponse` on iOS was a hard-coded no-op, based on the (now stale) premise that `AgentforceMessage`'s `message`/`state`/`isUserMessage`/`isWelcomeMessage` fields were internal. They are `public` in the pinned SDK, and the SDK already invokes the delegate with a finished message. As a result the JS `onAgentResponse` delegate — already wired in `AgentforceService.ts` — silently never received an event on iOS, while Android forwarded it correctly.

### Fix
Mirror the Android bridge behavior:
1. `ios/Agentforce/BridgeUIDelegate.swift` — implement `didReceiveResponse`: gate on `forwardingEnabled` and `message.state == .finished`, build a payload (`responseId`, `message`, `type`, `conversationId`, `timestamp`) from public fields, and emit via `module?.emitAgentResponseEvent`. `type` is derived from `isUserMessage` (`user`/`agent`); `responseId`/`timestamp` are bridge-synthesized because the SDK's canonical values remain non-public.
2. `ios/Agentforce/AgentforceModule.swift` — add `emitAgentResponseEvent(_:)` (mirroring the other emit methods) and register `onAgentResponse` in `supportedEvents()`.
3. `src/types/UIDelegate.ts` — correct the stale "Android only" doc comment.

No JS changes: `AgentforceService.ts` already listens for `onAgentResponse` and forwards to the client delegate.

### Tests
- `npm test` — 116/116 passing (9 suites).
- `npm run typecheck` — no new errors introduced by this change; the 11 pre-existing errors also present on the `dev` baseline are in the sample app and unrelated to `UIDelegate.ts`.
- Swift changes are not covered by an automated iOS bridge test target (none exists in the repo); manual integration verification per the Solution Spec test plan.

### Analysis docs
- Root Cause Analysis and Solution Spec authored for W-23664173 (see the work item's Chatter for the Google Doc links; local copies under `BugAnalysis/`).
