### PR TITLE
Promote dev to main: RN bridge 0.6.0 (voice caption/close behavior, SDK 262.1.3)

### DIFF
--- a/AgentforceSDK-ReactNative-Bridge/android/build.gradle
+++ b/AgentforceSDK-ReactNative-Bridge/android/build.gradle
@@ -60,8 +60,8 @@ repositories {
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
     implementation "com.facebook.react:react-android"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk:15.130.3-rc1"
-    api "com.salesforce.android.agentforcesdk:agentforce-sdk-voice:15.130.3-rc1"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk:15.130.4"
+    api "com.salesforce.android.agentforcesdk:agentforce-sdk-voice:15.130.4"
     // compileOnly: host app adds this for Employee Agent. Bridge compiles; host provides at runtime.
     compileOnly "com.salesforce.mobilesdk:SalesforceReact:13.1.1"
 

--- a/AgentforceSDK-ReactNative-Bridge/package.json
+++ b/AgentforceSDK-ReactNative-Bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/react-native-agentforce",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Agentforce React Native bridge: JS API and native module for Service Agent and Employee Agent (auth bridge included; host app adds Mobile SDK).",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/AgentforceSDK-ReactNative-Bridge/src/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/index.ts
@@ -45,6 +45,7 @@ export type {
   AgentSwitchEvent,
   ModifyUtteranceRequest,
   VoiceOptions,
+  LaunchOptions,
   AgentforceAppearance,
   AgentforceThemeMode,
   AgentforceFontWeight,

--- a/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
+++ b/AgentforceSDK-ReactNative-Bridge/src/types/index.ts
@@ -45,6 +45,9 @@ export type { HiddenPreChatFields } from './HiddenPreChatFields';
 // Voice configuration types
 export type { VoiceOptions } from './VoiceOptions';
 
+// Conversation launch option types
+export type { LaunchOptions } from './LaunchOptions';
+
 // Appearance customization types
 export type {
   AgentforceAppearance,

--- a/docs/voice-and-feature-flags-config.md
+++ b/docs/voice-and-feature-flags-config.md
@@ -1,6 +1,6 @@
 # Configuring Feature Flags & Voice Options — Employee Agent
 
-**Applies to:** `@salesforce/react-native-agentforce@0.5.0`
+**Applies to:** `@salesforce/react-native-agentforce@0.6.0`
 (iOS AgentforceSDK 18.26.17 / AgentforceVoice 2.8.2; Android agentforce-sdk 15.130.4; Agentforce Mobile SDK 262.1.3)
 
 Both `featureFlags` and `voiceOptions` are passed to a **single**

--- a/docs/voice-and-feature-flags-config.md
+++ b/docs/voice-and-feature-flags-config.md
@@ -1,7 +1,7 @@
 # Configuring Feature Flags & Voice Options — Employee Agent
 
 **Applies to:** `@salesforce/react-native-agentforce@0.5.0`
-(iOS AgentforceSDK 18.26.9-rc3 / AgentforceVoice 2.9.3-rc3; Android agentforce-sdk 15.130.3-rc1; Agentforce Mobile SDK 262.1.3 RC)
+(iOS AgentforceSDK 18.26.17 / AgentforceVoice 2.8.2; Android agentforce-sdk 15.130.4; Agentforce Mobile SDK 262.1.3)
 
 Both `featureFlags` and `voiceOptions` are passed to a **single**
 `AgentforceService.configure(...)` call, as **top-level siblings of `type`**.

--- a/docs/voice-and-feature-flags-config.md
+++ b/docs/voice-and-feature-flags-config.md
@@ -94,3 +94,18 @@ await AgentforceService.launchConversation({
 `'returnToChat'` is the default and returns the user to the chat transcript.
 `'dismissContainer'` dismisses the complete Agentforce presentation when Voice
 ends or the user closes it. Android retains its existing Voice close behavior.
+
+## Testing in the sample app
+
+Both options are wired into the Employee tab of the sample app's Settings
+screen (`src/screens/SettingsScreen.tsx`):
+
+- **Voice Options** section — toggles `autoEndWhileMuted` and
+  `defaultClosedCaptionsEnabled` (persisted in `src/store/VoiceTimeoutStore.ts`,
+  applied on the next `configure()` call from Home).
+- **Voice Close Behavior** section — a segmented control for
+  `voiceCloseBehavior` (persisted in `src/store/VoiceCloseBehaviorStore.ts`,
+  applied on the next `launchConversation()` call from Home).
+
+Both stores are in-memory only and reset on process restart, matching the
+existing Voice Timeout settings pattern.

--- a/ios/Podfile.common.rb
+++ b/ios/Podfile.common.rb
@@ -20,10 +20,10 @@ def shared_pods
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'AgentforceSDK', '18.26.9-rc4'
-  # The SDK RC podspec has a broad `~> 6` service dependency, which otherwise
-  # resolves to stable 6.11.2 instead of the tested 262.1.3 RC service binary.
-  pod 'AgentforceService', '6.11.3-rc1'
+  pod 'AgentforceSDK', '18.26.17'
+  # AgentforceSDK declares a broad `~> 6` service dependency; pin explicitly to
+  # the exact 262.1.3 service binary this SDK build was tested against.
+  pod 'AgentforceService', '6.11.4'
   pod 'AgentforceVoice', '2.8.2'
   pod 'Messaging-InApp-Core', '> 1.10.0'
   # Messaging-Multimedia-Core vends SMIMultimediaCore.framework, which

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
     },
     "AgentforceSDK-ReactNative-Bridge": {
       "name": "@salesforce/react-native-agentforce",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/src/config/AppConfig.ts
+++ b/src/config/AppConfig.ts
@@ -53,10 +53,15 @@ const appMode: 'service' | 'employee' | 'all' = APP_MODE as any;
  * `autoEndWhileMuted: false` (the default) pauses the silence timer while the
  * mic is muted, so a muted user is never auto-ended. Set `true` to count muted
  * time as silence.
+ *
+ * `defaultClosedCaptionsEnabled: false` (the default) preserves the existing
+ * off-by-default caption behavior for first-time voice users. Once a user
+ * changes their caption preference, their saved choice takes precedence.
  */
 export const EMPLOYEE_VOICE_OPTIONS: VoiceOptions = {
   userSilenceTimeoutSeconds: 30,
   autoEndWhileMuted: false,
+  defaultClosedCaptionsEnabled: false,
 };
 // These values seed the runtime-editable VoiceTimeoutStore (Settings > Employee
 // > Voice Timeout). configure() sends the store's current values, not this

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -49,6 +49,7 @@ import { UI_FEATURES } from '../config/AppConfig';
 import { getAgentAppearance, loadAppearanceSettings } from '../store/AgentAppearanceStore';
 import { getContextVariables } from '../store/ContextVariablesStore';
 import { getVoiceOptions } from '../store/VoiceTimeoutStore';
+import { getVoiceCloseBehavior } from '../store/VoiceCloseBehaviorStore';
 
 interface HomeScreenProps {
   navigation: any;
@@ -254,8 +255,12 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
       await AgentforceService.configure(config);
 
       const contextVars = getContextVariables();
+      // Read the latest close-behavior setting (editable in Settings > Employee > Voice Close
+      // Behavior) at launch time. iOS only; Android ignores this option.
+      const voiceCloseBehavior = getVoiceCloseBehavior();
       await AgentforceService.launchConversation({
         additionalContext: contextVars.length > 0 ? { variables: contextVars } : undefined,
+        voiceCloseBehavior,
       });
     } catch (error: any) {
       Alert.alert(

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -72,6 +72,8 @@ import {
   setVoiceTimeoutSettings,
 } from '../store/VoiceTimeoutStore';
 import type { VoiceTimeoutSettings } from '../store/VoiceTimeoutStore';
+import { getVoiceCloseBehavior, setVoiceCloseBehavior } from '../store/VoiceCloseBehaviorStore';
+import type { VoiceCloseBehavior } from '../store/VoiceCloseBehaviorStore';
 
 type TabType = 'service' | 'employee' | 'features' | 'theming';
 
@@ -176,6 +178,9 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
 
   const [voiceTimeout, setVoiceTimeout] = useState<VoiceTimeoutSettings>(() =>
     getVoiceTimeoutSettings(),
+  );
+  const [voiceCloseBehavior, setVoiceCloseBehaviorState] = useState<VoiceCloseBehavior>(() =>
+    getVoiceCloseBehavior(),
   );
 
   useEffect(() => {
@@ -476,6 +481,11 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
   useEffect(() => {
     setVoiceTimeoutSettings(voiceTimeout);
   }, [voiceTimeout]);
+
+  // Sync Voice close behavior to store whenever it changes
+  useEffect(() => {
+    setVoiceCloseBehavior(voiceCloseBehavior);
+  }, [voiceCloseBehavior]);
 
   const handleAddContextVariable = () => {
     const trimmedName = newEmployeeCtxName.trim();
@@ -918,11 +928,11 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
 
   const renderVoiceTimeoutSection = () => (
     <View style={styles.formContainerWithMargin}>
-      <Text style={styles.label}>Voice Timeout</Text>
+      <Text style={styles.label}>Voice Options</Text>
       <Text style={styles.hint}>
-        Auto-end a voice conversation after the user is silent. Requires the Voice feature flag.
-        Changes apply the next time you launch Employee Agent (rebuilding the client ends the active
-        conversation).
+        Auto-end a voice conversation after the user is silent, and set the default caption state.
+        Requires the Voice feature flag. Changes apply the next time you launch Employee Agent
+        (rebuilding the client ends the active conversation).
       </Text>
 
       <View style={[styles.flagRow, styles.flagRowBorder]}>
@@ -962,7 +972,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
         </View>
       )}
 
-      <View style={styles.flagRow}>
+      <View style={[styles.flagRow, styles.flagRowBorder]}>
         <View style={styles.flagLabelBlock}>
           <Text style={styles.label}>Auto-end while muted</Text>
           <Text style={styles.hint}>Also auto-end when the mic is muted.</Text>
@@ -975,6 +985,54 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
           trackColor={{ false: '#ced4da', true: '#28a745' }}
           thumbColor="#ffffff"
         />
+      </View>
+
+      <View style={styles.flagRow}>
+        <View style={styles.flagLabelBlock}>
+          <Text style={styles.label}>Closed captions by default</Text>
+          <Text style={styles.hint}>
+            Starts captions on for first-time voice users. A user's saved caption preference always
+            overrides this once they've changed it.
+          </Text>
+        </View>
+        <Switch
+          value={voiceTimeout.defaultClosedCaptionsEnabled}
+          onValueChange={defaultClosedCaptionsEnabled =>
+            setVoiceTimeout(prev => ({ ...prev, defaultClosedCaptionsEnabled }))
+          }
+          trackColor={{ false: '#ced4da', true: '#28a745' }}
+          thumbColor="#ffffff"
+        />
+      </View>
+    </View>
+  );
+
+  const renderVoiceCloseBehaviorSection = () => (
+    <View style={styles.formContainerWithMargin}>
+      <Text style={styles.label}>Voice Close Behavior</Text>
+      <Text style={styles.hint}>
+        What happens when the user closes the Voice UI. iOS only — Android retains its existing
+        Voice close behavior regardless of this setting. Applies to the next `launchConversation()`
+        call.
+      </Text>
+      <View style={styles.segmentedControl}>
+        {(['returnToChat', 'dismissContainer'] as VoiceCloseBehavior[]).map(behavior => (
+          <TouchableOpacity
+            key={behavior}
+            style={[
+              styles.segmentButton,
+              voiceCloseBehavior === behavior && styles.segmentButtonActive,
+            ]}
+            onPress={() => setVoiceCloseBehaviorState(behavior)}>
+            <Text
+              style={[
+                styles.segmentButtonText,
+                voiceCloseBehavior === behavior && styles.segmentButtonTextActive,
+              ]}>
+              {behavior === 'returnToChat' ? 'Return to Chat' : 'Dismiss Container'}
+            </Text>
+          </TouchableOpacity>
+        ))}
       </View>
     </View>
   );
@@ -1055,6 +1113,8 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation, route }) =>
       )}
 
       {authSupported && renderVoiceTimeoutSection()}
+
+      {authSupported && renderVoiceCloseBehaviorSection()}
 
       {authSupported && renderContextVariablesSection()}
 

--- a/src/store/VoiceCloseBehaviorStore.ts
+++ b/src/store/VoiceCloseBehaviorStore.ts
@@ -1,0 +1,28 @@
+import type { LaunchOptions } from '@salesforce/react-native-agentforce';
+
+/**
+ * Runtime-editable Voice close behavior for the Employee Agent, backing the
+ * Settings segmented control. Mirrors the in-memory pattern of
+ * VoiceTimeoutStore — state lives for the process lifetime, not across cold
+ * starts.
+ *
+ * iOS-only: the native bridge ignores `voiceCloseBehavior` on Android, which
+ * retains its existing Voice close behavior regardless of this setting.
+ */
+export type VoiceCloseBehavior = NonNullable<LaunchOptions['voiceCloseBehavior']>;
+
+export const DEFAULT_VOICE_CLOSE_BEHAVIOR: VoiceCloseBehavior = 'returnToChat';
+
+let voiceCloseBehavior: VoiceCloseBehavior = DEFAULT_VOICE_CLOSE_BEHAVIOR;
+
+export function getVoiceCloseBehavior(): VoiceCloseBehavior {
+  return voiceCloseBehavior;
+}
+
+export function setVoiceCloseBehavior(next: VoiceCloseBehavior): void {
+  voiceCloseBehavior = next;
+}
+
+export function resetVoiceCloseBehavior(): void {
+  voiceCloseBehavior = DEFAULT_VOICE_CLOSE_BEHAVIOR;
+}

--- a/src/store/VoiceTimeoutStore.ts
+++ b/src/store/VoiceTimeoutStore.ts
@@ -16,6 +16,7 @@ export interface VoiceTimeoutSettings {
   enabled: boolean;
   userSilenceTimeoutSeconds: number;
   autoEndWhileMuted: boolean;
+  defaultClosedCaptionsEnabled: boolean;
 }
 
 // Auto-end on silence is opt-in: default the toggle off, but pre-seed the
@@ -25,6 +26,7 @@ export const DEFAULT_VOICE_TIMEOUT_SETTINGS: VoiceTimeoutSettings = {
   enabled: false,
   userSilenceTimeoutSeconds: EMPLOYEE_VOICE_OPTIONS.userSilenceTimeoutSeconds ?? 30,
   autoEndWhileMuted: EMPLOYEE_VOICE_OPTIONS.autoEndWhileMuted ?? false,
+  defaultClosedCaptionsEnabled: EMPLOYEE_VOICE_OPTIONS.defaultClosedCaptionsEnabled ?? false,
 };
 
 let settings: VoiceTimeoutSettings = { ...DEFAULT_VOICE_TIMEOUT_SETTINGS };
@@ -46,14 +48,19 @@ export function resetVoiceTimeoutSettings(): void {
  * `voiceOptions` on the Employee Agent `configure()` call.
  *
  * When disabled, `userSilenceTimeoutSeconds` is omitted so the native layer maps
- * it to "never auto-end"; `autoEndWhileMuted` is always forwarded.
+ * it to "never auto-end"; `autoEndWhileMuted` and `defaultClosedCaptionsEnabled`
+ * are always forwarded since they're independent of the auto-end toggle.
  */
 export function getVoiceOptions(): VoiceOptions {
   if (!settings.enabled) {
-    return { autoEndWhileMuted: settings.autoEndWhileMuted };
+    return {
+      autoEndWhileMuted: settings.autoEndWhileMuted,
+      defaultClosedCaptionsEnabled: settings.defaultClosedCaptionsEnabled,
+    };
   }
   return {
     userSilenceTimeoutSeconds: settings.userSilenceTimeoutSeconds,
     autoEndWhileMuted: settings.autoEndWhileMuted,
+    defaultClosedCaptionsEnabled: settings.defaultClosedCaptionsEnabled,
   };
 }

--- a/src/store/__tests__/VoiceCloseBehaviorStore.test.ts
+++ b/src/store/__tests__/VoiceCloseBehaviorStore.test.ts
@@ -1,0 +1,32 @@
+import {
+  DEFAULT_VOICE_CLOSE_BEHAVIOR,
+  getVoiceCloseBehavior,
+  setVoiceCloseBehavior,
+  resetVoiceCloseBehavior,
+} from '../VoiceCloseBehaviorStore';
+
+beforeEach(() => {
+  resetVoiceCloseBehavior();
+});
+
+describe('VoiceCloseBehaviorStore defaults', () => {
+  it('defaults to returnToChat', () => {
+    expect(DEFAULT_VOICE_CLOSE_BEHAVIOR).toBe('returnToChat');
+    expect(getVoiceCloseBehavior()).toBe('returnToChat');
+  });
+});
+
+describe('setVoiceCloseBehavior', () => {
+  it('round-trips a value', () => {
+    setVoiceCloseBehavior('dismissContainer');
+    expect(getVoiceCloseBehavior()).toBe('dismissContainer');
+  });
+});
+
+describe('resetVoiceCloseBehavior', () => {
+  it('restores the default', () => {
+    setVoiceCloseBehavior('dismissContainer');
+    resetVoiceCloseBehavior();
+    expect(getVoiceCloseBehavior()).toBe(DEFAULT_VOICE_CLOSE_BEHAVIOR);
+  });
+});

--- a/src/store/__tests__/VoiceTimeoutStore.test.ts
+++ b/src/store/__tests__/VoiceTimeoutStore.test.ts
@@ -17,6 +17,7 @@ describe('VoiceTimeoutStore defaults', () => {
       enabled: false,
       userSilenceTimeoutSeconds: EMPLOYEE_VOICE_OPTIONS.userSilenceTimeoutSeconds ?? 30,
       autoEndWhileMuted: EMPLOYEE_VOICE_OPTIONS.autoEndWhileMuted ?? false,
+      defaultClosedCaptionsEnabled: EMPLOYEE_VOICE_OPTIONS.defaultClosedCaptionsEnabled ?? false,
     });
   });
 
@@ -31,24 +32,28 @@ describe('getVoiceOptions', () => {
       enabled: true,
       userSilenceTimeoutSeconds: 45,
       autoEndWhileMuted: true,
+      defaultClosedCaptionsEnabled: false,
     });
 
     expect(getVoiceOptions()).toEqual({
       userSilenceTimeoutSeconds: 45,
       autoEndWhileMuted: true,
+      defaultClosedCaptionsEnabled: false,
     });
   });
 
-  it('omits the timeout when disabled but keeps autoEndWhileMuted', () => {
+  it('omits the timeout when disabled but keeps autoEndWhileMuted and defaultClosedCaptionsEnabled', () => {
     setVoiceTimeoutSettings({
       enabled: false,
       userSilenceTimeoutSeconds: 45,
       autoEndWhileMuted: true,
+      defaultClosedCaptionsEnabled: true,
     });
 
     const options = getVoiceOptions();
     expect(options.userSilenceTimeoutSeconds).toBeUndefined();
     expect(options.autoEndWhileMuted).toBe(true);
+    expect(options.defaultClosedCaptionsEnabled).toBe(true);
   });
 });
 
@@ -58,6 +63,7 @@ describe('setVoiceTimeoutSettings', () => {
       enabled: false,
       userSilenceTimeoutSeconds: 10,
       autoEndWhileMuted: false,
+      defaultClosedCaptionsEnabled: false,
     };
     setVoiceTimeoutSettings(next);
     expect(getVoiceTimeoutSettings()).toEqual(next);
@@ -74,6 +80,7 @@ describe('setVoiceTimeoutSettings', () => {
       enabled: true,
       userSilenceTimeoutSeconds: 20,
       autoEndWhileMuted: false,
+      defaultClosedCaptionsEnabled: false,
     };
     setVoiceTimeoutSettings(input);
     input.userSilenceTimeoutSeconds = 999;
@@ -87,6 +94,7 @@ describe('resetVoiceTimeoutSettings', () => {
       enabled: false,
       userSilenceTimeoutSeconds: 5,
       autoEndWhileMuted: true,
+      defaultClosedCaptionsEnabled: true,
     });
     resetVoiceTimeoutSettings();
     expect(getVoiceTimeoutSettings()).toEqual(DEFAULT_VOICE_TIMEOUT_SETTINGS);


### PR DESCRIPTION
## Summary
Promotes `dev` to `main`, releasing **@salesforce/react-native-agentforce 0.6.0**. 12 commits since the last promotion.

## Included changes
- Bump React Native bridge to 0.6.0 (#158)
- Hook voice caption default and close behavior into sample app (#157)
- Bump Agentforce SDK to 262.1.3 (#155)
- Pin iOS Agentforce Voice to 2.8.2 (#152)
- Bump iOS Agentforce SDK to 262.1.3 RC4 (#151)
- Expose voice caption defaults and close behavior (#148)
- Fix initial Agentforce context timing (5ae03df)
- Add User Silence Timeout Flags to test app (#146)
- Add React Native Agentforce appearance customization (#144)
- Add per-agent custom splash (welcome) screen support (#127)
- Support direct launch into Voice mode (#143)
- Bump @salesforce/react-native-agentforce to 0.4.0 (sync dev)

## QA notes
- Automated gates on `dev` are green: jest (149 tests), lint, and bridge typecheck all pass.
- Known platform gap: `voiceCloseBehavior` (W-23683185) is implemented on iOS only; Android retains its existing (dismiss-overlay) close behavior and does not read the option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)