### PR TITLE
Bump Agentforce SDK: iOS 17.31.6 → 18.26.8, Android 15.101.5 → 15.130.1

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/build.gradle
+++ b/AgentforceSDK-ReactNative-Bridge/android/build.gradle
@@ -60,8 +60,8 @@ repositories {
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
     implementation "com.facebook.react:react-android"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk:15.101.5"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk-voice:15.101.5"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk:15.130.1"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk-voice:15.130.1"
     // compileOnly: host app adds this for Employee Agent. Bridge compiles; host provides at runtime.
     compileOnly "com.salesforce.mobilesdk:SalesforceReact:13.1.1"
 

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -291,7 +291,7 @@ class AgentforceModule: RCTEventEmitter {
 
         // Always pass bridgeViewProvider so late registrations take effect.
         // canHandle() returns false when the map is empty, matching nil behavior.
-        agentforceClient = AgentforceClient(
+        agentforceClient = await AgentforceClient(
             credentialProvider: credentialProvider,
             mode: .serviceAgent(serviceConfig),
             viewProvider: bridgeViewProvider
@@ -405,7 +405,7 @@ class AgentforceModule: RCTEventEmitter {
             print("[AgentforceModule] Creating new AgentforceClient for Employee Agent")
             // Always pass bridgeViewProvider so late registrations take effect.
             // canHandle() returns false when the map is empty, matching nil behavior.
-            agentforceClient = AgentforceClient(
+            agentforceClient = await AgentforceClient(
                 credentialProvider: credentialProvider,
                 mode: .fullConfig(fullConfiguration),
                 viewProvider: bridgeViewProvider

--- a/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
+++ b/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
     ]
     core.dependency "React-Core"
     core.dependency "AgentforceSDK"
-    core.dependency "AgentforceVoice", "2.5.2"
+    core.dependency "AgentforceVoice", "2.8.2"
     # AgentforceSDK 17.31.6 (262.1) depends on SharedUI ('~> 1'); declare it so
     # this target can resolve the design-system module.
     core.dependency "SharedUI", "1.3.1"

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -20,8 +20,8 @@ def shared_pods
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'AgentforceSDK', '17.31.6'
-  pod 'AgentforceVoice', '2.5.2'
+  pod 'AgentforceSDK', '18.26.8'
+  pod 'AgentforceVoice', '2.8.2'
   pod 'Messaging-InApp-Core', '> 1.10.0'
   # Messaging-Multimedia-Core vends SMIMultimediaCore.framework, which
   # AgentforceVoice 2.5.2 links at runtime (@rpath/SMIMultimediaCore.framework).


### PR DESCRIPTION
## Summary
- Bumps `AgentforceSDK` 17.31.6 → 18.26.8 and `AgentforceVoice` 2.5.2 → 2.8.2 on iOS (`ios/Podfile.common.rb`, `ReactNativeAgentforce.podspec`)
- Bumps `agentforce-sdk` / `agentforce-sdk-voice` 15.101.5 → 15.130.1 on Android (`build.gradle`)
- Both platforms land on the 262.1.2 SDK release cohort
- Fixes a required code change: AgentforceSDK 18.26.8 builds with Swift 6 strict concurrency, making `AgentforceClient`'s initializer main-actor-isolated. Added `await` at both call sites in `AgentforceModule.swift` (already inside `async throws` functions)

## Test plan
- [x] `node installios.js service && npm run build:ios:service` — BUILD SUCCEEDED
- [x] `node installios.js employee && npm run build:ios:employee` — BUILD SUCCEEDED
- [x] `node installandroid.js service && npm run build:android:service` — BUILD SUCCESSFUL
- [x] `node installandroid.js employee && npm run build:android:employee` — BUILD SUCCESSFUL
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run format` — passes
- [x] `npm run typecheck` — pre-existing errors only (confirmed identical against base commit via `git stash`)