### PR TITLE
Add voiceOnly launch mode for the dedicated voice view

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/README.md
+++ b/AgentforceSDK-ReactNative-Bridge/README.md
@@ -117,6 +117,26 @@ await AgentforceService.configure(config);
 await AgentforceService.launchConversation();
 ```
 
+**Launch modes:**
+
+`launchConversation()` accepts an optional `initialMode` controlling how the UI opens:
+
+```typescript
+// Chat (text) — the default
+await AgentforceService.launchConversation();
+
+// Voice: opens directly in Voice mode. iOS shows the combined voice + text
+// view (the user can switch back to text); Android shows the Voice view.
+await AgentforceService.launchConversation({ initialMode: 'voice' });
+
+// Voice-only: the dedicated Voice view with no text/interaction content
+// (iOS `AgentforceVoiceView`, Android `AgentforceVoiceContainer`).
+await AgentforceService.launchConversation({ initialMode: 'voiceOnly' });
+```
+
+Both `'voice'` and `'voiceOnly'` require the `enableVoice` feature flag; the
+launch promise rejects when Voice is disabled or unavailable.
+
 **Additional Context:**
 Provide context at launch when the initial agent response needs it:
 

--- a/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
+++ b/AgentforceSDK-ReactNative-Bridge/android/src/main/java/com/salesforce/android/reactagentforce/AgentforceModule.kt
@@ -521,7 +521,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
     /**
      * Launch the Agentforce conversation UI - works for both Service and Employee agents
      *
-     * @param options Optional map with "initialMode": "chat" | "voice"
+     * @param options Optional map with "initialMode": "chat" | "voice" | "voiceOnly"
      * @param promise Promise to resolve/reject
      */
     @ReactMethod
@@ -531,14 +531,21 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
         val initialMode = options?.getString("initialMode") ?: "chat"
         Log.d(TAG, "launchConversation: initialMode=$initialMode")
 
+        // Both "voice" and "voiceOnly" open the dedicated AgentforceVoiceContainer. Android's
+        // SDK exposes a single voice UI per launch (the combined launch-in-voice chat is a
+        // config-time setting, not a per-launch container option), so the two modes resolve to
+        // the same view here — the distinction only matters on iOS, where "voice" is the
+        // combined chat-in-voice view and "voiceOnly" is the standalone voice view.
+        val isVoiceView = initialMode == "voice" || initialMode == "voiceOnly"
+
         val activity = currentActivity
         if (activity == null) {
             promise.reject("ERROR", "Activity not available")
             return
         }
 
-        // Validate Voice feature flag if Voice mode requested
-        if (initialMode == "voice" && !getFeatureFlagsFromConfigOrPrefs(Arguments.createMap()).enableVoice) {
+        // Validate Voice feature flag if a voice view was requested
+        if (isVoiceView && !getFeatureFlagsFromConfigOrPrefs(Arguments.createMap()).enableVoice) {
             Log.e(TAG, "Voice mode requested but enableVoice feature flag is disabled")
             promise.reject("VOICE_DISABLED", "Voice is not enabled for this Agentforce configuration")
             return
@@ -568,7 +575,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                         conversation.setAdditionalContext(parseAdditionalContext(context))
                     }
 
-                    AgentforceConversationOverlay.show(activity, voiceMode = initialMode == "voice")
+                    AgentforceConversationOverlay.show(activity, voiceMode = isVoiceView)
                     promise.resolve(Arguments.createMap().apply {
                         putBoolean("success", true)
                     })
@@ -596,7 +603,7 @@ class AgentforceModule(reactContext: ReactApplicationContext) :
                     conversation.setAdditionalContext(parseAdditionalContext(context))
                 }
 
-                AgentforceConversationOverlay.show(activity, voiceMode = initialMode == "voice")
+                AgentforceConversationOverlay.show(activity, voiceMode = isVoiceView)
                 Log.d(TAG, "Conversation shown (initialMode=$initialMode)")
 
                 promise.resolve(Arguments.createMap().apply {

--- a/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
+++ b/AgentforceSDK-ReactNative-Bridge/ios/Agentforce/AgentforceModule.swift
@@ -603,16 +603,18 @@ class AgentforceModule: RCTEventEmitter {
                     try await conversation.setAdditionalContext(context: context)
                 }
 
-                // Parse initialMode from options (defaults to chat)
+                // Parse launch behavior from options (defaults to chat and returning to chat).
+                // - "chat":      combined chat view in text mode
+                // - "voice":     combined chat view launched in Voice mode (text still reachable)
+                // - "voiceOnly": dedicated Voice-only view, no combined text/interaction content
                 let initialModeString = options["initialMode"] as? String ?? "chat"
-                let initialMode: AgentforceViewMode = (initialModeString == "voice") ? .voice : .chat
                 let voiceCloseBehavior: AgentforceVoiceCloseBehavior =
                     (options["voiceCloseBehavior"] as? String == "dismissContainer")
                     ? .dismissContainer
                     : .returnToChat
 
-                // Validate Voice is enabled if voice mode requested
-                if initialMode == .voice {
+                // Validate Voice is enabled if any voice experience requested
+                if initialModeString == "voice" || initialModeString == "voiceOnly" {
                     guard getFeatureFlagsFromConfigOrUserDefaults([:]).enableVoice else {
                         throw NSError(
                             domain: "AgentforceModule",
@@ -622,21 +624,38 @@ class AgentforceModule: RCTEventEmitter {
                     }
                 }
 
-                let chatView = try client.createAgentforceChatView(
-                    conversation: conversation,
-                    initialMode: initialMode,
-                    delegate: bridgeUIDelegate,
-                    showTopBar: true,
-                    voiceCloseBehavior: voiceCloseBehavior,
-                    onContainerClose: { [weak self] in
-                        Task { @MainActor in
-                            self?.dismissConversation()
+                if initialModeString == "voiceOnly" {
+                    // Dedicated Voice-only view (AgentforceVoiceView). We intentionally use
+                    // createAgentforceVoiceView — the SDK deprecates it in favor of
+                    // createAgentforceChatView(initialMode: .voice), but that path is the
+                    // COMBINED voice + text view (exposed here as initialMode "voice").
+                    // This standalone view is the only way to present voice with no text UI.
+                    let voiceView = try client.createAgentforceVoiceView(
+                        conversation: conversation,
+                        onContainerClose: { [weak self] in
+                            Task { @MainActor in
+                                self?.dismissConversation()
+                            }
                         }
-                    },
-                    navigationBarBuilder: navigationBarBuilder
-                )
-
-                presentConversationView(chatView)
+                    )
+                    presentConversationView(voiceView)
+                } else {
+                    let initialMode: AgentforceViewMode = (initialModeString == "voice") ? .voice : .chat
+                    let chatView = try client.createAgentforceChatView(
+                        conversation: conversation,
+                        initialMode: initialMode,
+                        delegate: bridgeUIDelegate,
+                        showTopBar: true,
+                        voiceCloseBehavior: voiceCloseBehavior,
+                        onContainerClose: { [weak self] in
+                            Task { @MainActor in
+                                self?.dismissConversation()
+                            }
+                        },
+                        navigationBarBuilder: navigationBarBuilder
+                    )
+                    presentConversationView(chatView)
+                }
                 resolve(["success": true])
             } catch {
                 print("[AgentforceModule] ❌ Launch failed: \(error)")

--- a/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/AgentforceService.ts
@@ -841,11 +841,14 @@ class AgentforceService {
    * // Launch in default Chat mode
    * await AgentforceService.launchConversation();
    *
-   * // Launch directly in Voice mode
+   * // Launch directly in Voice mode (combined voice + text on iOS)
    * await AgentforceService.launchConversation({ initialMode: 'voice' });
    *
    * // Apply context before the native UI begins session initialization
    * await AgentforceService.launchConversation({ additionalContext: { variables: [] } });
+   *
+   * // Launch the dedicated Voice-only view (no text UI)
+   * await AgentforceService.launchConversation({ initialMode: 'voiceOnly' });
    * ```
    */
   async launchConversation(options?: LaunchOptions): Promise<boolean> {

--- a/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.LaunchOptions.test.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/services/__tests__/AgentforceService.LaunchOptions.test.ts
@@ -27,7 +27,7 @@ describe('AgentforceService.launchConversation with initialMode', () => {
     mockAgentforceModule.launchConversation.mockResolvedValue({ success: true });
   });
 
-  describe('SC-1: initialMode parameter accepts chat and voice', () => {
+  describe('SC-1: initialMode parameter accepts chat, voice, and voiceOnly', () => {
     it('accepts chat mode', async () => {
       await AgentforceService.launchConversation({ initialMode: 'chat' });
 
@@ -42,6 +42,15 @@ describe('AgentforceService.launchConversation with initialMode', () => {
 
       expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({
         initialMode: 'voice',
+        voiceCloseBehavior: 'returnToChat',
+      });
+    });
+
+    it('accepts voiceOnly mode', async () => {
+      await AgentforceService.launchConversation({ initialMode: 'voiceOnly' });
+
+      expect(mockAgentforceModule.launchConversation).toHaveBeenCalledWith({
+        initialMode: 'voiceOnly',
         voiceCloseBehavior: 'returnToChat',
       });
     });
@@ -124,6 +133,14 @@ describe('AgentforceService.launchConversation with initialMode', () => {
       await expect(AgentforceService.launchConversation({ initialMode: 'voice' })).rejects.toThrow(
         'Voice feature is disabled',
       );
+    });
+
+    it('throws when voiceOnly launch fails because Voice is disabled', async () => {
+      mockAgentforceModule.launchConversation.mockRejectedValue(new Error('Voice is not enabled'));
+
+      await expect(
+        AgentforceService.launchConversation({ initialMode: 'voiceOnly' }),
+      ).rejects.toThrow('Voice is not enabled');
     });
   });
 

--- a/AgentforceSDK-ReactNative-Bridge/src/types/LaunchOptions.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/LaunchOptions.ts
@@ -7,22 +7,28 @@ import type { AgentforceAdditionalContext } from './AgentforceContext';
 /**
  * Optional parameters for launching Agentforce conversation.
  *
- * Pass via `AgentforceService.launchConversation({ initialMode: 'voice' })`
+ * Pass via `AgentforceService.launchConversation({ initialMode: 'voiceOnly' })`
  * to control how the conversation opens.
  */
 export interface LaunchOptions {
   /**
    * Initial conversation mode.
    *
-   * - `'chat'` (default) opens the conversation in Chat mode
-   * - `'voice'` opens directly in Voice mode when Voice is enabled
+   * - `'chat'` (default) opens the conversation in Chat (text) mode.
+   * - `'voice'` opens directly in Voice mode. On iOS this is the combined
+   *   voice + text experience (the chat view launched in Voice, where the
+   *   user can still switch to text). On Android it opens the dedicated
+   *   Voice view.
+   * - `'voiceOnly'` opens the dedicated Voice-only view with no text /
+   *   interaction content — iOS `AgentforceVoiceView`, Android
+   *   `AgentforceVoiceContainer`.
    *
-   * Voice launch requires `enableVoice: true` in feature flags.
-   * When Voice is disabled or unavailable, launch fails with error.
+   * Both `'voice'` and `'voiceOnly'` require `enableVoice: true` in feature
+   * flags. When Voice is disabled or unavailable, launch fails with an error.
    *
    * @default 'chat'
    */
-  initialMode?: 'chat' | 'voice';
+  initialMode?: 'chat' | 'voice' | 'voiceOnly';
 
   /**
    * Behavior when a user closes the Voice UI.


### PR DESCRIPTION
## Summary

Adds a new `initialMode: 'voiceOnly'` option to `launchConversation()` that opens the SDK's **dedicated voice-only view** — no combined text/interaction content — alongside the existing `'chat'` and `'voice'` modes.

This complements the existing `'voice'` mode (added in #143), which opens the **combined** voice + text experience on iOS.

## Changes

- **TypeScript** — extend `LaunchOptions.initialMode` from `'chat' | 'voice'` to `'chat' | 'voice' | 'voiceOnly'`, with per-platform docs. `AgentforceService.launchConversation()` already threads `initialMode` through generically, so no logic change was needed there.
- **iOS** (`AgentforceModule.swift`) — `'voiceOnly'` routes to `client.createAgentforceVoiceView(...)` → `AgentforceVoiceView` (the standalone voice view). `'voice'` still uses `createAgentforceChatView(initialMode: .voice)` (combined). Both validate the `enableVoice` flag.
- **Android** (`AgentforceModule.kt`) — `'voice'` and `'voiceOnly'` both route to the dedicated `AgentforceVoiceContainer`. Android exposes a single per-launch voice UI (combined launch-in-voice is a config-time setting via `setVoiceModeEnabled`, not a per-call container option), so the two modes coincide here; the distinction is meaningful on iOS.
- **Tests** — add `voiceOnly` accept + voice-disabled failure cases to `AgentforceService.LaunchOptions.test.ts`.
- **Docs** — document all three launch modes in the bridge README.

## Notes

- iOS intentionally uses the deprecated `createAgentforceVoiceView` — the SDK deprecates it in favor of `createAgentforceChatView(initialMode: .voice)`, but that path is the *combined* view; the standalone view is the only way to present voice with no text UI.

## Testing

- Jest: full suite **144/144 pass** (9/9 in the launch-options suite)
- `tsc -p tsconfig.build.json`, eslint, and prettier all clean
- Native (Xcode/Gradle) builds not run in this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)