### PR TITLE
Bump @salesforce/react-native-agentforce to 0.4.0 (sync dev)

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/package.json
+++ b/AgentforceSDK-ReactNative-Bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/react-native-agentforce",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Agentforce React Native bridge: JS API and native module for Service Agent and Employee Agent (auth bridge included; host app adds Mobile SDK).",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Summary

Keeps `dev`'s bridge package version in sync with the 0.4.0 release cut from `main` (#141), which covers the Agentforce SDK bump (iOS 18.26.8 / Android 15.130.1, #137/#140).

Companion to #141 — same pattern as #129 (the 0.3.0 dev-sync PR).

## Test plan

- [x] Version-only change, no build impact