### PR TITLE
Fix onAgentResponse no-op on iOS (W-23664173) [main]

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -124,6 +124,7 @@ class AgentforceModule: RCTEventEmitter {
             "onNavigationRequest",
             "onUtteranceSent",
             "onAgentSwitch",
+            "onAgentResponse",
             "onModifyUtteranceRequest",
         ]
     }
@@ -1059,6 +1060,11 @@ class AgentforceModule: RCTEventEmitter {
     func emitAgentSwitchEvent(_ payload: [String: Any]) {
         guard listenerLock.withLock({ _hasListeners }) else { return }
         sendEvent(withName: "onAgentSwitch", body: payload)
+    }
+
+    func emitAgentResponseEvent(_ payload: [String: Any]) {
+        guard listenerLock.withLock({ _hasListeners }) else { return }
+        sendEvent(withName: "onAgentResponse", body: payload)
     }
 
     // MARK: - View Provider

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeUIDelegate.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeUIDelegate.swift
@@ -93,9 +93,20 @@ class BridgeUIDelegate: AgentforceUIDelegate {
         // Voice is managed internally in 260.5 - no forwarding needed.
     }
 
-    // didReceiveResponse is a no-op on iOS: AgentforceMessage properties are internal
-    // in SDK 260.5, so the bridge cannot extract message text, type, or timestamp.
-    // Android exposes these publicly via its data class. Re-evaluate when the iOS SDK
-    // makes AgentforceMessage fields public.
-    func didReceiveResponse(_ message: AgentforceMessage, from conversation: any AgentConversation) {}
+    func didReceiveResponse(_ message: AgentforceMessage, from conversation: any AgentConversation) {
+        guard forwardingEnabled, message.state == .finished else { return }
+
+        // AgentforceSDK.AgentforceMessage does not yet expose `id` or `type`.
+        // Generate a local responseId and derive type from isUserMessage until
+        // the SDK surfaces those properties.
+        let payload: [String: Any] = [
+            "responseId": UUID().uuidString,
+            "message": message.message ?? NSNull(),
+            "type": message.isUserMessage ? "user" : "agent",
+            "conversationId": conversation.conversationId.uuidString,
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+        ]
+
+        module?.emitAgentResponseEvent(payload)
+    }
 }

--- a/AgentforceSDK-ReactNative-Bridge/src/types/UIDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/UIDelegate.ts
@@ -69,7 +69,7 @@ export interface ModifyUtteranceRequest {
  * ```
  */
 export interface UIDelegate {
-  /** Called when the agent sends a response. Android only — iOS SDK does not expose message fields publicly. */
+  /** Called when the agent sends a completed (non-streaming) response. */
   onAgentResponse?(event: AgentResponseEvent): void;
   onUtteranceSent?(event: UtteranceSentEvent): void;
   onAgentSwitch?(event: AgentSwitchEvent): void;


### PR DESCRIPTION
## Summary
Same fix as #134, cherry-picked onto `main` since the affected files (`BridgeUIDelegate.swift`, `AgentforceModule.swift`, `UIDelegate.ts`) are currently identical between `main` and `dev`.

- `didReceiveResponse` in the iOS RN bridge was a hard no-op, stubbed out when `AgentforceMessage`'s useful properties were still SDK-internal. Those properties (`message`, `state`, `isUserMessage`, `isWelcomeMessage`) have since been made public and are already included in the SDK version this bridge depends on (17.31.6 / 262.1).
- Wires up `didReceiveResponse` to emit `onAgentResponse` to JS, matching existing Android behavior, and adds the corresponding `emitAgentResponseEvent` plumbing + event registration in `AgentforceModule.swift`.
- `responseId` and `timestamp` remain internal on `AgentforceMessage`, so the bridge generates its own `responseId` (UUID) and timestamp (emission time) for now.
- Updates the stale `UIDelegate.ts` doc comment that claimed `onAgentResponse` was Android-only.

## Test plan
- [x] `swift -frontend -parse` on both modified Swift files — no syntax errors
- [x] `npx jest AgentforceService.test.ts` against `main`'s tree — all 51 existing tests pass
- [ ] Manual verification on a physical/simulator iOS RN app (not run in this session — no iOS build environment available)