### PR TITLE
Hook voice caption default and close behavior into sample app

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/src/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/index.ts
@@ -45,6 +45,7 @@ export type {
   AgentSwitchEvent,
   ModifyUtteranceRequest,
   VoiceOptions,
+  LaunchOptions,
   AgentforceAppearance,
   AgentforceThemeMode,
   AgentforceFontWeight,

--- a/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
@@ -45,6 +45,9 @@ export type { HiddenPreChatFields } from './HiddenPreChatFields';
 // Voice configuration types
 export type { VoiceOptions } from './VoiceOptions';
 
+// Conversation launch option types
+export type { LaunchOptions } from './LaunchOptions';
+
 // Appearance customization types
 export type {
   AgentforceAppearance,

--- a/docs/voice-and-feature-flags-config.md
+++ b/docs/voice-and-feature-flags-config.md
@@ -94,3 +94,18 @@ await AgentforceService.launchConversation({
 `'returnToChat'` is the default and returns the user to the chat transcript.
 `'dismissContainer'` dismisses the complete Agentforce presentation when Voice
 ends or the user closes it. Android retains its existing Voice close behavior.
+
+## Testing in the sample app
+
+Both options are wired into the Employee tab of the sample app's Settings
+screen (`src/screens/SettingsScreen.tsx`):
+
+- **Voice Options** section — toggles `autoEndWhileMuted` and
+  `defaultClosedCaptionsEnabled` (persisted in `src/store/VoiceTimeoutStore.ts`,
+  applied on the next `configure()` call from Home).
+- **Voice Close Behavior** section — a segmented control for
+  `voiceCloseBehavior` (persisted in `src/store/VoiceCloseBehaviorStore.ts`,
+  applied on the next `launchConversation()` call from Home).
+
+Both stores are in-memory only and reset on process restart, matching the
+existing Voice Timeout settings pattern.

--- a/src/config/AppConfig.ts
+++ b/src/config/AppConfig.ts
@@ -53,10 +53,15 @@ const appMode: 'service' | 'employee' | 'all' = APP_MODE as any;
  * `autoEndWhileMuted: false` (the default) pauses the silence timer while the
  * mic is muted, so a muted user is never auto-ended. Set `true` to count muted
  * time as silence.
+ *
+ * `defaultClosedCaptionsEnabled: false` (the default) preserves the existing
+ * off-by-default caption behavior for first-time voice users. Once a user
+ * changes their caption preference, their saved choice takes precedence.
  */
 export const EMPLOYEE_VOICE_OPTIONS: VoiceOptions = {
   userSilenceTimeoutSeconds: 30,
   autoEndWhileMuted: false,
+  defaultClosedCaptionsEnabled: false,
 };
 // These values seed the runtime-editable VoiceTimeoutStore (Settings > Employee
 // > Voice Timeout). configure() sends the store's current values, not this

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -49,6 +49,7 @@ import { UI_FEATURES } from '../config/AppConfig';
 import { getAgentAppearance, loadAppearanceSettings } from '../store/AgentAppearanceStore';
 import { getContextVariables } from '../store/ContextVariablesStore';
 import { getVoiceOptions } from '../store/VoiceTimeoutStore';
+import { getVoiceCloseBehavior } from '../store/VoiceCloseBehaviorStore';
 
 interface HomeScreenProps {
   navigation: any;
@@ -254,8 +255,12 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
       await AgentforceService.configure(config);
 
       const contextVars = getContextVariables();
+      // Read the latest close-behavior setting (editable in Settings > Employee > Voice Close
+      // Behavior) at launch time. iOS only; Android ignores this option.
+      const voiceCloseBehavior = getVoiceCloseBehavior();
       await AgentforceService.launchConversation({
         additionalContext: contextVars.length > 0 ? { variables: contextVars } : undefined,
+        voiceCloseBehavior,
       });
     } catch (error: any) {
       Alert.alert(

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -72,6 +72,8 @@ import {
   setVoiceTimeoutSettings,
 } from '../store/VoiceTimeoutStore';
 import type { VoiceTimeoutSettings } from '../store/VoiceTimeoutStore';
+import { getVoiceCloseBehavior, setVoiceCloseBehavior } from '../store/VoiceCloseBehaviorStore';
+import type { VoiceCloseBehavior } from '../store/VoiceCloseBehaviorStore';
 
 type TabType = 'service' | 'employee' | 'features' | 'theming';
 
@@ -176,6 +178,9 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
 
   const [voiceTimeout, setVoiceTimeout] = useState<VoiceTimeoutSettings>(() =>
     getVoiceTimeoutSettings(),
+  );
+  const [voiceCloseBehavior, setVoiceCloseBehaviorState] = useState<VoiceCloseBehavior>(() =>
+    getVoiceCloseBehavior(),
   );
 
   useEffect(() => {
@@ -476,6 +481,11 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
   useEffect(() => {
     setVoiceTimeoutSettings(voiceTimeout);
   }, [voiceTimeout]);
+
+  // Sync Voice close behavior to store whenever it changes
+  useEffect(() => {
+    setVoiceCloseBehavior(voiceCloseBehavior);
+  }, [voiceCloseBehavior]);
 
   const handleAddContextVariable = () => {
     const trimmedName = newEmployeeCtxName.trim();
@@ -918,11 +928,11 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
 
   const renderVoiceTimeoutSection = () => (
     <View style={styles.formContainerWithMargin}>
-      <Text style={styles.label}>Voice Timeout</Text>
+      <Text style={styles.label}>Voice Options</Text>
       <Text style={styles.hint}>
-        Auto-end a voice conversation after the user is silent. Requires the Voice feature flag.
-        Changes apply the next time you launch Employee Agent (rebuilding the client ends the active
-        conversation).
+        Auto-end a voice conversation after the user is silent, and set the default caption state.
+        Requires the Voice feature flag. Changes apply the next time you launch Employee Agent
+        (rebuilding the client ends the active conversation).
       </Text>
 
       <View style={[styles.flagRow, styles.flagRowBorder]}>
@@ -962,7 +972,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
         </View>
       )}
 
-      <View style={styles.flagRow}>
+      <View style={[styles.flagRow, styles.flagRowBorder]}>
         <View style={styles.flagLabelBlock}>
           <Text style={styles.label}>Auto-end while muted</Text>
           <Text style={styles.hint}>Also auto-end when the mic is muted.</Text>
@@ -975,6 +985,54 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
           trackColor={{ false: '#ced4da', true: '#28a745' }}
           thumbColor="#ffffff"
         />
+      </View>
+
+      <View style={styles.flagRow}>
+        <View style={styles.flagLabelBlock}>
+          <Text style={styles.label}>Closed captions by default</Text>
+          <Text style={styles.hint}>
+            Starts captions on for first-time voice users. A user's saved caption preference always
+            overrides this once they've changed it.
+          </Text>
+        </View>
+        <Switch
+          value={voiceTimeout.defaultClosedCaptionsEnabled}
+          onValueChange={defaultClosedCaptionsEnabled =>
+            setVoiceTimeout(prev => ({ ...prev, defaultClosedCaptionsEnabled }))
+          }
+          trackColor={{ false: '#ced4da', true: '#28a745' }}
+          thumbColor="#ffffff"
+        />
+      </View>
+    </View>
+  );
+
+  const renderVoiceCloseBehaviorSection = () => (
+    <View style={styles.formContainerWithMargin}>
+      <Text style={styles.label}>Voice Close Behavior</Text>
+      <Text style={styles.hint}>
+        What happens when the user closes the Voice UI. iOS only — Android retains its existing
+        Voice close behavior regardless of this setting. Applies to the next `launchConversation()`
+        call.
+      </Text>
+      <View style={styles.segmentedControl}>
+        {(['returnToChat', 'dismissContainer'] as VoiceCloseBehavior[]).map(behavior => (
+          <TouchableOpacity
+            key={behavior}
+            style={[
+              styles.segmentButton,
+              voiceCloseBehavior === behavior && styles.segmentButtonActive,
+            ]}
+            onPress={() => setVoiceCloseBehaviorState(behavior)}>
+            <Text
+              style={[
+                styles.segmentButtonText,
+                voiceCloseBehavior === behavior && styles.segmentButtonTextActive,
+              ]}>
+              {behavior === 'returnToChat' ? 'Return to Chat' : 'Dismiss Container'}
+            </Text>
+          </TouchableOpacity>
+        ))}
       </View>
     </View>
   );
@@ -1055,6 +1113,8 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
       )}
 
       {authSupported && renderVoiceTimeoutSection()}
+
+      {authSupported && renderVoiceCloseBehaviorSection()}
 
       {authSupported && renderContextVariablesSection()}
 

--- a/src/store/VoiceCloseBehaviorStore.ts
+++ b/src/store/VoiceCloseBehaviorStore.ts
@@ -1,0 +1,28 @@
+import type { LaunchOptions } from '@salesforce/react-native-agentforce';
+
+/**
+ * Runtime-editable Voice close behavior for the Employee Agent, backing the
+ * Settings segmented control. Mirrors the in-memory pattern of
+ * VoiceTimeoutStore — state lives for the process lifetime, not across cold
+ * starts.
+ *
+ * iOS-only: the native bridge ignores `voiceCloseBehavior` on Android, which
+ * retains its existing Voice close behavior regardless of this setting.
+ */
+export type VoiceCloseBehavior = NonNullable<LaunchOptions['voiceCloseBehavior']>;
+
+export const DEFAULT_VOICE_CLOSE_BEHAVIOR: VoiceCloseBehavior = 'returnToChat';
+
+let voiceCloseBehavior: VoiceCloseBehavior = DEFAULT_VOICE_CLOSE_BEHAVIOR;
+
+export function getVoiceCloseBehavior(): VoiceCloseBehavior {
+  return voiceCloseBehavior;
+}
+
+export function setVoiceCloseBehavior(next: VoiceCloseBehavior): void {
+  voiceCloseBehavior = next;
+}
+
+export function resetVoiceCloseBehavior(): void {
+  voiceCloseBehavior = DEFAULT_VOICE_CLOSE_BEHAVIOR;
+}

--- a/src/store/VoiceTimeoutStore.ts
+++ b/src/store/VoiceTimeoutStore.ts
@@ -16,6 +16,7 @@ export interface VoiceTimeoutSettings {
   enabled: boolean;
   userSilenceTimeoutSeconds: number;
   autoEndWhileMuted: boolean;
+  defaultClosedCaptionsEnabled: boolean;
 }
 
 // Auto-end on silence is opt-in: default the toggle off, but pre-seed the
@@ -25,6 +26,7 @@ export const DEFAULT_VOICE_TIMEOUT_SETTINGS: VoiceTimeoutSettings = {
   enabled: false,
   userSilenceTimeoutSeconds: EMPLOYEE_VOICE_OPTIONS.userSilenceTimeoutSeconds ?? 30,
   autoEndWhileMuted: EMPLOYEE_VOICE_OPTIONS.autoEndWhileMuted ?? false,
+  defaultClosedCaptionsEnabled: EMPLOYEE_VOICE_OPTIONS.defaultClosedCaptionsEnabled ?? false,
 };
 
 let settings: VoiceTimeoutSettings = { ...DEFAULT_VOICE_TIMEOUT_SETTINGS };
@@ -46,14 +48,19 @@ export function resetVoiceTimeoutSettings(): void {
  * `voiceOptions` on the Employee Agent `configure()` call.
  *
  * When disabled, `userSilenceTimeoutSeconds` is omitted so the native layer maps
- * it to "never auto-end"; `autoEndWhileMuted` is always forwarded.
+ * it to "never auto-end"; `autoEndWhileMuted` and `defaultClosedCaptionsEnabled`
+ * are always forwarded since they're independent of the auto-end toggle.
  */
 export function getVoiceOptions(): VoiceOptions {
   if (!settings.enabled) {
-    return { autoEndWhileMuted: settings.autoEndWhileMuted };
+    return {
+      autoEndWhileMuted: settings.autoEndWhileMuted,
+      defaultClosedCaptionsEnabled: settings.defaultClosedCaptionsEnabled,
+    };
   }
   return {
     userSilenceTimeoutSeconds: settings.userSilenceTimeoutSeconds,
     autoEndWhileMuted: settings.autoEndWhileMuted,
+    defaultClosedCaptionsEnabled: settings.defaultClosedCaptionsEnabled,
   };
 }

--- a/src/store/__tests__/VoiceCloseBehaviorStore.test.ts
+++ b/src/store/__tests__/VoiceCloseBehaviorStore.test.ts
@@ -1,0 +1,32 @@
+import {
+  DEFAULT_VOICE_CLOSE_BEHAVIOR,
+  getVoiceCloseBehavior,
+  setVoiceCloseBehavior,
+  resetVoiceCloseBehavior,
+} from '../VoiceCloseBehaviorStore';
+
+beforeEach(() => {
+  resetVoiceCloseBehavior();
+});
+
+describe('VoiceCloseBehaviorStore defaults', () => {
+  it('defaults to returnToChat', () => {
+    expect(DEFAULT_VOICE_CLOSE_BEHAVIOR).toBe('returnToChat');
+    expect(getVoiceCloseBehavior()).toBe('returnToChat');
+  });
+});
+
+describe('setVoiceCloseBehavior', () => {
+  it('round-trips a value', () => {
+    setVoiceCloseBehavior('dismissContainer');
+    expect(getVoiceCloseBehavior()).toBe('dismissContainer');
+  });
+});
+
+describe('resetVoiceCloseBehavior', () => {
+  it('restores the default', () => {
+    setVoiceCloseBehavior('dismissContainer');
+    resetVoiceCloseBehavior();
+    expect(getVoiceCloseBehavior()).toBe(DEFAULT_VOICE_CLOSE_BEHAVIOR);
+  });
+});

--- a/src/store/__tests__/VoiceTimeoutStore.test.ts
+++ b/src/store/__tests__/VoiceTimeoutStore.test.ts
@@ -17,6 +17,7 @@ describe('VoiceTimeoutStore defaults', () => {
       enabled: false,
       userSilenceTimeoutSeconds: EMPLOYEE_VOICE_OPTIONS.userSilenceTimeoutSeconds ?? 30,
       autoEndWhileMuted: EMPLOYEE_VOICE_OPTIONS.autoEndWhileMuted ?? false,
+      defaultClosedCaptionsEnabled: EMPLOYEE_VOICE_OPTIONS.defaultClosedCaptionsEnabled ?? false,
     });
   });
 
@@ -31,24 +32,28 @@ describe('getVoiceOptions', () => {
       enabled: true,
       userSilenceTimeoutSeconds: 45,
       autoEndWhileMuted: true,
+      defaultClosedCaptionsEnabled: false,
     });
 
     expect(getVoiceOptions()).toEqual({
       userSilenceTimeoutSeconds: 45,
       autoEndWhileMuted: true,
+      defaultClosedCaptionsEnabled: false,
     });
   });
 
-  it('omits the timeout when disabled but keeps autoEndWhileMuted', () => {
+  it('omits the timeout when disabled but keeps autoEndWhileMuted and defaultClosedCaptionsEnabled', () => {
     setVoiceTimeoutSettings({
       enabled: false,
       userSilenceTimeoutSeconds: 45,
       autoEndWhileMuted: true,
+      defaultClosedCaptionsEnabled: true,
     });
 
     const options = getVoiceOptions();
     expect(options.userSilenceTimeoutSeconds).toBeUndefined();
     expect(options.autoEndWhileMuted).toBe(true);
+    expect(options.defaultClosedCaptionsEnabled).toBe(true);
   });
 });
 
@@ -58,6 +63,7 @@ describe('setVoiceTimeoutSettings', () => {
       enabled: false,
       userSilenceTimeoutSeconds: 10,
       autoEndWhileMuted: false,
+      defaultClosedCaptionsEnabled: false,
     };
     setVoiceTimeoutSettings(next);
     expect(getVoiceTimeoutSettings()).toEqual(next);
@@ -74,6 +80,7 @@ describe('setVoiceTimeoutSettings', () => {
       enabled: true,
       userSilenceTimeoutSeconds: 20,
       autoEndWhileMuted: false,
+      defaultClosedCaptionsEnabled: false,
     };
     setVoiceTimeoutSettings(input);
     input.userSilenceTimeoutSeconds = 999;
@@ -87,6 +94,7 @@ describe('resetVoiceTimeoutSettings', () => {
       enabled: false,
       userSilenceTimeoutSeconds: 5,
       autoEndWhileMuted: true,
+      defaultClosedCaptionsEnabled: true,
     });
     resetVoiceTimeoutSettings();
     expect(getVoiceTimeoutSettings()).toEqual(DEFAULT_VOICE_TIMEOUT_SETTINGS);


### PR DESCRIPTION
## Summary
- Adds `defaultClosedCaptionsEnabled` and `voiceCloseBehavior` toggles to Settings > Employee for documentation and testing of the bridge options added in #148.
- Exports `LaunchOptions` from the bridge's public API (`AgentforceSDK-ReactNative-Bridge/src/index.ts` / `types/index.ts`) — it previously existed only on `AgentforceService`, so the sample app couldn't reference the type.
- `VoiceTimeoutStore` now carries `defaultClosedCaptionsEnabled` alongside the existing auto-end settings, forwarded via `getVoiceOptions()`.
- New `VoiceCloseBehaviorStore` (mirrors the existing store pattern) backs a segmented control for `voiceCloseBehavior`, wired into `HomeScreen`'s Employee Agent `launchConversation()` call.
- Renamed the "Voice Timeout" Settings section to "Voice Options" to reflect the added captions toggle; added a new "Voice Close Behavior" section (noted iOS-only, since Android ignores this option).
- Documented the new sample-app wiring in `docs/voice-and-feature-flags-config.md`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (149/149 passing, including new/updated store tests)
- [ ] Manual: toggle "Closed captions by default" and "Voice Close Behavior" in Settings > Employee, launch Employee Agent voice, confirm captions start on and closing Voice matches the selected behavior on iOS.