### PR TITLE
Bump Agentforce SDK to 262.1.3

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/build.gradle
+++ b/AgentforceSDK-ReactNative-Bridge/android/build.gradle
@@ -60,8 +60,8 @@ repositories {
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
     implementation "com.facebook.react:react-android"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk:15.130.3-rc1"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk-voice:15.130.3-rc1"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk:15.130.4"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk-voice:15.130.4"
     // compileOnly: host app adds this for Employee Agent. Bridge compiles; host provides at runtime.
     compileOnly "com.salesforce.mobilesdk:SalesforceReact:13.1.1"
 

--- a/docs/voice-and-feature-flags-config.md
+++ b/docs/voice-and-feature-flags-config.md
@@ -1,7 +1,7 @@
 # Configuring Feature Flags & Voice Options — Employee Agent
 
 **Applies to:** `@salesforce/react-native-agentforce@0.5.0`
-(iOS AgentforceSDK 18.26.9-rc3 / AgentforceVoice 2.9.3-rc3; Android agentforce-sdk 15.130.3-rc1; Agentforce Mobile SDK 262.1.3 RC)
+(iOS AgentforceSDK 18.26.17 / AgentforceVoice 2.8.2; Android agentforce-sdk 15.130.4; Agentforce Mobile SDK 262.1.3)
 
 Both `featureFlags` and `voiceOptions` are passed to a **single**
 `AgentforceService.configure(...)` call, as **top-level siblings of `type`**.

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -20,10 +20,10 @@ def shared_pods
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'AgentforceSDK', '18.26.9-rc4'
-  # The SDK RC podspec has a broad `~> 6` service dependency, which otherwise
-  # resolves to stable 6.11.2 instead of the tested 262.1.3 RC service binary.
-  pod 'AgentforceService', '6.11.3-rc1'
+  pod 'AgentforceSDK', '18.26.17'
+  # AgentforceSDK declares a broad `~> 6` service dependency; pin explicitly to
+  # the exact 262.1.3 service binary this SDK build was tested against.
+  pod 'AgentforceService', '6.11.4'
   pod 'AgentforceVoice', '2.8.2'
   pod 'Messaging-InApp-Core', '> 1.10.0'
   # Messaging-Multimedia-Core vends SMIMultimediaCore.framework, which


### PR DESCRIPTION
## Summary
- iOS: `AgentforceSDK` 18.26.9-rc4 → 18.26.17, `AgentforceService` 6.11.3-rc1 → 6.11.4 (stable release pairing for 262.1.3, per the SDK's `~> 6` dependency). `AgentforceVoice` stays pinned at 2.8.2 as requested.
- Android: `agentforce-sdk` / `agentforce-sdk-voice` 15.130.3-rc1 → 15.130.4.
- Updated stale version references in `docs/voice-and-feature-flags-config.md`.

Release notes for both SDKs contain only feature additions and bug fixes — no breaking changes or new required modules.

## Test plan
- [x] `npm test` — 146 tests passed
- [x] `AgentforceSDK-ReactNative-Bridge`: `npm run build` (TypeScript build)
- [x] `npm run build:ios:service` — BUILD SUCCEEDED
- [x] `npm run build:ios:employee` — BUILD SUCCEEDED
- [x] `npm run build:android:service` — BUILD SUCCESSFUL
- [x] `npm run build:android:employee` — BUILD SUCCESSFUL
- [x] `npm run lint`, `npm run format`, `npm run typecheck` — all pass