### PR TITLE
Bump iOS Agentforce SDK to 262.1.3 RC4

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
+++ b/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
     ]
     core.dependency "React-Core"
     core.dependency "AgentforceSDK"
-    core.dependency "AgentforceVoice", "2.9.3-rc3"
+    core.dependency "AgentforceVoice", "2.9.3-rc4"
     # AgentforceSDK 17.31.6 (262.1) depends on SharedUI ('~> 1'); declare it so
     # this target can resolve the design-system module.
     core.dependency "SharedUI", "1.3.1"

--- a/AgentforceSDK-ReactNative-Bridge/package.json
+++ b/AgentforceSDK-ReactNative-Bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/react-native-agentforce",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Agentforce React Native bridge: JS API and native module for Service Agent and Employee Agent (auth bridge included; host app adds Mobile SDK).",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/docs/voice-and-feature-flags-config.md
+++ b/docs/voice-and-feature-flags-config.md
@@ -1,6 +1,6 @@
 # Configuring Feature Flags & Voice Options — Employee Agent
 
-**Applies to:** `@salesforce/react-native-agentforce@0.4.0`
+**Applies to:** `@salesforce/react-native-agentforce@0.5.0`
 (iOS AgentforceSDK 18.26.9-rc3 / AgentforceVoice 2.9.3-rc3; Android agentforce-sdk 15.130.3-rc1; Agentforce Mobile SDK 262.1.3 RC)
 
 Both `featureFlags` and `voiceOptions` are passed to a **single**

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -20,11 +20,11 @@ def shared_pods
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'AgentforceSDK', '18.26.9-rc3'
+  pod 'AgentforceSDK', '18.26.9-rc4'
   # The SDK RC podspec has a broad `~> 6` service dependency, which otherwise
   # resolves to stable 6.11.2 instead of the tested 262.1.3 RC service binary.
   pod 'AgentforceService', '6.11.3-rc1'
-  pod 'AgentforceVoice', '2.9.3-rc3'
+  pod 'AgentforceVoice', '2.9.3-rc4'
   pod 'Messaging-InApp-Core', '> 1.10.0'
   # Messaging-Multimedia-Core vends SMIMultimediaCore.framework, which
   # AgentforceVoice 2.5.2 links at runtime (@rpath/SMIMultimediaCore.framework).

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
     },
     "AgentforceSDK-ReactNative-Bridge": {
       "name": "@salesforce/react-native-agentforce",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",


### PR DESCRIPTION
## Summary
- consume AgentforceSDK `18.26.9-rc4` and AgentforceVoice `2.9.3-rc4` from the 262.1.3 RC4 specs
- retain the explicit AgentforceService `6.11.3-rc1` pin because the SDK podspec uses the broad `~> 6` constraint
- bump `@salesforce/react-native-agentforce` to `0.5.0`

## Validation
- `npm run format`
- `npm run typecheck`
- `npm run build:ios:service`
- `npm run build:ios:employee`