### PR TITLE
Bump React Native bridge to 0.6.0

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/package.json
+++ b/AgentforceSDK-ReactNative-Bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/react-native-agentforce",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Agentforce React Native bridge: JS API and native module for Service Agent and Employee Agent (auth bridge included; host app adds Mobile SDK).",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/docs/voice-and-feature-flags-config.md
+++ b/docs/voice-and-feature-flags-config.md
@@ -1,6 +1,6 @@
 # Configuring Feature Flags & Voice Options — Employee Agent
 
-**Applies to:** `@salesforce/react-native-agentforce@0.5.0`
+**Applies to:** `@salesforce/react-native-agentforce@0.6.0`
 (iOS AgentforceSDK 18.26.17 / AgentforceVoice 2.8.2; Android agentforce-sdk 15.130.4; Agentforce Mobile SDK 262.1.3)
 
 Both `featureFlags` and `voiceOptions` are passed to a **single**

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
     },
     "AgentforceSDK-ReactNative-Bridge": {
       "name": "@salesforce/react-native-agentforce",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",


### PR DESCRIPTION
## Summary
- Bumps `@salesforce/react-native-agentforce` from 0.5.0 to 0.6.0 in `AgentforceSDK-ReactNative-Bridge/package.json` and `package-lock.json`, following the version bump landed in #157 (voice caption default / close behavior).
- Updates the version reference in `docs/voice-and-feature-flags-config.md`.

## Test plan
- [x] `npm run build` (bridge)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (149/149 passing)