### PR TITLE
Release @salesforce/react-native-agentforce 0.4.0

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/package.json
+++ b/AgentforceSDK-ReactNative-Bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/react-native-agentforce",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Agentforce React Native bridge: JS API and native module for Service Agent and Employee Agent (auth bridge included; host app adds Mobile SDK).",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## What
Bump the bridge package version to `0.4.0` in preparation for the npm release.

## Why
The publish workflow (`publish-npm-package.yml`) verifies that the pushed git tag matches `AgentforceSDK-ReactNative-Bridge/package.json`. The package is currently at `0.3.0`; this sets it to `0.4.0` so tagging `v0.4.0` on main triggers a clean publish to npm, covering the Agentforce SDK 262.1.2 bump (iOS `AgentforceSDK` 18.26.8 / Android `agentforce-sdk` 15.130.1, #137/#140).

## Release steps (after this merges)
1. Merge this PR into `main`.
2. Tag the merge commit: `git tag v0.4.0 && git push origin v0.4.0`.
3. The tag push triggers `publish-npm-package.yml`, which publishes `@salesforce/react-native-agentforce@0.4.0` via OIDC trusted publishing (`--provenance`).

Companion PR bumps `dev` to keep it in sync.