### PR TITLE
@W-23683165 Support direct launch into Voice mode 

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceConversationOverlay.kt
@@ -53,6 +53,7 @@ object AgentforceConversationOverlay {
     private const val TAG = "AgentforceConvOverlay"
 
     internal var isVisible = mutableStateOf(false)
+    internal var isVoiceMode = mutableStateOf(false)
     private var overlayContainer: ViewGroup? = null
     private var attachedActivity: ComponentActivity? = null
 
@@ -73,7 +74,7 @@ object AgentforceConversationOverlay {
      * Show the conversation overlay on the given Activity.
      * Creates the ComposeView on first call, then toggles visibility.
      */
-    fun show(activity: Activity) {
+    fun show(activity: Activity, voiceMode: Boolean = false) {
         if (activity !is ComponentActivity) {
             Log.e(TAG, "Activity must be a ComponentActivity")
             return
@@ -83,8 +84,9 @@ object AgentforceConversationOverlay {
             attachToActivity(activity)
         }
 
+        isVoiceMode.value = voiceMode
         isVisible.value = true
-        Log.d(TAG, "Conversation overlay shown")
+        Log.d(TAG, "Conversation overlay shown (voiceMode=$voiceMode)")
     }
 
     /**
@@ -110,6 +112,7 @@ object AgentforceConversationOverlay {
         overlayContainer = null
         attachedActivity = null
         isVisible.value = false
+        isVoiceMode.value = false
         Log.d(TAG, "Conversation overlay destroyed")
     }
 
@@ -167,6 +170,7 @@ object AgentforceConversationOverlay {
 @Composable
 private fun ConversationOverlayContent(onClose: () -> Unit) {
     val visible by AgentforceConversationOverlay.isVisible
+    val voiceMode by AgentforceConversationOverlay.isVoiceMode
 
     val client = AgentforceClientHolder.agentforceClient
     val conversation = AgentforceClientHolder.currentConversation
@@ -210,10 +214,17 @@ private fun ConversationOverlayContent(onClose: () -> Unit) {
                 .navigationBarsPadding()
                 .imePadding()
         ) {
-            client.AgentforceConversationContainer(
-                conversation = conversation,
-                onClose = onClose
-            )
+            if (voiceMode) {
+                client.AgentforceVoiceContainer(
+                    session = conversation,
+                    onClose = onClose
+                )
+            } else {
+                client.AgentforceConversationContainer(
+                    conversation = conversation,
+                    onClose = onClose
+                )
+            }
         }
     }
 }

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -471,15 +471,31 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
 
     /**
      * Launch the Agentforce conversation UI - works for both Service and Employee agents
+     *
+     * @param options Optional map with "initialMode": "chat" | "voice"
+     * @param promise Promise to resolve/reject
      */
     @ReactMethod
-    fun launchConversation(promise: Promise) {
+    fun launchConversation(options: ReadableMap?, promise: Promise) {
         Log.d(TAG, "launchConversation() called")
+
+        val initialMode = options?.getString("initialMode") ?: "chat"
+        Log.d(TAG, "launchConversation: initialMode=$initialMode")
 
         val activity = currentActivity
         if (activity == null) {
             promise.reject("ERROR", "Activity not available")
             return
+        }
+
+        // Validate Voice feature flag if Voice mode requested
+        if (initialMode == "voice") {
+            val featureFlagSettings = AgentforceFeatureFlagSettings.getInstance()
+            if (!featureFlagSettings.enableVoice) {
+                Log.e(TAG, "Voice mode requested but enableVoice feature flag is disabled")
+                promise.reject("VOICE_DISABLED", "Voice is not enabled for this Agentforce configuration")
+                return
+            }
         }
 
         // Check if configured via new unified path or legacy path
@@ -497,7 +513,20 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                 try {
                     viewModel?.initializeAgentforce()
 
-                    AgentforceConversationOverlay.show(activity)
+                    if (initialMode == "voice") {
+                        // Launch Voice UI directly
+                        val conversation = AgentforceClientHolder.currentConversation
+                        if (conversation != null) {
+                            conversation.startVoice()
+                            Log.d(TAG, "Voice mode started (legacy path)")
+                        } else {
+                            Log.e(TAG, "Failed to start voice mode: no active conversation")
+                            promise.reject("VOICE_START_ERROR", "Failed to start voice mode")
+                            return@launch
+                        }
+                    } else {
+                        AgentforceConversationOverlay.show(activity)
+                    }
                     promise.resolve(Arguments.createMap().apply {
                         putBoolean("success", true)
                     })
@@ -519,10 +548,24 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     if (!createConversation(promise, "LAUNCH_ERROR")) return@launch
                 }
 
-                // Show conversation as overlay on current Activity (preserves ViewModel across show/hide)
-                AgentforceConversationOverlay.show(activity)
+                // Route to Voice or Chat UI based on initialMode
+                if (initialMode == "voice") {
+                    // Launch Voice UI directly
+                    val conversation = AgentforceClientHolder.currentConversation
+                    if (conversation != null) {
+                        conversation.startVoice()
+                        Log.d(TAG, "Voice mode started")
+                    } else {
+                        Log.e(TAG, "Failed to start voice mode: no active conversation")
+                        promise.reject("VOICE_START_ERROR", "Failed to start voice mode")
+                        return@launch
+                    }
+                } else {
+                    // Show conversation as overlay on current Activity (preserves ViewModel across show/hide)
+                    AgentforceConversationOverlay.show(activity)
+                    Log.d(TAG, "Chat mode shown")
+                }
 
-                Log.d(TAG, "Conversation overlay shown")
                 promise.resolve(Arguments.createMap().apply {
                     putBoolean("success", true)
                 })

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -222,6 +222,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                 // enableVoice flag like the Employee path; the MIAW voice provider is
                 // registered below via setBridgeVoiceModule().
                 val flags = getFeatureFlagsFromConfigOrPrefs(config)
+                saveFeatureFlagsToPrefs(flags)
                 val featureFlagSettings = AgentforceFeatureFlagSettings.builder()
                     .enableMultiAgent(flags.enableMultiAgent)
                     .enableMultiModalInput(flags.enableMultiModalInput)
@@ -331,6 +332,9 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         employeePrefs.edit().putString(KEY_EMPLOYEE_AGENT_ID, employeeConfig.agentId ?: "").apply()
 
         scope.launch(Dispatchers.Main) {
+            val flags = getFeatureFlagsFromConfigOrPrefs(config)
+            saveFeatureFlagsToPrefs(flags)
+
             if (!needsNewClient) {
                 // Reuse the existing client and its conversation (credentials refresh automatically
                 // via UnifiedCredentialProvider). Preserves conversation history across re-launch.
@@ -350,7 +354,6 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             AgentforceClientHolder.clear()
             try {
                 // Create AgentforceConfiguration for FullConfig mode
-                val flags = getFeatureFlagsFromConfigOrPrefs(config)
                 val featureFlagSettings = AgentforceFeatureFlagSettings.builder()
                     .enableMultiAgent(flags.enableMultiAgent)
                     .enableMultiModalInput(flags.enableMultiModalInput)
@@ -489,13 +492,10 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         }
 
         // Validate Voice feature flag if Voice mode requested
-        if (initialMode == "voice") {
-            val featureFlagSettings = AgentforceFeatureFlagSettings.getInstance()
-            if (!featureFlagSettings.enableVoice) {
-                Log.e(TAG, "Voice mode requested but enableVoice feature flag is disabled")
-                promise.reject("VOICE_DISABLED", "Voice is not enabled for this Agentforce configuration")
-                return
-            }
+        if (initialMode == "voice" && !getFeatureFlagsFromConfigOrPrefs(Arguments.createMap()).enableVoice) {
+            Log.e(TAG, "Voice mode requested but enableVoice feature flag is disabled")
+            promise.reject("VOICE_DISABLED", "Voice is not enabled for this Agentforce configuration")
+            return
         }
 
         // Check if configured via new unified path or legacy path
@@ -513,20 +513,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                 try {
                     viewModel?.initializeAgentforce()
 
-                    if (initialMode == "voice") {
-                        // Launch Voice UI directly
-                        val conversation = AgentforceClientHolder.currentConversation
-                        if (conversation != null) {
-                            conversation.startVoice()
-                            Log.d(TAG, "Voice mode started (legacy path)")
-                        } else {
-                            Log.e(TAG, "Failed to start voice mode: no active conversation")
-                            promise.reject("VOICE_START_ERROR", "Failed to start voice mode")
-                            return@launch
-                        }
-                    } else {
-                        AgentforceConversationOverlay.show(activity)
-                    }
+                    AgentforceConversationOverlay.show(activity, voiceMode = initialMode == "voice")
                     promise.resolve(Arguments.createMap().apply {
                         putBoolean("success", true)
                     })
@@ -548,23 +535,8 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     if (!createConversation(promise, "LAUNCH_ERROR")) return@launch
                 }
 
-                // Route to Voice or Chat UI based on initialMode
-                if (initialMode == "voice") {
-                    // Launch Voice UI directly
-                    val conversation = AgentforceClientHolder.currentConversation
-                    if (conversation != null) {
-                        conversation.startVoice()
-                        Log.d(TAG, "Voice mode started")
-                    } else {
-                        Log.e(TAG, "Failed to start voice mode: no active conversation")
-                        promise.reject("VOICE_START_ERROR", "Failed to start voice mode")
-                        return@launch
-                    }
-                } else {
-                    // Show conversation as overlay on current Activity (preserves ViewModel across show/hide)
-                    AgentforceConversationOverlay.show(activity)
-                    Log.d(TAG, "Chat mode shown")
-                }
+                AgentforceConversationOverlay.show(activity, voiceMode = initialMode == "voice")
+                Log.d(TAG, "Conversation shown (initialMode=$initialMode)")
 
                 promise.resolve(Arguments.createMap().apply {
                     putBoolean("success", true)

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeUIDelegate.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/BridgeUIDelegate.kt
@@ -141,6 +141,7 @@ class BridgeUIDelegate(private val reactContext: ReactContext) : AgentforceUIDel
             putString("message", agentforceMessage.message ?: agentforceMessage.text)
             putString("type", agentforceMessage.type ?: "agent")
             putString("conversationId", getConversationId(conversation))
+            putString("sessionId", conversation.sessionId.value)
             putString("timestamp", formatTimestamp(agentforceMessage.timeStamp))
         }
 

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.m
@@ -71,7 +71,8 @@ RCT_EXTERN_METHOD(setInternalFlags:(NSDictionary *)flags
 
 // MARK: - Conversation Methods
 
-RCT_EXTERN_METHOD(launchConversation:(RCTPromiseResolveBlock)resolve
+RCT_EXTERN_METHOD(launchConversation:(NSDictionary *)options
+                  resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(closeConversation:(RCTPromiseResolveBlock)resolve

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -266,6 +266,7 @@ class AgentforceModule: RCTEventEmitter {
         // (LiveKit/MIAW) internally once the flag is on. shouldBlockMicrophone stays
         // false so the mic isn't gated; other public flags carry through too.
         let flags = getFeatureFlagsFromConfigOrUserDefaults(configDict)
+        saveFeatureFlagsToUserDefaults(flags)
         let featureFlagSettings = AgentforceFeatureFlagSettings(
             enableMultiModalInput: flags.enableMultiModalInput,
             enablePDFFileUpload: flags.enablePDFUpload,
@@ -374,6 +375,7 @@ class AgentforceModule: RCTEventEmitter {
         )
 
         let flags = getFeatureFlagsFromConfigOrUserDefaults(configDict)
+        saveFeatureFlagsToUserDefaults(flags)
         let featureFlagSettings = AgentforceFeatureFlagSettings(
             enableMultiModalInput: flags.enableMultiModalInput,
             enablePDFFileUpload: flags.enablePDFUpload,
@@ -509,8 +511,7 @@ class AgentforceModule: RCTEventEmitter {
 
                 // Validate Voice is enabled if voice mode requested
                 if initialMode == .voice {
-                    let flags = try await client.getFeatureFlags()
-                    guard flags.enableVoice else {
+                    guard getFeatureFlagsFromConfigOrUserDefaults([:]).enableVoice else {
                         throw NSError(
                             domain: "AgentforceModule",
                             code: 1001,

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -488,7 +488,8 @@ class AgentforceModule: RCTEventEmitter {
     /// Launch the conversation UI - works for both Service and Employee agents
     @objc
     func launchConversation(
-        _ resolve: @escaping RCTPromiseResolveBlock,
+        _ options: NSDictionary,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) {
         Task { @MainActor in
@@ -502,8 +503,25 @@ class AgentforceModule: RCTEventEmitter {
 
                 let conversation = try getOrCreateConversation(client: client, mode: mode)
 
+                // Parse initialMode from options (defaults to chat)
+                let initialModeString = options["initialMode"] as? String ?? "chat"
+                let initialMode: AgentforceViewMode = (initialModeString == "voice") ? .voice : .chat
+
+                // Validate Voice is enabled if voice mode requested
+                if initialMode == .voice {
+                    let flags = try await client.getFeatureFlags()
+                    guard flags.enableVoice else {
+                        throw NSError(
+                            domain: "AgentforceModule",
+                            code: 1001,
+                            userInfo: [NSLocalizedDescriptionKey: "Voice is not enabled. Set enableVoice: true in feature flags."]
+                        )
+                    }
+                }
+
                 let chatView = try client.createAgentforceChatView(
                     conversation: conversation,
+                    initialMode: initialMode,
                     delegate: bridgeUIDelegate,
                     showTopBar: true,
                     onContainerClose: { [weak self] in

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeUIDelegate.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/BridgeUIDelegate.swift
@@ -104,6 +104,7 @@ class BridgeUIDelegate: AgentforceUIDelegate {
             "message": message.message ?? NSNull(),
             "type": message.isUserMessage ? "user" : "agent",
             "conversationId": conversation.conversationId.uuidString,
+            "sessionId": conversation.sessionId ?? NSNull(),
             "timestamp": ISO8601DateFormatter().string(from: Date()),
         ]
 

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -36,6 +36,7 @@ import type {
   ModifyUtteranceRequest,
 } from '../types/UIDelegate';
 import type { VoiceOptions } from '../types/VoiceOptions';
+import type { LaunchOptions } from '../types/LaunchOptions';
 
 const { AgentforceModule } = NativeModules;
 
@@ -54,6 +55,7 @@ export type {
   ModifyUtteranceRequest,
 };
 export type { VoiceOptions };
+export type { LaunchOptions };
 
 /**
  * Native module event names
@@ -705,20 +707,20 @@ class AgentforceService {
    * Preserves existing conversation if available, allowing users to continue
    * where they left off. Works for both Service Agent and Employee Agent modes.
    *
+   * @param options - Optional launch configuration
    * @returns Promise<boolean> indicating success
    * @throws Error if SDK is not configured or launch fails
    *
    * @example
    * ```typescript
-   * try {
-   *   await AgentforceService.launchConversation();
-   *   console.log('Conversation launched');
-   * } catch (error) {
-   *   console.error('Failed to launch:', error);
-   * }
+   * // Launch in default Chat mode
+   * await AgentforceService.launchConversation();
+   *
+   * // Launch directly in Voice mode
+   * await AgentforceService.launchConversation({ initialMode: 'voice' });
    * ```
    */
-  async launchConversation(): Promise<boolean> {
+  async launchConversation(options?: LaunchOptions): Promise<boolean> {
     if (Platform.OS !== 'android' && Platform.OS !== 'ios') {
       console.warn('Agentforce only supported on Android and iOS');
       return false;
@@ -730,8 +732,9 @@ class AgentforceService {
     }
 
     try {
-      const result = await AgentforceModule.launchConversation();
-      console.log('[AgentforceService] Conversation launched successfully');
+      const initialMode = options?.initialMode ?? 'chat';
+      const result = await AgentforceModule.launchConversation({ initialMode });
+      console.log(`[AgentforceService] Conversation launched successfully (mode: ${initialMode})`);
       return result?.success ?? true;
     } catch (error) {
       console.error('[AgentforceService] Failed to launch conversation:', error);

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.LaunchOptions.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.LaunchOptions.test.ts
@@ -2,6 +2,20 @@
  * Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
  */
 
+jest.mock('react-native', () => {
+  class NativeEventEmitter {}
+
+  return {
+    NativeModules: {
+      AgentforceModule: {
+        launchConversation: jest.fn(),
+      },
+    },
+    NativeEventEmitter,
+    Platform: { OS: 'ios' },
+  };
+});
+
 import { NativeModules } from 'react-native';
 import AgentforceService from '../AgentforceService';
 

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.LaunchOptions.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.LaunchOptions.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
+ */
+
+import { NativeModules } from 'react-native';
+import AgentforceService from '../AgentforceService';
+
+const mockAgentforceModule = NativeModules.AgentforceModule;
+
+describe('AgentforceService.launchConversation with initialMode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAgentforceModule.launchConversation.mockResolvedValue({ success: true });
+  });
+
+  describe('SC-1: initialMode parameter accepts chat and voice', () => {
+    it('accepts chat mode', async () => {
+      await AgentforceService.launchConversation({ initialMode: 'chat' });
+
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({ initialMode: 'chat' });
+    });
+
+    it('accepts voice mode', async () => {
+      await AgentforceService.launchConversation({ initialMode: 'voice' });
+
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({ initialMode: 'voice' });
+    });
+  });
+
+  describe('SC-2: Chat remains default when initialMode omitted', () => {
+    it('defaults to chat when no options provided', async () => {
+      await AgentforceService.launchConversation();
+
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({ initialMode: 'chat' });
+    });
+
+    it('defaults to chat when empty options object provided', async () => {
+      await AgentforceService.launchConversation({});
+
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({ initialMode: 'chat' });
+    });
+  });
+
+  describe('SC-6: Error returned when Voice disabled/unavailable', () => {
+    it('throws when Voice mode launch fails', async () => {
+      const error = new Error('Voice is not enabled');
+      mockAgentforceModule.launchConversation.mockRejectedValue(error);
+
+      await expect(AgentforceService.launchConversation({ initialMode: 'voice' })).rejects.toThrow(
+        'Voice is not enabled',
+      );
+    });
+
+    it('propagates native error message', async () => {
+      mockAgentforceModule.launchConversation.mockRejectedValue(
+        new Error('Voice feature is disabled'),
+      );
+
+      await expect(AgentforceService.launchConversation({ initialMode: 'voice' })).rejects.toThrow(
+        'Voice feature is disabled',
+      );
+    });
+  });
+
+  describe('backward compatibility', () => {
+    it('maintains existing behavior when called without arguments', async () => {
+      await AgentforceService.launchConversation();
+
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledTimes(1);
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({ initialMode: 'chat' });
+    });
+  });
+});

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.LaunchOptions.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.LaunchOptions.test.ts
@@ -23,7 +23,9 @@ describe('AgentforceService.launchConversation with initialMode', () => {
     it('accepts voice mode', async () => {
       await AgentforceService.launchConversation({ initialMode: 'voice' });
 
-      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({ initialMode: 'voice' });
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({
+        initialMode: 'voice',
+      });
     });
   });
 

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.test.ts
@@ -327,11 +327,18 @@ describe('AgentforceService UI delegate', () => {
     AgentforceService.setUIDelegate({ onAgentResponse, onUtteranceSent, onAgentSwitch });
     expect(nativeModule.enableUIDelegateForwarding).toHaveBeenCalledWith(true);
 
-    emit('onAgentResponse', { responseId: '1', message: 'hi', type: 'text', conversationId: 'c' });
+    const response = {
+      responseId: '1',
+      message: 'hi',
+      type: 'text',
+      conversationId: 'c',
+      sessionId: 'session-1',
+    };
+    emit('onAgentResponse', response);
     emit('onUtteranceSent', { utterance: 'hello', hasAttachment: false, timestamp: 't' });
     emit('onAgentSwitch', { conversationId: 'c2', timestamp: 't' });
 
-    expect(onAgentResponse).toHaveBeenCalledTimes(1);
+    expect(onAgentResponse).toHaveBeenCalledWith(response);
     expect(onUtteranceSent).toHaveBeenCalledTimes(1);
     expect(onAgentSwitch).toHaveBeenCalledTimes(1);
   });

--- a/AgentforceSDK-ReactNative-Bridge/src/types/LaunchOptions.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/LaunchOptions.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
+ */
+
+/**
+ * Optional parameters for launching Agentforce conversation.
+ *
+ * Pass via `AgentforceService.launchConversation({ initialMode: 'voice' })`
+ * to control how the conversation opens.
+ */
+export interface LaunchOptions {
+  /**
+   * Initial conversation mode.
+   *
+   * - `'chat'` (default) opens the conversation in Chat mode
+   * - `'voice'` opens directly in Voice mode when Voice is enabled
+   *
+   * Voice launch requires `enableVoice: true` in feature flags.
+   * When Voice is disabled or unavailable, launch fails with error.
+   *
+   * @default 'chat'
+   */
+  initialMode?: 'chat' | 'voice';
+}

--- a/AgentforceSDK-ReactNative-Bridge/src/types/UIDelegate.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/UIDelegate.ts
@@ -17,6 +17,8 @@ export interface AgentResponseEvent {
   type: string;
   /** Conversation that produced this response (UUID string) */
   conversationId: string;
+  /** Agentforce session that produced this response, if assigned */
+  sessionId: string | null;
   /** ISO 8601 timestamp */
   timestamp?: string;
 }


### PR DESCRIPTION
Add optional initialMode parameter to launchConversation() allowing
React Native developers to open Agentforce directly in Voice without
going through Chat first.

Changes:
- TypeScript: LaunchOptions type with initialMode: 'chat' | 'voice'
- TypeScript: AgentforceService.launchConversation(options?) with
  default to 'chat'
- iOS: Parse initialMode, validate enableVoice flag, pass to
  createAgentforceChatView(initialMode: .voice)
- Android: Parse initialMode, validate enableVoice flag, route to
  conversation.startVoice() when voice requested
- Tests: 7 test cases covering SC-1, SC-2, SC-6, backward compat
