### PR TITLE
Pin iOS Agentforce Voice to 2.8.2

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
+++ b/AgentforceSDK-ReactNative-Bridge/ios/ReactNativeAgentforce.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
     ]
     core.dependency "React-Core"
     core.dependency "AgentforceSDK"
-    core.dependency "AgentforceVoice", "2.9.3-rc4"
+    core.dependency "AgentforceVoice", "2.8.2"
     # AgentforceSDK 17.31.6 (262.1) depends on SharedUI ('~> 1'); declare it so
     # this target can resolve the design-system module.
     core.dependency "SharedUI", "1.3.1"

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -24,7 +24,7 @@ def shared_pods
   # The SDK RC podspec has a broad `~> 6` service dependency, which otherwise
   # resolves to stable 6.11.2 instead of the tested 262.1.3 RC service binary.
   pod 'AgentforceService', '6.11.3-rc1'
-  pod 'AgentforceVoice', '2.9.3-rc4'
+  pod 'AgentforceVoice', '2.8.2'
   pod 'Messaging-InApp-Core', '> 1.10.0'
   # Messaging-Multimedia-Core vends SMIMultimediaCore.framework, which
   # AgentforceVoice 2.5.2 links at runtime (@rpath/SMIMultimediaCore.framework).


### PR DESCRIPTION
## Summary
- align the iOS AgentforceVoice dependency with the `2.8.2` artifact published for the 262.1.3 release candidate
- update both the sample app Podfile and published bridge podspec

## Validation
- `git diff --check`