### PR TITLE
Expose voice caption defaults and close behavior

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/README.md
+++ b/AgentforceSDK-ReactNative-Bridge/README.md
@@ -332,4 +332,31 @@ await AgentforceService.configure({
   no-op — the value is stored and forwarded, but that SDK ignores unknown keys. Consult the
   native AgentforceSDK's internal-flag documentation for the keys valid on each platform.
 
+## Voice Options
+
+Configure voice-session behavior alongside the agent configuration:
+
+```typescript
+await AgentforceService.configure({
+  type: 'service',
+  serviceApiURL: 'https://service.salesforce.com',
+  organizationId: '00Dxx0000001234',
+  esDeveloperName: 'MyServiceAgent',
+  voiceOptions: {
+    userSilenceTimeoutSeconds: 30,
+    autoEndWhileMuted: false,
+    defaultClosedCaptionsEnabled: true,
+  },
+});
+```
+
+`defaultClosedCaptionsEnabled` applies only when the user has not previously
+chosen a closed-caption state. The native SDK persists a user's explicit caption
+choice, which always takes precedence over the configured default.
+
+On iOS, `launchConversation` also accepts `voiceCloseBehavior: 'returnToChat' |
+'dismissContainer'`. The default, `'returnToChat'`, preserves the existing
+integrated Voice behavior. `'dismissContainer'` dismisses the entire Agentforce
+presentation when Voice closes. Android retains its existing Voice close behavior.
+
 ---

--- a/AgentforceSDK-ReactNative-Bridge/android/build.gradle
+++ b/AgentforceSDK-ReactNative-Bridge/android/build.gradle
@@ -60,8 +60,8 @@ repositories {
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
     implementation "com.facebook.react:react-android"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk:15.130.1"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk-voice:15.130.1"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk:15.130.3-rc1"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk-voice:15.130.3-rc1"
     // compileOnly: host app adds this for Employee Agent. Bridge compiles; host provides at runtime.
     compileOnly "com.salesforce.mobilesdk:SalesforceReact:13.1.1"
 

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -770,10 +770,14 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         val autoEndWhileMuted = voiceOpts.hasKey("autoEndWhileMuted") &&
             !voiceOpts.isNull("autoEndWhileMuted") &&
             voiceOpts.getBoolean("autoEndWhileMuted")
+        val defaultClosedCaptionsEnabled = voiceOpts.hasKey("defaultClosedCaptionsEnabled") &&
+            !voiceOpts.isNull("defaultClosedCaptionsEnabled") &&
+            voiceOpts.getBoolean("defaultClosedCaptionsEnabled")
 
         return AgentforceVoiceSessionOptions(
             userSilenceTimeout = timeout,
             autoEndWhileMuted = autoEndWhileMuted,
+            defaultClosedCaptionsEnabled = defaultClosedCaptionsEnabled,
         )
     }
 
@@ -787,11 +791,12 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     private data class VoiceOptionsSnapshot(
         val userSilenceTimeoutSeconds: Double?,
         val autoEndWhileMuted: Boolean,
+        val defaultClosedCaptionsEnabled: Boolean,
     )
 
     private fun voiceOptionsSnapshot(config: ReadableMap): VoiceOptionsSnapshot {
-        if (!config.hasKey("voiceOptions")) return VoiceOptionsSnapshot(null, false)
-        val voiceOpts = config.getMap("voiceOptions") ?: return VoiceOptionsSnapshot(null, false)
+        if (!config.hasKey("voiceOptions")) return VoiceOptionsSnapshot(null, false, false)
+        val voiceOpts = config.getMap("voiceOptions") ?: return VoiceOptionsSnapshot(null, false, false)
 
         val seconds = if (
             voiceOpts.hasKey("userSilenceTimeoutSeconds") &&
@@ -806,8 +811,11 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         val autoEndWhileMuted = voiceOpts.hasKey("autoEndWhileMuted") &&
             !voiceOpts.isNull("autoEndWhileMuted") &&
             voiceOpts.getBoolean("autoEndWhileMuted")
+        val defaultClosedCaptionsEnabled = voiceOpts.hasKey("defaultClosedCaptionsEnabled") &&
+            !voiceOpts.isNull("defaultClosedCaptionsEnabled") &&
+            voiceOpts.getBoolean("defaultClosedCaptionsEnabled")
 
-        return VoiceOptionsSnapshot(seconds, autoEndWhileMuted)
+        return VoiceOptionsSnapshot(seconds, autoEndWhileMuted, defaultClosedCaptionsEnabled)
     }
 
     private data class FeatureFlags(

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -63,6 +63,7 @@ class AgentforceModule: RCTEventEmitter {
     private struct VoiceOptionsSnapshot: Equatable {
         let userSilenceTimeoutSeconds: Double?
         let autoEndWhileMuted: Bool
+        let defaultClosedCaptionsEnabled: Bool
     }
 
 
@@ -237,12 +238,29 @@ class AgentforceModule: RCTEventEmitter {
     /// matching how `parseVoiceSessionOptions` maps those to `.never`.
     private static func voiceOptionsSnapshot(from configDict: [String: Any]) -> VoiceOptionsSnapshot {
         guard let voiceOpts = configDict["voiceOptions"] as? [String: Any] else {
-            return VoiceOptionsSnapshot(userSilenceTimeoutSeconds: nil, autoEndWhileMuted: false)
+            return VoiceOptionsSnapshot(
+                userSilenceTimeoutSeconds: nil,
+                autoEndWhileMuted: false,
+                defaultClosedCaptionsEnabled: false
+            )
         }
         let autoEndWhileMuted = (voiceOpts["autoEndWhileMuted"] as? NSNumber)?.boolValue ?? false
+        let defaultClosedCaptionsEnabled =
+            (voiceOpts["defaultClosedCaptionsEnabled"] as? NSNumber)?.boolValue ?? false
         let seconds = (voiceOpts["userSilenceTimeoutSeconds"] as? NSNumber)?.doubleValue
         let normalizedSeconds = seconds.flatMap { $0.isFinite && $0 > 0 ? $0 : nil }
-        return VoiceOptionsSnapshot(userSilenceTimeoutSeconds: normalizedSeconds, autoEndWhileMuted: autoEndWhileMuted)
+        return VoiceOptionsSnapshot(
+            userSilenceTimeoutSeconds: normalizedSeconds,
+            autoEndWhileMuted: autoEndWhileMuted,
+            defaultClosedCaptionsEnabled: defaultClosedCaptionsEnabled
+        )
+    }
+
+    private static func defaultClosedCaptionsEnabled(from configDict: [String: Any]) -> Bool {
+        guard let voiceOpts = configDict["voiceOptions"] as? [String: Any] else {
+            return false
+        }
+        return (voiceOpts["defaultClosedCaptionsEnabled"] as? NSNumber)?.boolValue ?? false
     }
 
     // MARK: - Service Agent Configuration
@@ -305,6 +323,7 @@ class AgentforceModule: RCTEventEmitter {
         // (LiveKit/MIAW) internally once the flag is on. shouldBlockMicrophone stays
         // false so the mic isn't gated; other public flags carry through too.
         let flags = getFeatureFlagsFromConfigOrUserDefaults(configDict)
+        let defaultClosedCaptionsEnabled = Self.defaultClosedCaptionsEnabled(from: configDict)
         saveFeatureFlagsToUserDefaults(flags)
         let featureFlagSettings = AgentforceFeatureFlagSettings(
             enableMultiModalInput: flags.enableMultiModalInput,
@@ -313,6 +332,7 @@ class AgentforceModule: RCTEventEmitter {
             shouldBlockMicrophone: false,
             enableVoice: flags.enableVoice,
             enableOnboarding: false,
+            defaultClosedCaptionsEnabled: defaultClosedCaptionsEnabled,
             internalFlags: internalFlagsForSDK(configDict)
         )
 
@@ -434,6 +454,7 @@ class AgentforceModule: RCTEventEmitter {
         )
 
         let flags = getFeatureFlagsFromConfigOrUserDefaults(configDict)
+        let defaultClosedCaptionsEnabled = Self.defaultClosedCaptionsEnabled(from: configDict)
         saveFeatureFlagsToUserDefaults(flags)
         let featureFlagSettings = AgentforceFeatureFlagSettings(
             enableMultiModalInput: flags.enableMultiModalInput,
@@ -442,6 +463,7 @@ class AgentforceModule: RCTEventEmitter {
             shouldBlockMicrophone: false,
             enableVoice: flags.enableVoice,
             enableOnboarding: false,
+            defaultClosedCaptionsEnabled: defaultClosedCaptionsEnabled,
             internalFlags: internalFlagsForSDK(configDict)
         )
 
@@ -584,6 +606,10 @@ class AgentforceModule: RCTEventEmitter {
                 // Parse initialMode from options (defaults to chat)
                 let initialModeString = options["initialMode"] as? String ?? "chat"
                 let initialMode: AgentforceViewMode = (initialModeString == "voice") ? .voice : .chat
+                let voiceCloseBehavior: AgentforceVoiceCloseBehavior =
+                    (options["voiceCloseBehavior"] as? String == "dismissContainer")
+                    ? .dismissContainer
+                    : .returnToChat
 
                 // Validate Voice is enabled if voice mode requested
                 if initialMode == .voice {
@@ -601,6 +627,7 @@ class AgentforceModule: RCTEventEmitter {
                     initialMode: initialMode,
                     delegate: bridgeUIDelegate,
                     showTopBar: true,
+                    voiceCloseBehavior: voiceCloseBehavior,
                     onContainerClose: { [weak self] in
                         Task { @MainActor in
                             self?.dismissConversation()

--- a/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
+++ b/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
     ]
     core.dependency "React-Core"
     core.dependency "AgentforceSDK"
-    core.dependency "AgentforceVoice", "2.8.2"
+    core.dependency "AgentforceVoice", "2.9.3-rc3"
     # AgentforceSDK 17.31.6 (262.1) depends on SharedUI ('~> 1'); declare it so
     # this target can resolve the design-system module.
     core.dependency "SharedUI", "1.3.1"

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -866,10 +866,12 @@ class AgentforceService {
         this.validateAdditionalContext(additionalContext);
       }
 
-      const launchOptions = additionalContext
-        ? { initialMode, additionalContext }
-        : { initialMode };
-      const result = await AgentforceModule.launchConversation(launchOptions);
+      const voiceCloseBehavior = options?.voiceCloseBehavior ?? 'returnToChat';
+      const result = await AgentforceModule.launchConversation({
+        initialMode,
+        voiceCloseBehavior,
+        ...(additionalContext && { additionalContext }),
+      });
       console.log(`[AgentforceService] Conversation launched successfully (mode: ${initialMode})`);
       return result?.success ?? true;
     } catch (error) {

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.LaunchOptions.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.LaunchOptions.test.ts
@@ -31,7 +31,10 @@ describe('AgentforceService.launchConversation with initialMode', () => {
     it('accepts chat mode', async () => {
       await AgentforceService.launchConversation({ initialMode: 'chat' });
 
-      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({ initialMode: 'chat' });
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({
+        initialMode: 'chat',
+        voiceCloseBehavior: 'returnToChat',
+      });
     });
 
     it('accepts voice mode', async () => {
@@ -39,6 +42,7 @@ describe('AgentforceService.launchConversation with initialMode', () => {
 
       expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({
         initialMode: 'voice',
+        voiceCloseBehavior: 'returnToChat',
       });
     });
   });
@@ -47,13 +51,30 @@ describe('AgentforceService.launchConversation with initialMode', () => {
     it('defaults to chat when no options provided', async () => {
       await AgentforceService.launchConversation();
 
-      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({ initialMode: 'chat' });
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({
+        initialMode: 'chat',
+        voiceCloseBehavior: 'returnToChat',
+      });
     });
 
     it('defaults to chat when empty options object provided', async () => {
       await AgentforceService.launchConversation({});
 
-      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({ initialMode: 'chat' });
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({
+        initialMode: 'chat',
+        voiceCloseBehavior: 'returnToChat',
+      });
+    });
+  });
+
+  describe('voiceCloseBehavior', () => {
+    it('forwards dismissContainer to the native module', async () => {
+      await AgentforceService.launchConversation({ voiceCloseBehavior: 'dismissContainer' });
+
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({
+        initialMode: 'chat',
+        voiceCloseBehavior: 'dismissContainer',
+      });
     });
   });
 
@@ -67,6 +88,7 @@ describe('AgentforceService.launchConversation with initialMode', () => {
 
       expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({
         initialMode: 'chat',
+        voiceCloseBehavior: 'returnToChat',
         additionalContext,
       });
     });
@@ -110,7 +132,10 @@ describe('AgentforceService.launchConversation with initialMode', () => {
       await AgentforceService.launchConversation();
 
       expect(mockAgentforceModule.launchConversation).toHaveBeenCalledTimes(1);
-      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({ initialMode: 'chat' });
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({
+        initialMode: 'chat',
+        voiceCloseBehavior: 'returnToChat',
+      });
     });
   });
 });

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.VoiceOptions.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.VoiceOptions.test.ts
@@ -129,4 +129,14 @@ describe('voiceOptions round-trip via configure()', () => {
     const payload = nativeModule.configureWithConfig.mock.calls[0][0];
     expect(payload.voiceOptions).not.toHaveProperty('autoEndWhileMuted');
   });
+
+  it('forwards defaultClosedCaptionsEnabled to the native module', async () => {
+    await AgentforceService.configure({
+      ...baseServiceConfig,
+      voiceOptions: { defaultClosedCaptionsEnabled: true },
+    });
+
+    const payload = nativeModule.configureWithConfig.mock.calls[0][0];
+    expect(payload.voiceOptions).toEqual({ defaultClosedCaptionsEnabled: true });
+  });
 });

--- a/AgentforceSDK-ReactNative-Bridge/src/types/LaunchOptions.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/LaunchOptions.ts
@@ -25,7 +25,7 @@ export interface LaunchOptions {
   initialMode?: 'chat' | 'voice';
 
   /**
-    * Behavior when a user closes the Voice UI.
+   * Behavior when a user closes the Voice UI.
    *
    * - `'returnToChat'` (default) returns to the chat transcript.
    * - `'dismissContainer'` dismisses the entire native Agentforce UI.
@@ -33,8 +33,8 @@ export interface LaunchOptions {
    * This is currently supported on iOS only. Android retains its existing
    * Voice close behavior.
    *
-    * @default 'returnToChat'
-    */
+   * @default 'returnToChat'
+   */
   voiceCloseBehavior?: 'returnToChat' | 'dismissContainer';
 
   /**

--- a/AgentforceSDK-ReactNative-Bridge/src/types/LaunchOptions.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/LaunchOptions.ts
@@ -25,6 +25,19 @@ export interface LaunchOptions {
   initialMode?: 'chat' | 'voice';
 
   /**
+    * Behavior when a user closes the Voice UI.
+   *
+   * - `'returnToChat'` (default) returns to the chat transcript.
+   * - `'dismissContainer'` dismisses the entire native Agentforce UI.
+   *
+   * This is currently supported on iOS only. Android retains its existing
+   * Voice close behavior.
+   *
+    * @default 'returnToChat'
+    */
+  voiceCloseBehavior?: 'returnToChat' | 'dismissContainer';
+
+  /**
    * Context to apply before the native conversation UI is shown.
    *
    * Use this when the initial agent response needs the context. Call

--- a/AgentforceSDK-ReactNative-Bridge/src/types/VoiceOptions.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/VoiceOptions.ts
@@ -39,4 +39,15 @@ export interface VoiceOptions {
    * Has no effect when {@link userSilenceTimeoutSeconds} is unset.
    */
   autoEndWhileMuted?: boolean;
+
+  /**
+   * Whether closed captions start enabled for a first-time voice user.
+   *
+   * `false` (default) preserves the existing off-by-default behavior. Once a
+   * user has changed the closed-captions setting, their saved choice takes
+   * precedence over this default on future voice sessions.
+   *
+   * Has no effect when the native SDK's closed-captions feature gate is off.
+   */
+  defaultClosedCaptionsEnabled?: boolean;
 }

--- a/docs/voice-and-feature-flags-config.md
+++ b/docs/voice-and-feature-flags-config.md
@@ -1,7 +1,7 @@
 # Configuring Feature Flags & Voice Options — Employee Agent
 
 **Applies to:** `@salesforce/react-native-agentforce@0.4.0`
-(iOS AgentforceSDK 18.26.8 / AgentforceVoice 2.8.2; Android agentforce-sdk 15.130.1; Agentforce Mobile SDK 262.1.2)
+(iOS AgentforceSDK 18.26.9-rc3 / AgentforceVoice 2.9.3-rc3; Android agentforce-sdk 15.130.3-rc1; Agentforce Mobile SDK 262.1.3 RC)
 
 Both `featureFlags` and `voiceOptions` are passed to a **single**
 `AgentforceService.configure(...)` call, as **top-level siblings of `type`**.
@@ -29,6 +29,10 @@ async function startEmployeeAgent() {
     // true: muted time counts as silence, so the conversation still auto-ends
     //   after the timeout even if the user muted and walked away.
     autoEndWhileMuted: false,
+
+    // Start closed captions on for first-time voice users. A user's saved
+    // caption preference always overrides this value on later sessions.
+    defaultClosedCaptionsEnabled: true,
   };
 
   await AgentforceService.configure({
@@ -49,10 +53,11 @@ async function startEmployeeAgent() {
 
 ## What each voice field does
 
-| Field                       | Type               | Default                          | Meaning                                                                                                 |
-| --------------------------- | ------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `userSilenceTimeoutSeconds` | `number` (seconds) | `undefined` → **never auto-end** | Auto-end after this much continuous user silence. `0` or negative = disabled.                           |
-| `autoEndWhileMuted`         | `boolean`          | `false`                          | Whether the silence timer keeps running while muted. No effect if `userSilenceTimeoutSeconds` is unset. |
+| Field                          | Type               | Default                          | Meaning                                                                                                 |
+| ------------------------------ | ------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `userSilenceTimeoutSeconds`    | `number` (seconds) | `undefined` → **never auto-end** | Auto-end after this much continuous user silence. `0` or negative = disabled.                           |
+| `autoEndWhileMuted`            | `boolean`          | `false`                          | Whether the silence timer keeps running while muted. No effect if `userSilenceTimeoutSeconds` is unset. |
+| `defaultClosedCaptionsEnabled` | `boolean`          | `false`                          | Initial closed-caption state for a user with no saved caption preference.                               |
 
 ## Pitfalls to flag
 
@@ -63,14 +68,29 @@ async function startEmployeeAgent() {
 2. **`enableVoice: true` is required.** `voiceOptions` only govern _how_ a voice
    conversation ends; if voice itself is off, they do nothing and the mic UI
    won't appear.
-3. **On v0.4.0, voice options are locked in when the voice client is first built
-   for a session.** Reconfiguring an already-configured session with the **same
-   `agentId`** reuses the existing client and will **not** pick up changed
-   `voiceOptions`. They take effect on: the first `configure()` of a session, an
-   `agentId` change, or a cold start / sign-out-and-back-in. **Practical rule:**
-   set the values you want at the initial `configure()` before
-   `launchConversation()`; to change them at runtime, change the `agentId` or
-   have the user sign out and in again.
+3. **Voice options are locked in when the voice client is built.** Reconfigure
+   with changed voice options before launching the next conversation; the bridge
+   rebuilds the client so the next voice session uses them. An active voice
+   session always keeps its original options.
 4. **`featureFlags` is optional but sticky.** If omitted, the SDK reuses
    previously stored flags (or defaults). Pass the full object explicitly to be
    deterministic.
+5. **Caption defaults only affect first-time users.** Once a user enables or
+   disables captions in the native Voice UI, the SDK persists that choice and
+   ignores later `defaultClosedCaptionsEnabled` values for that user. The native
+   SDK's closed-caption feature gate must also be enabled.
+
+## iOS Voice Close Behavior
+
+Use `launchConversation` to select what closing Voice does on iOS:
+
+```typescript
+await AgentforceService.launchConversation({
+  initialMode: 'voice',
+  voiceCloseBehavior: 'dismissContainer',
+});
+```
+
+`'returnToChat'` is the default and returns the user to the chat transcript.
+`'dismissContainer'` dismisses the complete Agentforce presentation when Voice
+ends or the user closes it. Android retains its existing Voice close behavior.

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -20,8 +20,11 @@ def shared_pods
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'AgentforceSDK', '18.26.8'
-  pod 'AgentforceVoice', '2.8.2'
+  pod 'AgentforceSDK', '18.26.9-rc3'
+  # The SDK RC podspec has a broad `~> 6` service dependency, which otherwise
+  # resolves to stable 6.11.2 instead of the tested 262.1.3 RC service binary.
+  pod 'AgentforceService', '6.11.3-rc1'
+  pod 'AgentforceVoice', '2.9.3-rc3'
   pod 'Messaging-InApp-Core', '> 1.10.0'
   # Messaging-Multimedia-Core vends SMIMultimediaCore.framework, which
   # AgentforceVoice 2.5.2 links at runtime (@rpath/SMIMultimediaCore.framework).


### PR DESCRIPTION
## Summary
- update iOS and Android dependencies to the 262.1.3 RC SDKs
- expose `VoiceOptions.defaultClosedCaptionsEnabled` with native persisted-preference semantics
- expose iOS `LaunchOptions.voiceCloseBehavior` for return-to-chat or container dismissal
- document the options and add service forwarding coverage

## Validation
- `npm run typecheck`
- `npm run format`
- `npm run lint` (11 existing warnings, no errors)
- `npm test -- --runInBand` (13 suites, 144 tests)
- `(cd AgentforceSDK-ReactNative-Bridge && npm run build)`
- `npm run build:ios:service`
- `npm run build:ios:employee`
- `npm run build:android:service`
- `npm run build:android:employee`