### PR TITLE
@W-23734538 Fix initial Agentforce context timing

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/README.md
+++ b/AgentforceSDK-ReactNative-Bridge/README.md
@@ -118,20 +118,24 @@ await AgentforceService.launchConversation();
 ```
 
 **Additional Context:**
-Provide contextual data to personalize agent responses (must be called after launching conversation):
+Provide context at launch when the initial agent response needs it:
 
 ```typescript
-await AgentforceService.setAdditionalContext({
-  variables: [
-    { name: ‘userId’, type: ‘Text’, value: ‘005xx0000001234’ },
-    { name: ‘accountId’, type: ‘Text’, value: ‘001xx0000001234’ },
-    { name: ‘priority’, type: ‘Text’, value: ‘high’ },
-    { name: ‘score’, type: ‘Number’, value: 95.5 },
-    { name: ‘isVIP’, type: ‘Boolean’, value: true },
-    { name: ‘createdDate’, type: ‘DateTime’, value: ‘2026-03-06T10:00:00Z’ }
-  ]
+await AgentforceService.launchConversation({
+  additionalContext: {
+    variables: [
+      { name: 'userId', type: 'Text', value: '005xx0000001234' },
+      { name: 'accountId', type: 'Text', value: '001xx0000001234' },
+      { name: 'priority', type: 'Text', value: 'high' },
+      { name: 'score', type: 'Number', value: 95.5 },
+      { name: 'isVIP', type: 'Boolean', value: true },
+      { name: 'createdDate', type: 'DateTime', value: '2026-03-06T10:00:00Z' },
+    ],
+  },
 });
 ```
+
+Call `setAdditionalContext()` after launch to update context on an active conversation.
 
 **Supported types:**
 

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -559,6 +559,15 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                 try {
                     viewModel?.initializeAgentforce()
 
+                    if (AgentforceClientHolder.currentConversation == null) {
+                        if (!createConversation(promise, "LAUNCH_ERROR")) return@launch
+                    }
+                    options?.getMap("additionalContext")?.let { context ->
+                        val conversation = AgentforceClientHolder.currentConversation
+                            ?: throw IllegalStateException("Conversation was not created")
+                        conversation.setAdditionalContext(parseAdditionalContext(context))
+                    }
+
                     AgentforceConversationOverlay.show(activity, voiceMode = initialMode == "voice")
                     promise.resolve(Arguments.createMap().apply {
                         putBoolean("success", true)
@@ -579,6 +588,12 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                 // can find it immediately after the promise resolves (matches iOS behavior).
                 if (AgentforceClientHolder.currentConversation == null) {
                     if (!createConversation(promise, "LAUNCH_ERROR")) return@launch
+                }
+
+                options?.getMap("additionalContext")?.let { context ->
+                    val conversation = AgentforceClientHolder.currentConversation
+                        ?: throw IllegalStateException("Conversation was not created")
+                    conversation.setAdditionalContext(parseAdditionalContext(context))
                 }
 
                 AgentforceConversationOverlay.show(activity, voiceMode = initialMode == "voice")
@@ -1178,6 +1193,44 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
 
     // region Additional Context
 
+    private fun parseAdditionalContext(context: ReadableMap): CopilotAdditionalContext {
+        val variablesArray = context.getArray("variables")
+            ?: throw IllegalArgumentException("Missing 'variables' array in context")
+        val contextVariables = mutableListOf<CopilotContextVariable>()
+
+        for (i in 0 until variablesArray.size()) {
+            val varMap = variablesArray.getMap(i)
+                ?: throw IllegalArgumentException("Invalid variable at index $i")
+            val name = varMap.getString("name")
+            val type = varMap.getString("type")
+            if (name == null || type == null) {
+                throw IllegalArgumentException("Variable at index $i missing 'name' or 'type'")
+            }
+
+            val value = when {
+                varMap.hasKey("value") && !varMap.isNull("value") -> when (varMap.getType("value")) {
+                    ReadableType.String -> varMap.getString("value")
+                    ReadableType.Number -> varMap.getDouble("value")
+                    ReadableType.Boolean -> varMap.getBoolean("value")
+                    ReadableType.Map -> varMap.getMap("value")?.toHashMap()
+                    ReadableType.Array -> varMap.getArray("value")?.toArrayList()
+                    else -> null
+                }
+                else -> null
+            }
+            contextVariables.add(
+                CopilotContextVariable(
+                    name = name,
+                    type = type,
+                    description = varMap.getString("description"),
+                    value = value
+                )
+            )
+        }
+
+        return CopilotAdditionalContext(variables = contextVariables)
+    }
+
     /**
      * Set additional context for the current conversation.
      * Must be called after launching a conversation.
@@ -1190,62 +1243,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         Log.d(TAG, "setAdditionalContext() called")
 
         try {
-            // Validate context structure
-            val variablesArray = context.getArray("variables")
-            if (variablesArray == null) {
-                promise.reject("INVALID_CONTEXT", "Missing 'variables' array in context")
-                return
-            }
-
-            // Convert to CopilotContextVariable list (do this synchronously)
-            val contextVariables = mutableListOf<CopilotContextVariable>()
-            for (i in 0 until variablesArray.size()) {
-                val varMap = variablesArray.getMap(i)
-                if (varMap == null) {
-                    promise.reject("INVALID_CONTEXT", "Invalid variable at index $i")
-                    return
-                }
-
-                val name = varMap.getString("name")
-                val type = varMap.getString("type")
-
-                if (name == null || type == null) {
-                    promise.reject(
-                        "INVALID_CONTEXT",
-                        "Variable at index $i missing 'name' or 'type'"
-                    )
-                    return
-                }
-
-                // Extract optional fields
-                val description = varMap.getString("description")
-                val value = when {
-                    varMap.hasKey("value") && !varMap.isNull("value") -> {
-                        // Read value based on type
-                        when (varMap.getType("value")) {
-                            ReadableType.String -> varMap.getString("value")
-                            ReadableType.Number -> varMap.getDouble("value")
-                            ReadableType.Boolean -> varMap.getBoolean("value")
-                            ReadableType.Map -> varMap.getMap("value")?.toHashMap()
-                            ReadableType.Array -> varMap.getArray("value")?.toArrayList()
-                            else -> null
-                        }
-                    }
-                    else -> null
-                }
-
-                // Create CopilotContextVariable
-                val variable = CopilotContextVariable(
-                    name = name,
-                    type = type,
-                    description = description,
-                    value = value
-                )
-                contextVariables.add(variable)
-            }
-
-            // Create CopilotAdditionalContext
-            val additionalContext = CopilotAdditionalContext(variables = contextVariables)
+            val additionalContext = parseAdditionalContext(context)
 
             // Apply context to conversation (async) - check conversation inside coroutine
             scope.launch {
@@ -1262,7 +1260,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     }
 
                     conversation.setAdditionalContext(additionalContext)
-                    Log.d(TAG, "Additional context set: ${contextVariables.size} variables")
+                    Log.d(TAG, "Additional context set: ${additionalContext.variables.size} variables")
 
                     promise.resolve(Arguments.createMap().apply {
                         putBoolean("success", true)

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -576,6 +576,11 @@ class AgentforceModule: RCTEventEmitter {
 
                 let conversation = try getOrCreateConversation(client: client, mode: mode)
 
+                if let contextDict = options["additionalContext"] as? NSDictionary {
+                    let context = try additionalContextVariables(from: contextDict)
+                    try await conversation.setAdditionalContext(context: context)
+                }
+
                 // Parse initialMode from options (defaults to chat)
                 let initialModeString = options["initialMode"] as? String ?? "chat"
                 let initialMode: AgentforceViewMode = (initialModeString == "voice") ? .voice : .chat
@@ -1384,6 +1389,38 @@ class AgentforceModule: RCTEventEmitter {
         }
     }
 
+    private func additionalContextVariables(from contextDict: NSDictionary) throws -> [AgentforceVariable] {
+        guard let variables = contextDict["variables"] as? [[String: Any]] else {
+            throw NSError(
+                domain: "AgentforceModule",
+                code: 1002,
+                userInfo: [NSLocalizedDescriptionKey: "Missing or invalid 'variables' array"]
+            )
+        }
+
+        var context: [AgentforceVariable] = []
+        for (index, variable) in variables.enumerated() {
+            guard let name = variable["name"] as? String,
+                  let type = variable["type"] as? String else {
+                throw NSError(
+                    domain: "AgentforceModule",
+                    code: 1002,
+                    userInfo: [NSLocalizedDescriptionKey: "Variable at index \(index) missing 'name' or 'type'"]
+                )
+            }
+
+            context.append(
+                AgentforceVariable(
+                    name: name,
+                    type: type,
+                    value: variable["value"].flatMap(convertToJSEncodableValue)
+                )
+            )
+        }
+
+        return context
+    }
+
     /// Set additional context for the current conversation.
     /// Must be called after launching a conversation.
     ///
@@ -1401,12 +1438,6 @@ class AgentforceModule: RCTEventEmitter {
             // don't run bridge work or resolve promises into a dead JS runtime.
             guard !isInvalidated else { return }
             do {
-                // Validate context structure
-                guard let variables = contextDict["variables"] as? [[String: Any]] else {
-                    reject("INVALID_CONTEXT", "Missing or invalid 'variables' array", nil)
-                    return
-                }
-
                 // Check if conversation exists
                 guard let conversation = currentConversation else {
                     reject(
@@ -1417,44 +1448,10 @@ class AgentforceModule: RCTEventEmitter {
                     return
                 }
 
-                // Convert to AgentforceVariable array
-                var agentforceVariables: [AgentforceVariable] = []
-                for (index, varDict) in variables.enumerated() {
-                    guard let name = varDict["name"] as? String,
-                          let type = varDict["type"] as? String else {
-                        reject(
-                            "INVALID_CONTEXT",
-                            "Variable at index \(index) missing 'name' or 'type'",
-                            nil
-                        )
-                        return
-                    }
+                let context = try additionalContextVariables(from: contextDict)
+                try await conversation.setAdditionalContext(context: context)
 
-                    // Convert value to JSEncodableValue enum using recursive helper
-                    let value: JSEncodableValue?
-                    if let rawValue = varDict["value"] {
-                        value = convertToJSEncodableValue(rawValue)
-                        if value == nil {
-                            print("[AgentforceModule] ⚠️ Unsupported value type at index \(index)")
-                        }
-                    } else {
-                        value = nil
-                    }
-
-                    // Create AgentforceVariable
-                    // Note: iOS AgentforceVariable doesn't support description field (Android only)
-                    let variable = AgentforceVariable(
-                        name: name,
-                        type: type,
-                        value: value
-                    )
-                    agentforceVariables.append(variable)
-                }
-
-                // Set context on conversation
-                try await conversation.setAdditionalContext(context: agentforceVariables)
-
-                print("[AgentforceModule] ✓ Additional context set: \(agentforceVariables.count) variables")
+                print("[AgentforceModule] ✓ Additional context set: \(context.count) variables")
                 resolve(["success": true])
 
             } catch {

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -843,6 +843,9 @@ class AgentforceService {
    *
    * // Launch directly in Voice mode
    * await AgentforceService.launchConversation({ initialMode: 'voice' });
+   *
+   * // Apply context before the native UI begins session initialization
+   * await AgentforceService.launchConversation({ additionalContext: { variables: [] } });
    * ```
    */
   async launchConversation(options?: LaunchOptions): Promise<boolean> {
@@ -858,7 +861,15 @@ class AgentforceService {
 
     try {
       const initialMode = options?.initialMode ?? 'chat';
-      const result = await AgentforceModule.launchConversation({ initialMode });
+      const additionalContext = options?.additionalContext;
+      if (additionalContext) {
+        this.validateAdditionalContext(additionalContext);
+      }
+
+      const launchOptions = additionalContext
+        ? { initialMode, additionalContext }
+        : { initialMode };
+      const result = await AgentforceModule.launchConversation(launchOptions);
       console.log(`[AgentforceService] Conversation launched successfully (mode: ${initialMode})`);
       return result?.success ?? true;
     } catch (error) {
@@ -1191,7 +1202,8 @@ class AgentforceService {
    * such as user ID, account ID, case number, or any other relevant data.
    * This helps the agent provide more personalized and relevant responses.
    *
-   * **Must be called after launching a conversation.**
+   * Call this after launching a conversation to update its context. To make context
+   * available to the initial agent response, pass it to `launchConversation()`.
    *
    * @param context - The additional context with variables to set
    * @returns Promise<boolean> indicating success
@@ -1221,28 +1233,7 @@ class AgentforceService {
       return false;
     }
 
-    // Validate context structure
-    if (!context || !Array.isArray(context.variables)) {
-      throw new Error('Invalid context: must have "variables" array');
-    }
-
-    // Validate each variable
-    for (let i = 0; i < context.variables.length; i++) {
-      const variable = context.variables[i];
-      if (!variable.name || typeof variable.name !== 'string') {
-        throw new Error(`Invalid context variable at index ${i}: missing or invalid "name"`);
-      }
-      if (!variable.type || typeof variable.type !== 'string') {
-        throw new Error(`Invalid context variable at index ${i}: missing or invalid "type"`);
-      }
-      // Validate type against known types
-      if (!VALID_CONTEXT_TYPES.has(variable.type as AgentforceContextVariableType)) {
-        throw new Error(
-          `Invalid context variable at index ${i}: unknown type "${variable.type}". ` +
-            `Valid types: ${Array.from(VALID_CONTEXT_TYPES).join(', ')}`,
-        );
-      }
-    }
+    this.validateAdditionalContext(context);
 
     try {
       const result = await AgentforceModule.setAdditionalContext(context);
@@ -1253,6 +1244,28 @@ class AgentforceService {
     } catch (error) {
       console.error('[AgentforceService] Failed to set additional context:', error);
       throw error;
+    }
+  }
+
+  private validateAdditionalContext(context: AgentforceAdditionalContext): void {
+    if (!context || !Array.isArray(context.variables)) {
+      throw new Error('Invalid context: must have "variables" array');
+    }
+
+    for (let i = 0; i < context.variables.length; i++) {
+      const variable = context.variables[i];
+      if (!variable.name || typeof variable.name !== 'string') {
+        throw new Error(`Invalid context variable at index ${i}: missing or invalid "name"`);
+      }
+      if (!variable.type || typeof variable.type !== 'string') {
+        throw new Error(`Invalid context variable at index ${i}: missing or invalid "type"`);
+      }
+      if (!VALID_CONTEXT_TYPES.has(variable.type as AgentforceContextVariableType)) {
+        throw new Error(
+          `Invalid context variable at index ${i}: unknown type "${variable.type}". ` +
+            `Valid types: ${Array.from(VALID_CONTEXT_TYPES).join(', ')}`,
+        );
+      }
     }
   }
 

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.LaunchOptions.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.LaunchOptions.test.ts
@@ -57,6 +57,33 @@ describe('AgentforceService.launchConversation with initialMode', () => {
     });
   });
 
+  describe('additionalContext', () => {
+    it('forwards context with the launch request', async () => {
+      const additionalContext = {
+        variables: [{ name: 'userId', type: 'Text' as const, value: '005' }],
+      };
+
+      await AgentforceService.launchConversation({ additionalContext });
+
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({
+        initialMode: 'chat',
+        additionalContext,
+      });
+    });
+
+    it('validates context before launching', async () => {
+      await expect(
+        AgentforceService.launchConversation({ additionalContext: { variables: [] } }),
+      ).resolves.toBe(true);
+
+      await expect(
+        AgentforceService.launchConversation({
+          additionalContext: { variables: [{ name: 'userId', type: 'Unknown' as any }] },
+        }),
+      ).rejects.toThrow(/unknown type/);
+    });
+  });
+
   describe('SC-6: Error returned when Voice disabled/unavailable', () => {
     it('throws when Voice mode launch fails', async () => {
       const error = new Error('Voice is not enabled');

--- a/AgentforceSDK-ReactNative-Bridge/src/types/AgentforceContext.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/AgentforceContext.ts
@@ -63,8 +63,7 @@ export interface AgentforceContextVariable {
  *   ]
  * };
  *
- * await AgentforceService.launchConversation();
- * await AgentforceService.setAdditionalContext(context);
+ * await AgentforceService.launchConversation({ additionalContext: context });
  * ```
  */
 export interface AgentforceAdditionalContext {

--- a/AgentforceSDK-ReactNative-Bridge/src/types/LaunchOptions.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/LaunchOptions.ts
@@ -2,6 +2,8 @@
  * Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
  */
 
+import type { AgentforceAdditionalContext } from './AgentforceContext';
+
 /**
  * Optional parameters for launching Agentforce conversation.
  *
@@ -21,4 +23,12 @@ export interface LaunchOptions {
    * @default 'chat'
    */
   initialMode?: 'chat' | 'voice';
+
+  /**
+   * Context to apply before the native conversation UI is shown.
+   *
+   * Use this when the initial agent response needs the context. Call
+   * `setAdditionalContext()` to update context after launch.
+   */
+  additionalContext?: AgentforceAdditionalContext;
 }

--- a/README.md
+++ b/README.md
@@ -501,18 +501,18 @@ npm start -- --reset-cache
 
 ### setAdditionalContext
 
-Provide contextual data (user ID, account ID, etc.) to personalize agent responses. Must be called after launching a conversation.
+Provide contextual data (user ID, account ID, etc.) to personalize agent responses. Pass context to `launchConversation()` when the first agent response needs it. Use `setAdditionalContext()` after launch to update an active conversation.
 
 ```typescript
-await AgentforceService.launchConversation();
-
-await AgentforceService.setAdditionalContext({
-  variables: [
-    { name: 'userId', type: 'Text', value: '005xx0000001234' },
-    { name: 'accountId', type: 'Text', value: '001xx0000001234' },
-    { name: 'score', type: 'Number', value: 95.5 },
-    { name: 'isVIP', type: 'Boolean', value: true },
-  ],
+await AgentforceService.launchConversation({
+  additionalContext: {
+    variables: [
+      { name: 'userId', type: 'Text', value: '005xx0000001234' },
+      { name: 'accountId', type: 'Text', value: '001xx0000001234' },
+      { name: 'score', type: 'Number', value: 95.5 },
+      { name: 'isVIP', type: 'Boolean', value: true },
+    ],
+  },
 });
 ```
 

--- a/skills/integrate-agentforce-react-native/references/api-reference.md
+++ b/skills/integrate-agentforce-react-native/references/api-reference.md
@@ -14,11 +14,8 @@ AgentforceService.setNavigationDelegate(myNavigation);
 // 2. Configure
 await AgentforceService.configure({ type: 'service', ... });
 
-// 3. Launch the native conversation UI
-await AgentforceService.launchConversation();
-
-// 4. (Optional) attach context to the live conversation
-await AgentforceService.setAdditionalContext({ variables: [...] });
+// 3. Launch with context required by the initial agent response
+await AgentforceService.launchConversation({ additionalContext: { variables: [...] } });
 
 // 5. On app shutdown — clean up event listeners
 AgentforceService.destroy();
@@ -39,9 +36,10 @@ await AgentforceService.configure({
 });
 ```
 
-### `launchConversation()`
+### `launchConversation({ additionalContext? })`
 
 Open the native chat UI. **Preserves** any existing conversation — users continue where they left off. Throws if `configure()` hasn't been called.
+Pass `additionalContext` to apply variables before the chat UI begins session initialization.
 
 ### `startNewConversation()`
 
@@ -57,7 +55,7 @@ Check current state. `getConfigurationInfo()` returns `{ configured, mode, descr
 
 ### `setAdditionalContext({ variables })`
 
-Attach contextual data to the **current** conversation. Must be called **after** `launchConversation()`.
+Attach contextual data to the **current** conversation after launch. Use `launchConversation({ additionalContext })` when the initial response needs the variables.
 
 ```ts
 await AgentforceService.setAdditionalContext({

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -253,16 +253,10 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
           };
       await AgentforceService.configure(config);
 
-      await AgentforceService.launchConversation();
-
       const contextVars = getContextVariables();
-      if (contextVars.length > 0) {
-        try {
-          await AgentforceService.setAdditionalContext({ variables: contextVars });
-        } catch (ctxError) {
-          console.warn('Failed to set employee agent context variables:', ctxError);
-        }
-      }
+      await AgentforceService.launchConversation({
+        additionalContext: contextVars.length > 0 ? { variables: contextVars } : undefined,
+      });
     } catch (error: any) {
       Alert.alert(
         'Error',


### PR DESCRIPTION
## Summary
- allow additional context to be supplied atomically to `launchConversation()`
- apply context before iOS chat presentation and Android overlay bootstrap
- update the Employee Agent sample, API documentation, and launch-option tests

## Why
The existing `launchConversation()` followed by `setAdditionalContext()` sequence allowed native session initialization to start before context arrived, so initial Agentforce activity could observe missing variables.

## Validation
- `npm run lint` (passes with existing warnings)
- `npm run format`
- `npm run typecheck`
- targeted Jest suites: 68 tests passed
- `npm run build` in `AgentforceSDK-ReactNative-Bridge`
- `./gradlew :react-native-agentforce:compileDebugKotlin`
- iOS EmployeeAgent simulator build