### PR TITLE
@W-23749472: Add User Silence Timeout Flags to test app

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -128,6 +128,11 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     // Defaults to all-off (`AgentforceVoiceSessionOptions()`).
     private var voiceSessionOptions: AgentforceVoiceSessionOptions = AgentforceVoiceSessionOptions()
 
+    // Normalized voice options applied to the currently-live client. Compared against a fresh
+    // snapshot on reconfigure so a voice-options change forces a new client (the SDK reads voice
+    // options only at client creation). `null` when no client is live. Mirrors the iOS bridge.
+    private var appliedVoiceOptions: VoiceOptionsSnapshot? = null
+
     // Coroutine scope for async operations
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
@@ -343,11 +348,20 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             activity != null &&
             !AgentforceConversationOverlay.isAttachedTo(activity)
 
-        val needsNewClient = switchingModes || agentIdChanged ||
+        // A live client only reads its voice options at creation, so a change to them must force a
+        // rebuild. Only meaningful when a client already exists. Mirrors the iOS bridge.
+        val currentVoiceOptions = voiceOptionsSnapshot(config)
+        val voiceOptionsChanged = AgentforceClientHolder.agentforceClient != null &&
+            appliedVoiceOptions != currentVoiceOptions
+
+        val needsNewClient = switchingModes || agentIdChanged || voiceOptionsChanged ||
             AgentforceClientHolder.agentforceClient == null || activityChanged
 
         if (activityChanged) {
             Log.d(TAG, "Host Activity changed since last attach - forcing fresh client to avoid re-launch hang")
+        }
+        if (voiceOptionsChanged) {
+            Log.d(TAG, "Voice options changed - forcing fresh client to apply them")
         }
 
         // Configure unified credential provider for Employee Agent mode
@@ -465,7 +479,8 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                 
                 AgentforceClientHolder.setClient(client)
                 AgentforceClientHolder.setMode(LocalAgentMode.Employee(employeeConfig))
-                
+                appliedVoiceOptions = currentVoiceOptions
+
                 promise.resolve(Arguments.createMap().apply {
                     putBoolean("success", true)
                     putString("mode", "employee")
@@ -745,6 +760,39 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             userSilenceTimeout = timeout,
             autoEndWhileMuted = autoEndWhileMuted,
         )
+    }
+
+    /**
+     * Value snapshot of the voice options that actually affect client behavior,
+     * normalized the same way [parseVoiceSessionOptions] treats them: a missing,
+     * non-finite, or non-positive timeout collapses to `null` ("never auto-end"),
+     * so cosmetic differences in the raw JS payload don't spuriously rebuild the
+     * client. Mirrors the iOS bridge's VoiceOptionsSnapshot.
+     */
+    private data class VoiceOptionsSnapshot(
+        val userSilenceTimeoutSeconds: Double?,
+        val autoEndWhileMuted: Boolean,
+    )
+
+    private fun voiceOptionsSnapshot(config: ReadableMap): VoiceOptionsSnapshot {
+        if (!config.hasKey("voiceOptions")) return VoiceOptionsSnapshot(null, false)
+        val voiceOpts = config.getMap("voiceOptions") ?: return VoiceOptionsSnapshot(null, false)
+
+        val seconds = if (
+            voiceOpts.hasKey("userSilenceTimeoutSeconds") &&
+            !voiceOpts.isNull("userSilenceTimeoutSeconds")
+        ) {
+            val raw = voiceOpts.getDouble("userSilenceTimeoutSeconds")
+            if (raw.isFinite() && raw > 0) raw else null
+        } else {
+            null
+        }
+
+        val autoEndWhileMuted = voiceOpts.hasKey("autoEndWhileMuted") &&
+            !voiceOpts.isNull("autoEndWhileMuted") &&
+            voiceOpts.getBoolean("autoEndWhileMuted")
+
+        return VoiceOptionsSnapshot(seconds, autoEndWhileMuted)
     }
 
     private data class FeatureFlags(
@@ -1084,6 +1132,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
             AgentforceClientHolder.clear()
             viewModel?.resetConfiguration()
             currentMode = null
+            appliedVoiceOptions = null
             credentialProvider.reset()
             bridgeViewProvider.reset()
             bridgeSplashScreenBuilder.reset()

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -50,6 +50,21 @@ class AgentforceModule: RCTEventEmitter {
     /// supplied, so the SDK falls back to the server-provided agent label.
     private var navigationBarBuilder: BridgeNavigationBarBuilder?
 
+    /// Normalized voice options applied to the currently-live client. Compared
+    /// against a fresh snapshot on reconfigure so a voice-options change forces a
+    /// new client (the SDK reads voice options only at client creation). `nil`
+    /// when no client is live.
+    private var appliedVoiceOptions: VoiceOptionsSnapshot?
+
+    /// Value snapshot of the voice options that actually affect client behavior,
+    /// normalized the same way the SDK treats them: a missing, non-positive, or
+    /// non-finite timeout collapses to `nil` ("never auto-end"), so cosmetic
+    /// differences in the raw JS payload don't spuriously rebuild the client.
+    private struct VoiceOptionsSnapshot: Equatable {
+        let userSilenceTimeoutSeconds: Double?
+        let autoEndWhileMuted: Bool
+    }
+
 
     private let listenerLock = NSLock()
     private var _hasListeners = false
@@ -216,6 +231,20 @@ class AgentforceModule: RCTEventEmitter {
         )
     }
 
+    /// Build a normalized, comparable snapshot of the voice options from the JS
+    /// config map. A missing, non-positive, or non-finite `userSilenceTimeoutSeconds`
+    /// collapses to `nil` so it compares equal to an explicitly-disabled timeout —
+    /// matching how `parseVoiceSessionOptions` maps those to `.never`.
+    private static func voiceOptionsSnapshot(from configDict: [String: Any]) -> VoiceOptionsSnapshot {
+        guard let voiceOpts = configDict["voiceOptions"] as? [String: Any] else {
+            return VoiceOptionsSnapshot(userSilenceTimeoutSeconds: nil, autoEndWhileMuted: false)
+        }
+        let autoEndWhileMuted = (voiceOpts["autoEndWhileMuted"] as? NSNumber)?.boolValue ?? false
+        let seconds = (voiceOpts["userSilenceTimeoutSeconds"] as? NSNumber)?.doubleValue
+        let normalizedSeconds = seconds.flatMap { $0.isFinite && $0 > 0 ? $0 : nil }
+        return VoiceOptionsSnapshot(userSilenceTimeoutSeconds: normalizedSeconds, autoEndWhileMuted: autoEndWhileMuted)
+    }
+
     // MARK: - Service Agent Configuration
 
     private func configureServiceAgent(
@@ -341,14 +370,23 @@ class AgentforceModule: RCTEventEmitter {
             agentIdChanged = existingConfig.agentId != config.agentId
         }
         
-        let needsNewClient = switchingModes || agentIdChanged || agentforceClient == nil
+        // A live client only reads its voice options at creation, so a change to
+        // them must force a rebuild. Only meaningful when a client already exists.
+        let voiceOptionsSnapshot = Self.voiceOptionsSnapshot(from: configDict)
+        let voiceOptionsChanged = agentforceClient != nil && appliedVoiceOptions != voiceOptionsSnapshot
 
-        // Only cleanup if switching from Service mode or agentId changed
+        let needsNewClient = switchingModes || agentIdChanged || voiceOptionsChanged || agentforceClient == nil
+
+        // Only cleanup if switching from Service mode, agentId changed, or voice options changed
         if switchingModes {
             print("[AgentforceModule] ⚠️ Switching from Service to Employee mode - cleaning up")
             cleanupClient()
         } else if agentIdChanged {
             print("[AgentforceModule] ⚠️ AgentId changed - cleaning up conversation")
+            await closeCurrentConversation()
+            cleanupClient()
+        } else if voiceOptionsChanged {
+            print("[AgentforceModule] ⚠️ Voice options changed - cleaning up conversation to rebuild client")
             await closeCurrentConversation()
             cleanupClient()
         } else if agentforceClient != nil {
@@ -444,6 +482,7 @@ class AgentforceModule: RCTEventEmitter {
                 mode: .fullConfig(fullConfiguration),
                 viewProvider: bridgeViewProvider
             )
+            appliedVoiceOptions = voiceOptionsSnapshot
         } else {
             print("[AgentforceModule] Reusing existing AgentforceClient - credentials will be refreshed automatically")
         }
@@ -1241,6 +1280,7 @@ class AgentforceModule: RCTEventEmitter {
     private func cleanupClient() {
         currentConversation = nil
         agentforceClient = nil
+        appliedVoiceOptions = nil
         bridgeHiddenPreChat.setFields([:])
     }
 

--- a/docs/voice-and-feature-flags-config.md
+++ b/docs/voice-and-feature-flags-config.md
@@ -12,10 +12,10 @@ import type { FeatureFlags, VoiceOptions } from '@salesforce/react-native-agentf
 
 async function startEmployeeAgent() {
   const featureFlags: FeatureFlags = {
-    enableMultiAgent: false,       // route across multiple agents in the org
-    enableMultiModalInput: false,  // image/attachment input
-    enablePDFUpload: false,        // PDF upload
-    enableVoice: true,             // REQUIRED for any voice conversation / mic UI
+    enableMultiAgent: false, // route across multiple agents in the org
+    enableMultiModalInput: false, // image/attachment input
+    enablePDFUpload: false, // PDF upload
+    enableVoice: true, // REQUIRED for any voice conversation / mic UI
     enableCustomViewProvider: false,
   };
 
@@ -36,11 +36,11 @@ async function startEmployeeAgent() {
     instanceUrl: 'https://myorg.my.salesforce.com',
     organizationId: '00Dxx0000001234',
     userId: '005xx0000001234',
-    agentId: '0Xxxx0000001234',   // omit / leave undefined for multi-agent mode
+    agentId: '0Xxxx0000001234', // omit / leave undefined for multi-agent mode
     // accessToken is optional — the native SDK fetches fresh tokens from the
     // Salesforce Mobile SDK automatically when auth is wired up.
-    featureFlags,                 // <-- sibling of `type`
-    voiceOptions,                 // <-- sibling of `type`
+    featureFlags, // <-- sibling of `type`
+    voiceOptions, // <-- sibling of `type`
   });
 
   await AgentforceService.launchConversation();
@@ -49,10 +49,10 @@ async function startEmployeeAgent() {
 
 ## What each voice field does
 
-| Field | Type | Default | Meaning |
-|---|---|---|---|
-| `userSilenceTimeoutSeconds` | `number` (seconds) | `undefined` → **never auto-end** | Auto-end after this much continuous user silence. `0` or negative = disabled. |
-| `autoEndWhileMuted` | `boolean` | `false` | Whether the silence timer keeps running while muted. No effect if `userSilenceTimeoutSeconds` is unset. |
+| Field                       | Type               | Default                          | Meaning                                                                                                 |
+| --------------------------- | ------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `userSilenceTimeoutSeconds` | `number` (seconds) | `undefined` → **never auto-end** | Auto-end after this much continuous user silence. `0` or negative = disabled.                           |
+| `autoEndWhileMuted`         | `boolean`          | `false`                          | Whether the silence timer keeps running while muted. No effect if `userSilenceTimeoutSeconds` is unset. |
 
 ## Pitfalls to flag
 
@@ -60,7 +60,7 @@ async function startEmployeeAgent() {
    any other object.** The bridge only reads `config.voiceOptions` and
    `config.featureFlags` at the top level. Anywhere else is silently ignored —
    no error, it just won't take effect.
-2. **`enableVoice: true` is required.** `voiceOptions` only govern *how* a voice
+2. **`enableVoice: true` is required.** `voiceOptions` only govern _how_ a voice
    conversation ends; if voice itself is off, they do nothing and the mic UI
    won't appear.
 3. **On v0.4.0, voice options are locked in when the voice client is first built

--- a/docs/voice-and-feature-flags-config.md
+++ b/docs/voice-and-feature-flags-config.md
@@ -1,0 +1,76 @@
+# Configuring Feature Flags & Voice Options — Employee Agent
+
+**Applies to:** `@salesforce/react-native-agentforce@0.4.0`
+(iOS AgentforceSDK 18.26.8 / AgentforceVoice 2.8.2; Android agentforce-sdk 15.130.1; Agentforce Mobile SDK 262.1.2)
+
+Both `featureFlags` and `voiceOptions` are passed to a **single**
+`AgentforceService.configure(...)` call, as **top-level siblings of `type`**.
+
+```typescript
+import { AgentforceService } from '@salesforce/react-native-agentforce';
+import type { FeatureFlags, VoiceOptions } from '@salesforce/react-native-agentforce';
+
+async function startEmployeeAgent() {
+  const featureFlags: FeatureFlags = {
+    enableMultiAgent: false,       // route across multiple agents in the org
+    enableMultiModalInput: false,  // image/attachment input
+    enablePDFUpload: false,        // PDF upload
+    enableVoice: true,             // REQUIRED for any voice conversation / mic UI
+    enableCustomViewProvider: false,
+  };
+
+  const voiceOptions: VoiceOptions = {
+    // Auto-end the voice conversation after this many seconds of continuous
+    // user silence. Omit (or use 0 / a negative value) to never auto-end.
+    userSilenceTimeoutSeconds: 30,
+
+    // false (default): muting pauses the silence timer, so a muted user is
+    //   never auto-ended.
+    // true: muted time counts as silence, so the conversation still auto-ends
+    //   after the timeout even if the user muted and walked away.
+    autoEndWhileMuted: false,
+  };
+
+  await AgentforceService.configure({
+    type: 'employee',
+    instanceUrl: 'https://myorg.my.salesforce.com',
+    organizationId: '00Dxx0000001234',
+    userId: '005xx0000001234',
+    agentId: '0Xxxx0000001234',   // omit / leave undefined for multi-agent mode
+    // accessToken is optional — the native SDK fetches fresh tokens from the
+    // Salesforce Mobile SDK automatically when auth is wired up.
+    featureFlags,                 // <-- sibling of `type`
+    voiceOptions,                 // <-- sibling of `type`
+  });
+
+  await AgentforceService.launchConversation();
+}
+```
+
+## What each voice field does
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `userSilenceTimeoutSeconds` | `number` (seconds) | `undefined` → **never auto-end** | Auto-end after this much continuous user silence. `0` or negative = disabled. |
+| `autoEndWhileMuted` | `boolean` | `false` | Whether the silence timer keeps running while muted. No effect if `userSilenceTimeoutSeconds` is unset. |
+
+## Pitfalls to flag
+
+1. **Do not nest `voiceOptions` (or `featureFlags`) inside each other or inside
+   any other object.** The bridge only reads `config.voiceOptions` and
+   `config.featureFlags` at the top level. Anywhere else is silently ignored —
+   no error, it just won't take effect.
+2. **`enableVoice: true` is required.** `voiceOptions` only govern *how* a voice
+   conversation ends; if voice itself is off, they do nothing and the mic UI
+   won't appear.
+3. **On v0.4.0, voice options are locked in when the voice client is first built
+   for a session.** Reconfiguring an already-configured session with the **same
+   `agentId`** reuses the existing client and will **not** pick up changed
+   `voiceOptions`. They take effect on: the first `configure()` of a session, an
+   `agentId` change, or a cold start / sign-out-and-back-in. **Practical rule:**
+   set the values you want at the initial `configure()` before
+   `launchConversation()`; to change them at runtime, change the `agentId` or
+   have the user sign out and in again.
+4. **`featureFlags` is optional but sticky.** If omitted, the SDK reuses
+   previously stored flags (or defaults). Pass the full object explicitly to be
+   deterministic.

--- a/src/config/AppConfig.ts
+++ b/src/config/AppConfig.ts
@@ -29,10 +29,39 @@
  * See src/config/README.md for detailed documentation.
  */
 
+import type { VoiceOptions } from '@salesforce/react-native-agentforce';
+
 import { APP_MODE } from './AppConfig.generated';
 
 // Widen the type for comparison - APP_MODE can be 'service', 'employee', or 'all'
 const appMode: 'service' | 'employee' | 'all' = APP_MODE as any;
+
+/**
+ * Example voice-session options for the Employee Agent.
+ *
+ * Auto-ends a voice conversation after `userSilenceTimeoutSeconds` seconds of
+ * continuous user silence. Pass this as `voiceOptions` on the config object —
+ * it must be a top-level sibling of `type`, not nested inside `featureFlags`.
+ * The native bridge only reads `config.voiceOptions`; anywhere else is ignored.
+ *
+ * Voice options are applied when the voice session's client is created. The
+ * native bridge tracks the last-applied options and rebuilds the client when
+ * they change, so an edit takes effect on the next `configure()` (e.g. the next
+ * launch from Home) — at the cost of ending the active conversation. A
+ * reconfigure with unchanged options reuses the existing client.
+ *
+ * `autoEndWhileMuted: false` (the default) pauses the silence timer while the
+ * mic is muted, so a muted user is never auto-ended. Set `true` to count muted
+ * time as silence.
+ */
+export const EMPLOYEE_VOICE_OPTIONS: VoiceOptions = {
+  userSilenceTimeoutSeconds: 30,
+  autoEndWhileMuted: false,
+};
+// These values seed the runtime-editable VoiceTimeoutStore (Settings > Employee
+// > Voice Timeout). configure() sends the store's current values, not this
+// constant directly. Note: the store defaults auto-end-on-silence *off* and uses
+// these only as the pre-filled values when the user enables the toggle.
 
 /**
  * Feature flags derived from APP_MODE

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -48,6 +48,7 @@ import {
 import { UI_FEATURES } from '../config/AppConfig';
 import { getAgentAppearance, loadAppearanceSettings } from '../store/AgentAppearanceStore';
 import { getContextVariables } from '../store/ContextVariablesStore';
+import { getVoiceOptions } from '../store/VoiceTimeoutStore';
 
 interface HomeScreenProps {
   navigation: any;
@@ -224,6 +225,8 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
       const agentId = storedAgentId?.trim() || undefined; // Empty string becomes undefined
       const creds = await getEmployeeAgentCredentials();
       const featureFlags = await AgentforceService.getFeatureFlags();
+      // Read the latest voice-timeout settings (editable in Settings) at configure time
+      const voiceOptions = getVoiceOptions();
 
       // Always reconfigure Employee Agent to ensure fresh credentials and agentId
       const config = creds
@@ -237,6 +240,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
             accessToken: creds.accessToken,
             featureFlags,
             appearance: getAgentAppearance(),
+            voiceOptions, // auto-end voice after user silence; edit in Settings > Employee > Voice Timeout
           }
         : // optional: set agentLabel to a custom name to display in the chat header (overrides the server agent label)
           {
@@ -245,6 +249,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
             agentLabel: '',
             featureFlags,
             appearance: getAgentAppearance(),
+            voiceOptions,
           };
       await AgentforceService.configure(config);
 

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -921,8 +921,8 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
       <Text style={styles.label}>Voice Timeout</Text>
       <Text style={styles.hint}>
         Auto-end a voice conversation after the user is silent. Requires the Voice feature flag.
-        Changes apply the next time you launch Employee Agent (rebuilding the client ends the
-        active conversation).
+        Changes apply the next time you launch Employee Agent (rebuilding the client ends the active
+        conversation).
       </Text>
 
       <View style={[styles.flagRow, styles.flagRowBorder]}>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -66,6 +66,12 @@ import {
   updateAppearanceThemeMode,
 } from '../store/AgentAppearanceStore';
 import { getContextVariables, setContextVariables } from '../store/ContextVariablesStore';
+import {
+  getVoiceOptions,
+  getVoiceTimeoutSettings,
+  setVoiceTimeoutSettings,
+} from '../store/VoiceTimeoutStore';
+import type { VoiceTimeoutSettings } from '../store/VoiceTimeoutStore';
 
 type TabType = 'service' | 'employee' | 'features' | 'theming';
 
@@ -167,6 +173,10 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
 
   const [utteranceText, setUtteranceText] = useState('');
   const [sendingUtterance, setSendingUtterance] = useState(false);
+
+  const [voiceTimeout, setVoiceTimeout] = useState<VoiceTimeoutSettings>(() =>
+    getVoiceTimeoutSettings(),
+  );
 
   useEffect(() => {
     loadSavedConfiguration();
@@ -320,6 +330,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
         accessToken: creds.accessToken,
         featureFlags: currentFlags,
         appearance: getAgentAppearance(),
+        voiceOptions: getVoiceOptions(), // auto-end voice after user silence; edit under Voice Timeout below
       });
       setEmployeeLoggedIn(true);
       Alert.alert(
@@ -460,6 +471,11 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
   useEffect(() => {
     setContextVariables(employeeContextVars);
   }, [employeeContextVars]);
+
+  // Sync voice-timeout settings to store whenever they change
+  useEffect(() => {
+    setVoiceTimeoutSettings(voiceTimeout);
+  }, [voiceTimeout]);
 
   const handleAddContextVariable = () => {
     const trimmedName = newEmployeeCtxName.trim();
@@ -900,6 +916,69 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
     </ScrollView>
   );
 
+  const renderVoiceTimeoutSection = () => (
+    <View style={styles.formContainerWithMargin}>
+      <Text style={styles.label}>Voice Timeout</Text>
+      <Text style={styles.hint}>
+        Auto-end a voice conversation after the user is silent. Requires the Voice feature flag.
+        Changes apply the next time you launch Employee Agent (rebuilding the client ends the
+        active conversation).
+      </Text>
+
+      <View style={[styles.flagRow, styles.flagRowBorder]}>
+        <View style={styles.flagLabelBlock}>
+          <Text style={styles.label}>Auto-end on silence</Text>
+          <Text style={styles.hint}>When off, voice never auto-ends from silence.</Text>
+        </View>
+        <Switch
+          value={voiceTimeout.enabled}
+          onValueChange={enabled => setVoiceTimeout(prev => ({ ...prev, enabled }))}
+          trackColor={{ false: '#ced4da', true: '#28a745' }}
+          thumbColor="#ffffff"
+        />
+      </View>
+
+      {voiceTimeout.enabled && (
+        <View style={[styles.voiceSecondsRow, styles.flagRowBorder]}>
+          <Text style={styles.label}>Silence timeout (seconds)</Text>
+          <TextInput
+            style={styles.input}
+            value={
+              voiceTimeout.userSilenceTimeoutSeconds > 0
+                ? String(voiceTimeout.userSilenceTimeoutSeconds)
+                : ''
+            }
+            onChangeText={text => {
+              const seconds = parseInt(text.replace(/[^0-9]/g, ''), 10);
+              setVoiceTimeout(prev => ({
+                ...prev,
+                userSilenceTimeoutSeconds: isNaN(seconds) ? 0 : seconds,
+              }));
+            }}
+            placeholder="30"
+            placeholderTextColor="#999"
+            keyboardType="number-pad"
+          />
+        </View>
+      )}
+
+      <View style={styles.flagRow}>
+        <View style={styles.flagLabelBlock}>
+          <Text style={styles.label}>Auto-end while muted</Text>
+          <Text style={styles.hint}>Also auto-end when the mic is muted.</Text>
+        </View>
+        <Switch
+          value={voiceTimeout.autoEndWhileMuted}
+          onValueChange={autoEndWhileMuted =>
+            setVoiceTimeout(prev => ({ ...prev, autoEndWhileMuted }))
+          }
+          trackColor={{ false: '#ced4da', true: '#28a745' }}
+          thumbColor="#ffffff"
+        />
+      </View>
+    </View>
+  );
+
   const renderEmployeeAgentTab = () => (
     <ScrollView
       style={styles.tabContent}
@@ -974,6 +1053,8 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
           />
         </View>
       )}
+
+      {authSupported && renderVoiceTimeoutSection()}
 
       {authSupported && renderContextVariablesSection()}
 
@@ -1737,6 +1818,9 @@ const styles = StyleSheet.create({
   flagRowBorder: {
     borderBottomWidth: 1,
     borderBottomColor: '#f1f3f4',
+  },
+  voiceSecondsRow: {
+    paddingVertical: 14,
   },
   flagLabelBlock: {
     flex: 1,

--- a/src/store/VoiceTimeoutStore.ts
+++ b/src/store/VoiceTimeoutStore.ts
@@ -1,0 +1,59 @@
+import type { VoiceOptions } from '@salesforce/react-native-agentforce';
+
+import { EMPLOYEE_VOICE_OPTIONS } from '../config/AppConfig';
+
+/**
+ * Runtime-editable voice auto-end (silence timeout) settings for the Employee
+ * Agent, backing the Settings toggle. Mirrors the in-memory pattern of
+ * ContextVariablesStore — state lives for the process lifetime, not across
+ * cold starts.
+ *
+ * `enabled` maps to the native `.afterUserSilence` vs `.never` auto-end policy:
+ * disabling omits the timeout from the derived VoiceOptions so the bridge treats
+ * it as "never auto-end".
+ */
+export interface VoiceTimeoutSettings {
+  enabled: boolean;
+  userSilenceTimeoutSeconds: number;
+  autoEndWhileMuted: boolean;
+}
+
+// Auto-end on silence is opt-in: default the toggle off, but pre-seed the
+// timeout and muted values from EMPLOYEE_VOICE_OPTIONS so enabling it starts
+// from sensible defaults rather than an empty field.
+export const DEFAULT_VOICE_TIMEOUT_SETTINGS: VoiceTimeoutSettings = {
+  enabled: false,
+  userSilenceTimeoutSeconds: EMPLOYEE_VOICE_OPTIONS.userSilenceTimeoutSeconds ?? 30,
+  autoEndWhileMuted: EMPLOYEE_VOICE_OPTIONS.autoEndWhileMuted ?? false,
+};
+
+let settings: VoiceTimeoutSettings = { ...DEFAULT_VOICE_TIMEOUT_SETTINGS };
+
+export function getVoiceTimeoutSettings(): VoiceTimeoutSettings {
+  return { ...settings };
+}
+
+export function setVoiceTimeoutSettings(next: VoiceTimeoutSettings): void {
+  settings = { ...next };
+}
+
+export function resetVoiceTimeoutSettings(): void {
+  settings = { ...DEFAULT_VOICE_TIMEOUT_SETTINGS };
+}
+
+/**
+ * Derive the bridge `VoiceOptions` from the current settings. Pass the result as
+ * `voiceOptions` on the Employee Agent `configure()` call.
+ *
+ * When disabled, `userSilenceTimeoutSeconds` is omitted so the native layer maps
+ * it to "never auto-end"; `autoEndWhileMuted` is always forwarded.
+ */
+export function getVoiceOptions(): VoiceOptions {
+  if (!settings.enabled) {
+    return { autoEndWhileMuted: settings.autoEndWhileMuted };
+  }
+  return {
+    userSilenceTimeoutSeconds: settings.userSilenceTimeoutSeconds,
+    autoEndWhileMuted: settings.autoEndWhileMuted,
+  };
+}

--- a/src/store/__tests__/VoiceTimeoutStore.test.ts
+++ b/src/store/__tests__/VoiceTimeoutStore.test.ts
@@ -1,0 +1,94 @@
+import { EMPLOYEE_VOICE_OPTIONS } from '../../config/AppConfig';
+import {
+  DEFAULT_VOICE_TIMEOUT_SETTINGS,
+  getVoiceTimeoutSettings,
+  setVoiceTimeoutSettings,
+  resetVoiceTimeoutSettings,
+  getVoiceOptions,
+} from '../VoiceTimeoutStore';
+
+beforeEach(() => {
+  resetVoiceTimeoutSettings();
+});
+
+describe('VoiceTimeoutStore defaults', () => {
+  it('defaults auto-end-on-silence to off, pre-seeding the timeout value', () => {
+    expect(DEFAULT_VOICE_TIMEOUT_SETTINGS).toEqual({
+      enabled: false,
+      userSilenceTimeoutSeconds: EMPLOYEE_VOICE_OPTIONS.userSilenceTimeoutSeconds ?? 30,
+      autoEndWhileMuted: EMPLOYEE_VOICE_OPTIONS.autoEndWhileMuted ?? false,
+    });
+  });
+
+  it('returns the defaults initially', () => {
+    expect(getVoiceTimeoutSettings()).toEqual(DEFAULT_VOICE_TIMEOUT_SETTINGS);
+  });
+});
+
+describe('getVoiceOptions', () => {
+  it('includes the timeout when enabled', () => {
+    setVoiceTimeoutSettings({
+      enabled: true,
+      userSilenceTimeoutSeconds: 45,
+      autoEndWhileMuted: true,
+    });
+
+    expect(getVoiceOptions()).toEqual({
+      userSilenceTimeoutSeconds: 45,
+      autoEndWhileMuted: true,
+    });
+  });
+
+  it('omits the timeout when disabled but keeps autoEndWhileMuted', () => {
+    setVoiceTimeoutSettings({
+      enabled: false,
+      userSilenceTimeoutSeconds: 45,
+      autoEndWhileMuted: true,
+    });
+
+    const options = getVoiceOptions();
+    expect(options.userSilenceTimeoutSeconds).toBeUndefined();
+    expect(options.autoEndWhileMuted).toBe(true);
+  });
+});
+
+describe('setVoiceTimeoutSettings', () => {
+  it('round-trips a settings object', () => {
+    const next = {
+      enabled: false,
+      userSilenceTimeoutSeconds: 10,
+      autoEndWhileMuted: false,
+    };
+    setVoiceTimeoutSettings(next);
+    expect(getVoiceTimeoutSettings()).toEqual(next);
+  });
+
+  it('returns a copy, not a reference to internal state', () => {
+    const result = getVoiceTimeoutSettings();
+    result.userSilenceTimeoutSeconds = 999;
+    expect(getVoiceTimeoutSettings().userSilenceTimeoutSeconds).not.toBe(999);
+  });
+
+  it('does not retain a reference to the input object', () => {
+    const input = {
+      enabled: true,
+      userSilenceTimeoutSeconds: 20,
+      autoEndWhileMuted: false,
+    };
+    setVoiceTimeoutSettings(input);
+    input.userSilenceTimeoutSeconds = 999;
+    expect(getVoiceTimeoutSettings().userSilenceTimeoutSeconds).toBe(20);
+  });
+});
+
+describe('resetVoiceTimeoutSettings', () => {
+  it('restores the defaults', () => {
+    setVoiceTimeoutSettings({
+      enabled: false,
+      userSilenceTimeoutSeconds: 5,
+      autoEndWhileMuted: true,
+    });
+    resetVoiceTimeoutSettings();
+    expect(getVoiceTimeoutSettings()).toEqual(DEFAULT_VOICE_TIMEOUT_SETTINGS);
+  });
+});


### PR DESCRIPTION
## What & why

Adds a runtime-editable **Voice Timeout** control to the Employee Agent Settings tab, mirroring the native test app's `enableVoiceTimeout` / `voiceTimeoutSeconds` / `autoEndWhileMuted` controls. Previously these were hardcoded in `AppConfig.EMPLOYEE_VOICE_OPTIONS`.

## Changes

- **`src/store/VoiceTimeoutStore.ts`** (new) — in-memory store (mirrors `ContextVariablesStore`) seeded from `EMPLOYEE_VOICE_OPTIONS`. Auto-end-on-silence **defaults off**; `getVoiceOptions()` derives the bridge `VoiceOptions`, omitting the timeout when disabled so native maps it to never-auto-end. TDD-covered (`__tests__/VoiceTimeoutStore.test.ts`).
- **`src/screens/SettingsScreen.tsx`** — new Voice Timeout section: enable `Switch`, seconds input (shown when enabled), `autoEndWhileMuted` `Switch`, synced to the store.
- **`HomeScreen.tsx` / `SettingsScreen.tsx`** — both employee `configure()` sites now send `getVoiceOptions()` instead of the constant.
- **iOS `AgentforceModule.swift` + Android `AgentforceModule.kt`** — track the last-applied voice options via a normalized snapshot and fold a change check into `needsNewClient`, so an edit takes effect on the next launch.
- **`docs/voice-and-feature-flags-config.md`** (new) — customer-facing example of wiring `featureFlags` + `voiceOptions` through `configure()`, version-stamped for v0.4.0.

## Tradeoff

Because voice options are read only at voice-client creation, applying a change rebuilds the client, which **ends the active conversation**. This is intentional and documented in-code and in the doc.

## Testing

- `npx jest` — 133/133 passing (8 new store tests).
- Native bridge changes are unbuilt in this environment (no Xcode/Gradle) — iOS/Android builds should be run before merge.

## Excluded from this PR (intentionally)

- `ios/EmployeeAgent/bootconfig.plist` — local OAuth debugging change, not part of this feature.
- `package-lock.json` — unrelated 0.3.0->0.4.0 lockfile bump.